### PR TITLE
Add exception handling in all library OpenMP loops

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,7 +29,6 @@ Checks: '
    -modernize-use-trailing-return-type,
   mpi-*,
   openmp-*,
-    -openmp-exception-escape,
     -openmp-use-default-none
   performance-*,
   readability-*,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(Similarity similarity.cpp)
 target_link_libraries(
   Similarity
   PUBLIC CUDA::cudart device_vector
-  PRIVATE similarity_kernels ${RDKit_LIBS} device_vector device
+  PRIVATE similarity_kernels ${RDKit_LIBS} device_vector device openmp_helpers
           OpenMP::OpenMP_CXX)
 target_include_directories(Similarity PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(Similarity SYSTEM PRIVATE ${Boost_INCLUDE_DIRS})
@@ -52,7 +52,7 @@ add_library(
                     morgan_fingerprint_cpu.cpp morgan_fingerprint_common.cpp)
 target_link_libraries(
   morganFingerprint
-  PRIVATE ${RDKit_LIBS} OpenMP::OpenMP_CXX device
+  PRIVATE ${RDKit_LIBS} OpenMP::OpenMP_CXX device openmp_helpers
   PUBLIC morganFingerprintKernels)
 target_include_directories(morganFingerprint PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -108,5 +108,6 @@ target_link_libraries(
           rdkit_dist_geom_flattened
           etkdg_impl
           etkdg_stages
+          openmp_helpers
           OpenMP::OpenMP_CXX)
 target_include_directories(etkdg PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/minimizer/CMakeLists.txt
+++ b/src/minimizer/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(bfgs PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(bfgs_mmff bfgs_mmff.cpp)
 target_link_libraries(
   bfgs_mmff PRIVATE ${RDKit_LIBS} rdkit_mmff_flattened device device_vector
-                    bfgs OpenMP::OpenMP_CXX)
+                    bfgs OpenMP::OpenMP_CXX openmp_helpers)
 target_include_directories(bfgs_mmff PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(bfgs_distgeom bfgs_distgeom.cpp)

--- a/src/similarity.cpp
+++ b/src/similarity.cpp
@@ -20,6 +20,7 @@
 #include "device.h"
 #include "device_vector.h"
 #include "host_vector.h"
+#include "openmp_helpers.h"
 #include "similarity_kernels.h"
 #include "utils/nvtx.h"
 namespace nvMolKit {
@@ -144,84 +145,89 @@ std::vector<double> crossSimilarityImpl(const cuda::std::span<const std::uint32_
 
   std::vector<double> res(nFps1 * nFps2);
 
-  const size_t nBatches = (nFps1 + batchSizeA - 1) / batchSizeA;
-
+  const size_t                    nBatches = (nFps1 + batchSizeA - 1) / batchSizeA;
+  detail::OpenMPExceptionRegistry exceptionHandler;
 #pragma omp parallel for num_threads(2) schedule(dynamic) default(shared)
   for (size_t batchIdx = 0; batchIdx < nBatches; ++batchIdx) {
-    const ScopedNvtxRange      batchRange("CrossSimilarity: batch");
-    const int                  tid           = omp_get_thread_num();
-    cudaStream_t               currentStream = rotBuffers.streamForThread(tid);
-    AsyncDeviceVector<double>& currentBuffer = rotBuffers.bufferForThread(tid);
-    // Double-buffered pinned buffers for overlap
-    PinnedHostVector<double>&  pinnedBuffer0 = rotBuffers.pinnedForThreadBuffer(tid, 0);
-    PinnedHostVector<double>&  pinnedBuffer1 = rotBuffers.pinnedForThreadBuffer(tid, 1);
+    try {
+      const ScopedNvtxRange      batchRange("CrossSimilarity: batch");
+      const int                  tid           = omp_get_thread_num();
+      cudaStream_t               currentStream = rotBuffers.streamForThread(tid);
+      AsyncDeviceVector<double>& currentBuffer = rotBuffers.bufferForThread(tid);
+      // Double-buffered pinned buffers for overlap
+      PinnedHostVector<double>&  pinnedBuffer0 = rotBuffers.pinnedForThreadBuffer(tid, 0);
+      PinnedHostVector<double>&  pinnedBuffer1 = rotBuffers.pinnedForThreadBuffer(tid, 1);
 
-    const size_t startIdx          = batchIdx * batchSizeA;
-    const size_t currentBatchSizeA = std::min(batchSizeA, nFps1 - startIdx);
+      const size_t startIdx          = batchIdx * batchSizeA;
+      const size_t currentBatchSizeA = std::min(batchSizeA, nFps1 - startIdx);
 
-    // Launch compute for this batch
-    ScopedNvtxRange launchRange("CrossSimilarity: launch kernel");
-    launchKernel(bitsOneBuffer.subspan(startIdx * nElementsPerFp, currentBatchSizeA * nElementsPerFp),
-                 bitsTwoBuffer,
-                 nElementsPerFp,
-                 toSpan(currentBuffer),
-                 0,
-                 currentStream);
-    launchRange.pop();
+      // Launch compute for this batch
+      ScopedNvtxRange launchRange("CrossSimilarity: launch kernel");
+      launchKernel(bitsOneBuffer.subspan(startIdx * nElementsPerFp, currentBatchSizeA * nElementsPerFp),
+                   bitsTwoBuffer,
+                   nElementsPerFp,
+                   toSpan(currentBuffer),
+                   0,
+                   currentStream);
+      launchRange.pop();
 
-    // Double-buffered chunked D2H into pinned buffers with overlap of CPU memcpy
-    const size_t batchElemsTotal = currentBatchSizeA * nFps2;
-    unsigned int bufIdx          = 0;  // 0 -> use pinnedBuffer0, 1 -> pinnedBuffer1
-    bool         hasPrev         = false;
-    size_t       prevOffset      = 0;
-    size_t       prevSize        = 0;
-    int          prevBufIdx      = 0;
-    for (size_t chunkOffset = 0; chunkOffset < batchElemsTotal; chunkOffset += pinnedCapacityDoubles, bufIdx ^= 1U) {
-      const size_t chunkSize  = std::min(pinnedCapacityDoubles, batchElemsTotal - chunkOffset);
-      auto&        pinnedBuf  = (bufIdx == 0) ? pinnedBuffer0 : pinnedBuffer1;
-      auto&        prevPinned = (bufIdx == 0) ? pinnedBuffer1 : pinnedBuffer0;
-      cudaEvent_t  bufEvent   = rotBuffers.eventForThreadBuffer(tid, bufIdx);
-      cudaEvent_t  prevEvent  = rotBuffers.eventForThreadBuffer(tid, prevBufIdx);
+      // Double-buffered chunked D2H into pinned buffers with overlap of CPU memcpy
+      const size_t batchElemsTotal = currentBatchSizeA * nFps2;
+      unsigned int bufIdx          = 0;  // 0 -> use pinnedBuffer0, 1 -> pinnedBuffer1
+      bool         hasPrev         = false;
+      size_t       prevOffset      = 0;
+      size_t       prevSize        = 0;
+      int          prevBufIdx      = 0;
+      for (size_t chunkOffset = 0; chunkOffset < batchElemsTotal; chunkOffset += pinnedCapacityDoubles, bufIdx ^= 1U) {
+        const size_t chunkSize  = std::min(pinnedCapacityDoubles, batchElemsTotal - chunkOffset);
+        auto&        pinnedBuf  = (bufIdx == 0) ? pinnedBuffer0 : pinnedBuffer1;
+        auto&        prevPinned = (bufIdx == 0) ? pinnedBuffer1 : pinnedBuffer0;
+        cudaEvent_t  bufEvent   = rotBuffers.eventForThreadBuffer(tid, bufIdx);
+        cudaEvent_t  prevEvent  = rotBuffers.eventForThreadBuffer(tid, prevBufIdx);
 
-      // Enqueue D2H into the selected pinned buffer and record event
-      ScopedNvtxRange d2hRange("CrossSimilarity: D2H chunk");
-      const size_t    deviceOffset = chunkOffset;
-      currentBuffer.copyToHost(pinnedBuf.data(), chunkSize, 0, deviceOffset);
-      cudaEventRecord(bufEvent, currentStream);
-      d2hRange.pop();
+        // Enqueue D2H into the selected pinned buffer and record event
+        ScopedNvtxRange d2hRange("CrossSimilarity: D2H chunk");
+        const size_t    deviceOffset = chunkOffset;
+        currentBuffer.copyToHost(pinnedBuf.data(), chunkSize, 0, deviceOffset);
+        cudaEventRecord(bufEvent, currentStream);
+        d2hRange.pop();
 
-      // While this D2H is running, memcpy from the previous buffer (if not first iteration)
-      if (hasPrev) {
-        ScopedNvtxRange memcpyPrevRange("CrossSimilarity: memcpy prev chunk");
-        const size_t    resOffset = (startIdx * nFps2) + prevOffset;
-        cudaEventSynchronize(prevEvent);
-        std::memcpy(res.data() + resOffset, prevPinned.data(), sizeof(double) * prevSize);
-        memcpyPrevRange.pop();
+        // While this D2H is running, memcpy from the previous buffer (if not first iteration)
+        if (hasPrev) {
+          ScopedNvtxRange memcpyPrevRange("CrossSimilarity: memcpy prev chunk");
+          const size_t    resOffset = (startIdx * nFps2) + prevOffset;
+          cudaEventSynchronize(prevEvent);
+          std::memcpy(res.data() + resOffset, prevPinned.data(), sizeof(double) * prevSize);
+          memcpyPrevRange.pop();
+        }
+
+        // Set current as previous for next iteration
+        hasPrev    = true;
+        prevOffset = chunkOffset;
+        prevSize   = chunkSize;
+        prevBufIdx = bufIdx;
       }
 
-      // Set current as previous for next iteration
-      hasPrev    = true;
-      prevOffset = chunkOffset;
-      prevSize   = chunkSize;
-      prevBufIdx = bufIdx;
-    }
+      // Copy the last in-flight chunk
+      if (hasPrev) {
+        ScopedNvtxRange memcpyLastRange("CrossSimilarity: memcpy last chunk");
+        auto&           lastPinned = (prevBufIdx == 0) ? pinnedBuffer0 : pinnedBuffer1;
+        cudaEvent_t     lastEvent  = rotBuffers.eventForThreadBuffer(tid, prevBufIdx);
+        cudaEventSynchronize(lastEvent);
+        const size_t resOffset = (startIdx * nFps2) + prevOffset;
+        std::memcpy(res.data() + resOffset, lastPinned.data(), sizeof(double) * prevSize);
+        memcpyLastRange.pop();
+      }
 
-    // Copy the last in-flight chunk
-    if (hasPrev) {
-      ScopedNvtxRange memcpyLastRange("CrossSimilarity: memcpy last chunk");
-      auto&           lastPinned = (prevBufIdx == 0) ? pinnedBuffer0 : pinnedBuffer1;
-      cudaEvent_t     lastEvent  = rotBuffers.eventForThreadBuffer(tid, prevBufIdx);
-      cudaEventSynchronize(lastEvent);
-      const size_t resOffset = (startIdx * nFps2) + prevOffset;
-      std::memcpy(res.data() + resOffset, lastPinned.data(), sizeof(double) * prevSize);
-      memcpyLastRange.pop();
+      // Ensure all D2H copies are complete before proceeding
+      ScopedNvtxRange syncRange("CrossSimilarity: stream sync");
+      cudaStreamSynchronize(currentStream);
+      syncRange.pop();
+    } catch (...) {
+      exceptionHandler.store(std::current_exception());
     }
-
-    // Ensure all D2H copies are complete before proceeding
-    ScopedNvtxRange syncRange("CrossSimilarity: stream sync");
-    cudaStreamSynchronize(currentStream);
-    syncRange.pop();
   }
+  exceptionHandler.rethrow();
 
   return res;
 }

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -44,3 +44,7 @@ target_include_directories(work_splitting INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(nvtx INTERFACE)
 target_link_libraries(nvtx INTERFACE CUDA::nvtx3)
 target_include_directories(nvtx INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(openmp_helpers openmp_helpers.cpp)
+target_link_libraries(openmp_helpers PRIVATE OpenMP::OpenMP_CXX)
+target_include_directories(openmp_helpers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/utils/openmp_helpers.cpp
+++ b/src/utils/openmp_helpers.cpp
@@ -1,0 +1,27 @@
+#include "openmp_helpers.h"
+
+namespace nvMolKit {
+namespace detail {
+
+void OpenMPExceptionRegistry::store(std::exception_ptr exceptionPtr) {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (!exception_) {
+    exception_ = std::move(exceptionPtr);
+  }
+}
+
+void OpenMPExceptionRegistry::rethrow() {
+  std::exception_ptr toThrow;
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    toThrow    = exception_;
+    exception_ = nullptr;
+  }
+
+  if (toThrow) {
+    std::rethrow_exception(toThrow);
+  }
+}
+
+}  // namespace detail
+}  // namespace nvMolKit

--- a/src/utils/openmp_helpers.h
+++ b/src/utils/openmp_helpers.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NVMOLKIT_OPENMP_HELPERS_H
+#define NVMOLKIT_OPENMP_HELPERS_H
+
+#include <exception>
+#include <mutex>
+
+namespace nvMolKit {
+namespace detail {
+
+//! A thread-safe registry to store and rethrow the first encountered exception from OpenMP threads
+//! Usage:
+//!   OpenMPExceptionRegistry exceptionRegistry;
+//!   #pragma omp parallel
+//!   {
+//!     try {
+//!       // Do work that may throw
+//!     } catch (...) {
+//!       exceptionRegistry.store(std::current_exception());
+//!     }
+//!   }
+//!   exceptionRegistry.rethrow(); // Rethrows the first stored exception, if any
+class OpenMPExceptionRegistry {
+ public:
+  void store(std::exception_ptr exceptionPtr);
+  void rethrow();
+
+ private:
+  std::mutex         mutex_;
+  std::exception_ptr exception_;
+};
+
+}  // namespace detail
+}  // namespace nvMolKit
+
+#endif  // NVMOLKIT_OPENMP_HELPERS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,9 @@ target_include_directories(test_flat_bit_vect SYSTEM
 add_executable(test_work_splitting test_work_splitting.cpp)
 target_link_libraries(test_work_splitting PRIVATE work_splitting)
 
+add_executable(test_openmp_helpers test_openmp_helpers.cpp)
+target_link_libraries(test_openmp_helpers PRIVATE openmp_helpers OpenMP::OpenMP_CXX)
+
 add_library(test_utils test_utils.cpp)
 target_link_libraries(
   test_utils PRIVATE ${RDKit_LIBS} GTest::gtest GTest::gtest_main GTest::gmock
@@ -172,6 +175,7 @@ target_link_libraries(test_etkdg_result_tracker PRIVATE etkdg_impl)
 
 set(TEST_LIST
     test_bfgs_hessian
+    test_openmp_helpers
     test_conformer_checkers
     test_coordgen
     test_cuda_error_check

--- a/tests/test_distgeom_kernels.cu
+++ b/tests/test_distgeom_kernels.cu
@@ -1630,7 +1630,8 @@ TEST_F(ETK3DGpuTestFixture, CombinedEnergiesMultiMol) {
   std::vector<double> wantEnergy(molsPtrs_.size(), 0.0);
   for (size_t molIdx = 0; molIdx < molsPtrs_.size(); ++molIdx) {
     for (const auto& term : allETK3DTerms) {
-      const double e = getReferenceETK3DEnergyTerm(molsPtrs_[molIdx], term, positionsHost.data() + 3 * atomStartsHost[molIdx]);
+      const double e =
+        getReferenceETK3DEnergyTerm(molsPtrs_[molIdx], term, positionsHost.data() + 3 * atomStartsHost[molIdx]);
       wantEnergy[molIdx] += e;
     }
   }
@@ -1652,7 +1653,8 @@ TEST_F(ETK3DGpuTestFixture, CombinedGradientsMultiMol) {
   for (size_t molIdx = 0; molIdx < molsPtrs_.size(); ++molIdx) {
     std::vector<double> molGradients(4 * molsPtrs_[molIdx]->getNumAtoms(), 0.0);
     for (const auto& term : allETK3DTerms) {
-      auto termGrad = getReferenceETK3DGradientTerm(molsPtrs_[molIdx], term, positionsHost.data() + 3 * atomStartsHost[molIdx]);
+      auto termGrad =
+        getReferenceETK3DGradientTerm(molsPtrs_[molIdx], term, positionsHost.data() + 3 * atomStartsHost[molIdx]);
       for (size_t i = 0; i < molGradients.size(); ++i) {
         molGradients[i] += termGrad[i];
       }
@@ -1662,7 +1664,8 @@ TEST_F(ETK3DGpuTestFixture, CombinedGradientsMultiMol) {
 
   std::vector<std::vector<double>> gotGradSplit = splitCombinedGrads(gotGrad, atomStartsHost);
   for (size_t i = 0; i < wantGradients.size(); ++i) {
-    EXPECT_THAT(gotGradSplit[i], ::testing::Pointwise(::testing::FloatNear(1e-4), wantGradients[i])) << "For system " << i;
+    EXPECT_THAT(gotGradSplit[i], ::testing::Pointwise(::testing::FloatNear(1e-4), wantGradients[i]))
+      << "For system " << i;
   }
 }
 
@@ -1684,7 +1687,10 @@ TEST_F(ETK3DGpuTestFixture, PlainCombinedEnergiesMultiMol) {
   std::vector<double> wantEnergy(molsPtrs_.size(), 0.0);
   for (size_t molIdx = 0; molIdx < molsPtrs_.size(); ++molIdx) {
     for (const auto& term : plainETK3DTerms) {
-      const double e = getReferenceETK3DEnergyTerm(molsPtrs_[molIdx], term, positionsHost.data() + 3 * atomStartsHost[molIdx], DGeomHelpers::ETDG);
+      const double e = getReferenceETK3DEnergyTerm(molsPtrs_[molIdx],
+                                                   term,
+                                                   positionsHost.data() + 3 * atomStartsHost[molIdx],
+                                                   DGeomHelpers::ETDG);
       wantEnergy[molIdx] += e;
     }
   }
@@ -1710,7 +1716,10 @@ TEST_F(ETK3DGpuTestFixture, PlainCombinedGradientsMultiMol) {
   for (size_t molIdx = 0; molIdx < molsPtrs_.size(); ++molIdx) {
     std::vector<double> molGradients(4 * molsPtrs_[molIdx]->getNumAtoms(), 0.0);
     for (const auto& term : plainETK3DTerms) {
-      auto termGrad = getReferenceETK3DGradientTerm(molsPtrs_[molIdx], term, positionsHost.data() + 3 * atomStartsHost[molIdx], DGeomHelpers::ETDG);
+      auto termGrad = getReferenceETK3DGradientTerm(molsPtrs_[molIdx],
+                                                    term,
+                                                    positionsHost.data() + 3 * atomStartsHost[molIdx],
+                                                    DGeomHelpers::ETDG);
       for (size_t i = 0; i < molGradients.size(); ++i) {
         molGradients[i] += termGrad[i];
       }
@@ -1720,6 +1729,7 @@ TEST_F(ETK3DGpuTestFixture, PlainCombinedGradientsMultiMol) {
 
   std::vector<std::vector<double>> gotGradSplit = splitCombinedGrads(gotGrad, atomStartsHost);
   for (size_t i = 0; i < wantGradients.size(); ++i) {
-    EXPECT_THAT(gotGradSplit[i], ::testing::Pointwise(::testing::FloatNear(1e-4), wantGradients[i])) << "For system " << i;
+    EXPECT_THAT(gotGradSplit[i], ::testing::Pointwise(::testing::FloatNear(1e-4), wantGradients[i]))
+      << "For system " << i;
   }
 }

--- a/tests/test_etkdg.cu
+++ b/tests/test_etkdg.cu
@@ -15,6 +15,7 @@
 
 #include <gmock/gmock.h>
 #include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/FileParsers/MolWriters.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <gtest/gtest.h>
 
@@ -510,7 +511,7 @@ void testEnergyImprovement(const std::vector<RDKit::ROMol*>&    mols,
 
     // Calculate and store initial energy
     const double initialEnergy = field->calcEnergy();
-    ASSERT_GT(initialEnergy, 0.0) << "Initial energy should be positive";
+    ASSERT_GE(initialEnergy, 0.0) << "Initial energy should be positive";
     initialEnergies.push_back(initialEnergy);
   }
 
@@ -549,7 +550,7 @@ void testEnergyImprovement(const std::vector<RDKit::ROMol*>&    mols,
 
       // Calculate final energy
       const double finalEnergy = field->calcEnergy();
-      ASSERT_GT(finalEnergy, 0.0) << "Molecule " << i << " conformer " << confId << ": Final energy should be positive";
+      ASSERT_GE(finalEnergy, 0.0) << "Molecule " << i << " conformer " << confId << ": Final energy should be positive";
 
       // Verify energy has improved
       EXPECT_LT(finalEnergy, initialEnergies[i])

--- a/tests/test_openmp_helpers.cpp
+++ b/tests/test_openmp_helpers.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <omp.h>
+
+#include <chrono>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+
+#include "openmp_helpers.h"
+
+namespace {
+
+using ::nvMolKit::detail::OpenMPExceptionRegistry;
+
+constexpr int kNumThreads = 4;
+
+class ScopedThreadCount {
+ public:
+  explicit ScopedThreadCount(const int desiredThreads)
+      : previousThreads_(omp_get_max_threads()),
+        appliedThreads_(desiredThreads <= previousThreads_ ? desiredThreads : previousThreads_) {
+    if (appliedThreads_ > 0) {
+      omp_set_num_threads(appliedThreads_);
+    }
+  }
+  ScopedThreadCount(const ScopedThreadCount&)            = delete;
+  ScopedThreadCount& operator=(const ScopedThreadCount&) = delete;
+  ScopedThreadCount(ScopedThreadCount&&)                 = delete;
+  ScopedThreadCount& operator=(ScopedThreadCount&&)      = delete;
+
+  ~ScopedThreadCount() { omp_set_num_threads(previousThreads_); }
+
+ private:
+  int previousThreads_;
+  int appliedThreads_;
+};
+
+}  // namespace
+
+TEST(OpenMPExceptionRegistryTest, NoExceptionNoThrow) {
+  ScopedThreadCount const setThreads(kNumThreads);
+  OpenMPExceptionRegistry exceptionHandler;
+  EXPECT_NO_THROW(exceptionHandler.rethrow());
+}
+
+TEST(OpenMPExceptionRegistryTest, SingleExceptionCaptured) {
+  ScopedThreadCount const setThreads(kNumThreads);
+  OpenMPExceptionRegistry exceptionHandler;
+
+#pragma omp parallel for shared(exceptionHandler) default(none)
+  for (int i = 0; i < kNumThreads; ++i) {
+    try {
+      if (omp_get_thread_num() == 2) {
+        throw std::runtime_error("thread 2 exception");
+      }
+    } catch (...) {
+      exceptionHandler.store(std::current_exception());
+    }
+  }
+
+  try {
+    exceptionHandler.rethrow();
+    FAIL() << "Expected exception not thrown";
+  } catch (const std::runtime_error& err) {
+    EXPECT_STREQ("thread 2 exception", err.what());
+  }
+}
+
+TEST(OpenMPExceptionRegistryTest, OnlyFirstExceptionCapturedUnderRace) {
+  ScopedThreadCount const setThreads(kNumThreads);
+
+  // Only run if OMP parallel sections execute simultaneously for all threads
+  if (omp_get_max_threads() < kNumThreads) {
+    GTEST_SKIP() << "Insufficient OpenMP threads to run concurrency test";
+  }
+  OpenMPExceptionRegistry exceptionHandler;
+
+  constexpr int kSleepMicroseconds = 100;
+#pragma omp parallel for default(none) shared(exceptionHandler, kSleepMicroseconds)
+  for (int i = 0; i < kNumThreads; ++i) {
+    try {
+      if (i == 3) {
+        throw std::runtime_error("thread 3 immediate exception");
+      }
+      std::this_thread::sleep_for(std::chrono::microseconds(kSleepMicroseconds));
+      throw std::runtime_error("delayed exception");
+    } catch (...) {
+      exceptionHandler.store(std::current_exception());
+    }
+  }
+
+  try {
+    exceptionHandler.rethrow();
+    FAIL() << "Expected exception not thrown";
+  } catch (const std::runtime_error& err) {
+    EXPECT_STREQ("thread 3 immediate exception", err.what());
+  }
+}
+
+TEST(OpenMPExceptionRegistryTest, NoDeadlockWithOtherSynchronization) {
+  ScopedThreadCount const setThreads(kNumThreads);
+  OpenMPExceptionRegistry exceptionHandler;
+
+  std::mutex mutex;
+
+#pragma omp parallel for default(none) shared(mutex, exceptionHandler)
+  for (int i = 0; i < kNumThreads; ++i) {
+    try {
+      {
+        const std::lock_guard<std::mutex> lock(mutex);
+        if (i == 3) {
+          throw std::runtime_error("Critical section throws");
+        }
+      }
+
+      if (i == 1) {
+        throw std::runtime_error("Noncritical section throws");
+      }
+    } catch (...) {
+      exceptionHandler.store(std::current_exception());
+    }
+  }
+
+  EXPECT_THROW(exceptionHandler.rethrow(), std::runtime_error);
+}


### PR DESCRIPTION
Added a new class which just stores the first seen exception then throws at the end of the loop.

Additionally, relaxed an energy check in test_etkdg that was failing. We have a few very simple molecules which can reach zero energy with some ETKDG variants.

Ran formatter which changed test_distgeom_kernels slightly.

Fixes #9 