### PR TITLE
Remove old threading count check

### DIFF
--- a/src/etkdg.cpp
+++ b/src/etkdg.cpp
@@ -81,11 +81,6 @@ void embedMolecules(const std::vector<RDKit::ROMol*>&           mols,
     hardwareOptions.preprocessingThreads == -1 ? omp_get_max_threads() : hardwareOptions.preprocessingThreads;
   const int batchSize = hardwareOptions.batchSize == -1 ? 500 : hardwareOptions.batchSize;
 
-  // Validate batchesPerGpu
-  if (batchesPerGpu > numThreads) {
-    throw std::invalid_argument("batchesPerGpu (" + std::to_string(batchesPerGpu) + ") cannot exceed numThreads (" +
-                                std::to_string(numThreads) + ")");
-  }
   if (batchesPerGpu <= 0) {
     throw std::invalid_argument("batchesPerGpu must be greater than 0");
   }


### PR DESCRIPTION
The CPU vs GPU driving threads are decoupled and we shouldn't check for consistency here. In the extreme case of a 1 CPU system, it's valid to have 1 CPU thread for preprocessing and multiple for GPU dispatch, if not ideal. 

Fixes #31 