### PR TITLE
Use fast math and fix compiler flag appending issue

### DIFF
--- a/cmake/cuda_targets.cmake
+++ b/cmake/cuda_targets.cmake
@@ -37,8 +37,6 @@ elseif(NVMOLKIT_CUDA_TARGET_MODE STREQUAL "full")
         STATUS "CUDA < 12.8 detected, Blackwell (100-real) arch not enabled")
     endif()
   endif()
-  # Suppress possible warnings about deprecated GPU targets 70 and onward.
-  string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets")
 
   set(CMAKE_CUDA_ARCHITECTURES "${_nvmolkit_cuda_arch_list}")
   message(

--- a/cmake/device_compiler_flags.cmake
+++ b/cmake/device_compiler_flags.cmake
@@ -14,14 +14,15 @@
 # the License.
 
 # General flags for CUDA compilation
-string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets")
+# Build up all flags in a temporary variable to avoid duplication on reconfigure
+set(NVMOLKIT_NVCC_ALL_FLAGS "-Wno-deprecated-gpu-targets --default-stream per-thread")
 if(NVMOLKIT_EXTRA_DEV_FLAGS)
-  string(APPEND CMAKE_CUDA_FLAGS " --Werror all-warnings")
+  string(APPEND NVMOLKIT_NVCC_ALL_FLAGS " --Werror all-warnings")
 endif()
 
-set(NVMOLKIT_NVCC_ALL_FLAGS "--default-stream per-thread")
+# Combine host flags (from host_compiler_flags.cmake) and device flags
 set(CMAKE_CUDA_FLAGS
-    "${CMAKE_CUDA_FLAGS} ${NVMOLKIT_NVCC_ALL_FLAGS}"
+    "${NVMOLKIT_HOST_CUDA_FLAGS} ${NVMOLKIT_NVCC_ALL_FLAGS}"
     CACHE STRING "All CUDA flags" FORCE)
 
 set(NVMOLKIT_DEBUG_FLAGS "-g -G")

--- a/cmake/device_compiler_flags.cmake
+++ b/cmake/device_compiler_flags.cmake
@@ -26,7 +26,9 @@ set(CMAKE_CUDA_FLAGS
 
 set(NVMOLKIT_DEBUG_FLAGS "-g -G")
 
-set(NVMOLKIT_RELWITHDEBINFO_FLAGS "-lineinfo")
+set(NVMOLKIT_RELWITHDEBINFO_FLAGS "-lineinfo --ftz=true")
+
+set(NVMOLKIT_RELEASE_FLAGS "--ftz=true")
 
 set(CMAKE_CUDA_FLAGS_DEBUG
     ${NVMOLKIT_DEBUG_FLAGS}
@@ -36,3 +38,7 @@ set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO
     ${NVMOLKIT_RELWITHDEBINFO_FLAGS}
     CACHE STRING "Flags to CUDA compiler used during RelWithDebInfo builds"
           FORCE)
+
+set(CMAKE_CUDA_FLAGS_RELEASE
+    ${NVMOLKIT_RELEASE_FLAGS}
+    CACHE STRING "Flags to CUDA compiler used during Release builds" FORCE)

--- a/cmake/device_compiler_flags.cmake
+++ b/cmake/device_compiler_flags.cmake
@@ -27,9 +27,9 @@ set(CMAKE_CUDA_FLAGS
 
 set(NVMOLKIT_DEBUG_FLAGS "-g -G")
 
-set(NVMOLKIT_RELWITHDEBINFO_FLAGS "-lineinfo --ftz=true")
+set(NVMOLKIT_RELWITHDEBINFO_FLAGS "-lineinfo --use_fast_math")
 
-set(NVMOLKIT_RELEASE_FLAGS "--ftz=true")
+set(NVMOLKIT_RELEASE_FLAGS "--use_fast_math")
 
 set(CMAKE_CUDA_FLAGS_DEBUG
     ${NVMOLKIT_DEBUG_FLAGS}

--- a/cmake/host_compiler_flags.cmake
+++ b/cmake/host_compiler_flags.cmake
@@ -16,8 +16,9 @@
 if(NVMOLKIT_EXTRA_DEV_FLAGS)
   message(STATUS "Enabling extra development flags")
   string(APPEND CMAKE_CXX_FLAGS " -Werror -Wall  -Wextra -Wno-sign-compare")
-  string(APPEND CMAKE_CUDA_FLAGS
-         " --compiler-options \"-Werror -Wall  -Wextra\"")
+  set(NVMOLKIT_HOST_CUDA_FLAGS " --compiler-options \"-Werror -Wall  -Wextra\"")
+else()
+  set(NVMOLKIT_HOST_CUDA_FLAGS "")
 endif()
 if(NVMOLKIT_BUILD_AGAINST_PIP_RDKIT)
   message(STATUS "Using pre-cxx11 ABI")


### PR DESCRIPTION
The warning suppressions had been appended each invocation, which was harmless but led to a bunch of repetition in nvcc invocations.

For fast math, this doesn't break our tests because we're currently mostly in double precision, but have future single precision work that will be affected by it. 