### PR TITLE
Scratch buffers for common copies

### DIFF
--- a/src/etkdg.cpp
+++ b/src/etkdg.cpp
@@ -188,10 +188,10 @@ void embedMolecules(const std::vector<RDKit::ROMol*>&           mols,
   {
     try {
       // Pinned reusable buffers for common copies.
-      PinnedHostVector<double>                positionsScratch;
-      PinnedHostVector<uint8_t>               activeScratch;
-      PinnedHostVector<int16_t>               failuresScratch;
-      detail::ETKDGDriver driver;
+      PinnedHostVector<double>  positionsScratch;
+      PinnedHostVector<uint8_t> activeScratch;
+      PinnedHostVector<int16_t> failuresScratch;
+      detail::ETKDGDriver       driver;
 
       while (!workComplete.load()) {
         // Dispatch work for this thread
@@ -237,8 +237,12 @@ void embedMolecules(const std::vector<RDKit::ROMol*>&           mols,
 
         // Create coordinate generation stage based on parameter
         // FIXME: arguments still involve useRDKitcoordgen.
-        stages.push_back(
-          std::make_unique<detail::ETKDGCoordGenRDKitStage>(paramsCopy, constMolPtrs, batchEargs, positionsScratch, activeScratch, streamPtr));
+        stages.push_back(std::make_unique<detail::ETKDGCoordGenRDKitStage>(paramsCopy,
+                                                                           constMolPtrs,
+                                                                           batchEargs,
+                                                                           positionsScratch,
+                                                                           activeScratch,
+                                                                           streamPtr));
 
         // First minimize, then first round of chiral checks.
         stages.push_back(
@@ -290,8 +294,9 @@ void embedMolecules(const std::vector<RDKit::ROMol*>&           mols,
                                                                               confsPerMolecule));
 
         // Create and run driver
-        auto                context_ptr = std::make_unique<detail::ETKDGContext>(std::move(context));
-        driver.reset(std::move(context_ptr), std::move(stages), debugMode, streamPtr, &allFinished);        stageSetupRange.pop();
+        auto context_ptr = std::make_unique<detail::ETKDGContext>(std::move(context));
+        driver.reset(std::move(context_ptr), std::move(stages), debugMode, streamPtr, &allFinished);
+        stageSetupRange.pop();
 
         ScopedNvtxRange runRange("ETKDG execute");
         driver.run(1);

--- a/src/etkdg_impl.cpp
+++ b/src/etkdg_impl.cpp
@@ -63,11 +63,11 @@ void ETKDGDriver::reset(std::unique_ptr<ETKDGContext>&&            context,
                         bool                                       debugMode,
                         cudaStream_t                               stream,
                         const std::atomic<bool>*                   earlyExitToggle) {
-  context_    = std::move(context);
-  stages_     = std::move(stages);
-  stream_     = stream;
-  earlyExit_  = earlyExitToggle;
-  debugMode_  = debugMode;
+  context_   = std::move(context);
+  stages_    = std::move(stages);
+  stream_    = stream;
+  earlyExit_ = earlyExitToggle;
+  debugMode_ = debugMode;
 
   // Reset counters
   numFinished_ = 0;
@@ -202,7 +202,7 @@ std::vector<std::vector<int16_t>> ETKDGDriver::getFailures(PinnedHostVector<int1
   const size_t numStages = context_->totalFailures.size();
 
   // Calculate total required size for all stages
-  size_t totalSize = 0;
+  size_t              totalSize = 0;
   std::vector<size_t> stageSizes;
   stageSizes.reserve(numStages);
   for (const auto& stageFailures : context_->totalFailures) {

--- a/src/etkdg_impl.cpp
+++ b/src/etkdg_impl.cpp
@@ -211,19 +211,16 @@ std::vector<std::vector<int16_t>> ETKDGDriver::getFailures(PinnedHostVector<int1
     totalSize += stageSize;
   }
 
-  // Resize pinned scratch buffer only if needed
   if (failuresScratch.size() < totalSize) {
     failuresScratch.resize(totalSize);
   }
 
-  // Dispatch all device -> pinned memory copies at once (asynchronously)
+  // Dispatch all device -> pinned memory copies at once and then only one sync.
   size_t offset = 0;
   for (size_t i = 0; i < numStages; ++i) {
     context_->totalFailures[i].copyToHost(failuresScratch.data() + offset, stageSizes[i]);
     offset += stageSizes[i];
   }
-
-  // Single synchronization point for all copies
   cudaStreamSynchronize(stream_);
 
   // Split pinned memory into individual std::vectors

--- a/src/etkdg_impl.cpp
+++ b/src/etkdg_impl.cpp
@@ -55,6 +55,29 @@ ETKDGDriver::ETKDGDriver(std::unique_ptr<ETKDGContext>&&            context,
       stream_(stream),
       earlyExit_(earlyExitToggle),
       debugMode_(debugMode) {
+  initialize();
+}
+
+void ETKDGDriver::reset(std::unique_ptr<ETKDGContext>&&            context,
+                        std::vector<std::unique_ptr<ETKDGStage>>&& stages,
+                        bool                                       debugMode,
+                        cudaStream_t                               stream,
+                        const std::atomic<bool>*                   earlyExitToggle) {
+  context_    = std::move(context);
+  stages_     = std::move(stages);
+  stream_     = stream;
+  earlyExit_  = earlyExitToggle;
+  debugMode_  = debugMode;
+
+  // Reset counters
+  numFinished_ = 0;
+  iteration_   = 0;
+  stageTimings_.clear();
+
+  initialize();
+}
+
+void ETKDGDriver::initialize() {
   if (context_->nTotalSystems == 0) {
     throw std::runtime_error("No conformers to process.");
   }
@@ -119,7 +142,7 @@ void ETKDGDriver::iterate() {
     launchCollectAndFilterFailuresKernel(*context_, static_cast<int>(i), stream_);
   }
 
-  numFinished_ += launchGetFinishedKernels(*context_, iteration_, stream_);
+  numFinished_ += launchGetFinishedKernels(*context_, iteration_, finishedCountHost_.data(), stream_);
   iteration_++;
 }
 
@@ -175,11 +198,41 @@ void ETKDGDriver::printTimingStatistics() const {
   std::cout << std::string(kTableWidth, '=') << "\n";
 }
 
-std::vector<std::vector<int16_t>> ETKDGDriver::getFailures() const {
+std::vector<std::vector<int16_t>> ETKDGDriver::getFailures(PinnedHostVector<int16_t>& failuresScratch) const {
+  const size_t numStages = context_->totalFailures.size();
+
+  // Calculate total required size for all stages
+  size_t totalSize = 0;
+  std::vector<size_t> stageSizes;
+  stageSizes.reserve(numStages);
+  for (const auto& stageFailures : context_->totalFailures) {
+    const size_t stageSize = stageFailures.size();
+    stageSizes.push_back(stageSize);
+    totalSize += stageSize;
+  }
+
+  // Resize pinned scratch buffer only if needed
+  if (failuresScratch.size() < totalSize) {
+    failuresScratch.resize(totalSize);
+  }
+
+  // Dispatch all device -> pinned memory copies at once (asynchronously)
+  size_t offset = 0;
+  for (size_t i = 0; i < numStages; ++i) {
+    context_->totalFailures[i].copyToHost(failuresScratch.data() + offset, stageSizes[i]);
+    offset += stageSizes[i];
+  }
+
+  // Single synchronization point for all copies
+  cudaStreamSynchronize(stream_);
+
+  // Split pinned memory into individual std::vectors
   std::vector<std::vector<int16_t>> res;
-  for (const auto& failures : context_->totalFailures) {
-    auto& stageRes = res.emplace_back(failures.size());
-    failures.copyToHost(stageRes);
+  res.reserve(numStages);
+  offset = 0;
+  for (size_t i = 0; i < numStages; ++i) {
+    res.emplace_back(failuresScratch.begin() + offset, failuresScratch.begin() + offset + stageSizes[i]);
+    offset += stageSizes[i];
   }
   return res;
 }

--- a/src/etkdg_impl.h
+++ b/src/etkdg_impl.h
@@ -142,7 +142,7 @@ class ETKDGDriver {
 
   ETKDGDriver() = default;
 
-  //! Reset the driver with a new context and stages, allowing reuse
+  //! Reset the driver with a new context and stages
   void reset(std::unique_ptr<ETKDGContext>&&            context,
              std::vector<std::unique_ptr<ETKDGStage>>&& stages,
              bool                                       debugMode       = false,

--- a/src/etkdg_impl.h
+++ b/src/etkdg_impl.h
@@ -32,6 +32,7 @@
 #include "device_vector.h"
 #include "dist_geom.h"
 #include "embedder_utils.h"
+#include "host_vector.h"
 
 // forward declarations
 
@@ -89,7 +90,8 @@ void setStreams(ETKDGContext& ctx, cudaStream_t stream);
 void launchCollectAndFilterFailuresKernel(ETKDGContext& context, int stageId, cudaStream_t stream);
 
 //! Checks for newly finished conformers, returns the number of remaining conformers.
-int launchGetFinishedKernels(ETKDGContext& context, int iteration, cudaStream_t stream);
+//! Accepts pinned scratch buffer for finished counts.
+int launchGetFinishedKernels(ETKDGContext& context, int iteration, int* finishedCountHost, cudaStream_t stream);
 
 //! Set initial active filter, based on if a conformer has succeeded in the previous iteration.
 void launchSetRunFilterForIterationKernel(ETKDGContext& context, cudaStream_t stream);
@@ -122,21 +124,30 @@ struct StageTiming {
 };
 
 //! ETKDG Runner class.
-//! Note that this class cannot be reused. It is designed to forward in iterations once.
+//! Can be reused across multiple batches by calling reset() with a new context and stages.
 //!
 //! The runner is designed to operate on batches of molecules. Conformers for the same molecule are considered
 //! independent, and any shared setup upstream of this class should be finished by the time the context is passed to the
-//! constructor.
+//! constructor or reset() method.
 //!
 //! At each iteration, an active subset of conformers are attempted to be generated. A conformer is inactive if a
 //! previous iteration completed succesfully, OR if a previous stage in the current iteration has failed.
 class ETKDGDriver {
  public:
   ETKDGDriver(std::unique_ptr<ETKDGContext>&&            context,
-              std::vector<std::unique_ptr<ETKDGStage>>&& stages,
-              bool                                       debugMode       = false,
-              cudaStream_t                               stream          = nullptr,
-              const std::atomic<bool>*                   earlyExitToggle = nullptr);
+            std::vector<std::unique_ptr<ETKDGStage>>&& stages,
+            bool                                       debugMode       = false,
+            cudaStream_t                               stream          = nullptr,
+            const std::atomic<bool>*                   earlyExitToggle = nullptr);
+
+  ETKDGDriver() = default;
+
+  //! Reset the driver with a new context and stages, allowing reuse
+  void reset(std::unique_ptr<ETKDGContext>&&            context,
+             std::vector<std::unique_ptr<ETKDGStage>>&& stages,
+             bool                                       debugMode       = false,
+             cudaStream_t                               stream          = nullptr,
+             const std::atomic<bool>*                   earlyExitToggle = nullptr);
 
   //! Run one iteration. The iteration ID is incremented.
   void                              iterate();
@@ -150,7 +161,8 @@ class ETKDGDriver {
   std::vector<int16_t>              completedConformers() const;
   //! Returns failure counts. The outer vector is per stage, the inner vector is per conformer,
   //! so getFailures()[i][j] is the number of times that conformer j has failed stage i.
-  std::vector<std::vector<int16_t>> getFailures() const;
+  //! Uses single pinned memory buffer for intermediate D2H transfer (all stages concatenated).
+  std::vector<std::vector<int16_t>> getFailures(PinnedHostVector<int16_t>& failuresScratch) const;
   const ETKDGContext&               context() const { return *context_; }
 
   //! Iterate until all conformers are finished or maxIterations is reached. Does not reset iterations,
@@ -162,15 +174,20 @@ class ETKDGDriver {
  private:
   std::unique_ptr<ETKDGContext>            context_;
   std::vector<std::unique_ptr<ETKDGStage>> stages_;
-  int                                      totalConfs_;
-  int                                      numFinished_ = 0;
-  int                                      iteration_   = 0;
-  cudaStream_t                             stream_;
-  const std::atomic<bool>*                 earlyExit_;  // Optional early exit flag for external control
-
+  int                                      totalConfs_   = 0;
+  int                                      numFinished_  = 0;
+  int                                      iteration_    = 0;
+  cudaStream_t                             stream_       = nullptr;
+  const std::atomic<bool>*                 earlyExit_    = nullptr;  // Optional early exit flag for external control
   // Debug mode members
   bool                                         debugMode_ = false;
   std::unordered_map<std::string, StageTiming> stageTimings_;
+
+  // Pinned memory buffer for D2H transfer of finished count
+  PinnedHostVector<int>                        finishedCountHost_{1};
+
+  // Helper method to initialize driver state from context and stages
+  void initialize();
 
   // Helper method to record timing for a stage
   void recordStageTiming(const std::string& stageName, double duration);

--- a/src/etkdg_impl.h
+++ b/src/etkdg_impl.h
@@ -135,10 +135,10 @@ struct StageTiming {
 class ETKDGDriver {
  public:
   ETKDGDriver(std::unique_ptr<ETKDGContext>&&            context,
-            std::vector<std::unique_ptr<ETKDGStage>>&& stages,
-            bool                                       debugMode       = false,
-            cudaStream_t                               stream          = nullptr,
-            const std::atomic<bool>*                   earlyExitToggle = nullptr);
+              std::vector<std::unique_ptr<ETKDGStage>>&& stages,
+              bool                                       debugMode       = false,
+              cudaStream_t                               stream          = nullptr,
+              const std::atomic<bool>*                   earlyExitToggle = nullptr);
 
   ETKDGDriver() = default;
 
@@ -172,19 +172,19 @@ class ETKDGDriver {
   void run(int maxIterations);
 
  private:
-  std::unique_ptr<ETKDGContext>            context_;
-  std::vector<std::unique_ptr<ETKDGStage>> stages_;
-  int                                      totalConfs_   = 0;
-  int                                      numFinished_  = 0;
-  int                                      iteration_    = 0;
-  cudaStream_t                             stream_       = nullptr;
-  const std::atomic<bool>*                 earlyExit_    = nullptr;  // Optional early exit flag for external control
+  std::unique_ptr<ETKDGContext>                context_;
+  std::vector<std::unique_ptr<ETKDGStage>>     stages_;
+  int                                          totalConfs_  = 0;
+  int                                          numFinished_ = 0;
+  int                                          iteration_   = 0;
+  cudaStream_t                                 stream_      = nullptr;
+  const std::atomic<bool>*                     earlyExit_   = nullptr;  // Optional early exit flag for external control
   // Debug mode members
-  bool                                         debugMode_ = false;
+  bool                                         debugMode_   = false;
   std::unordered_map<std::string, StageTiming> stageTimings_;
 
   // Pinned memory buffer for D2H transfer of finished count
-  PinnedHostVector<int>                        finishedCountHost_{1};
+  PinnedHostVector<int> finishedCountHost_{1};
 
   // Helper method to initialize driver state from context and stages
   void initialize();

--- a/src/etkdg_kernels.cu
+++ b/src/etkdg_kernels.cu
@@ -95,7 +95,11 @@ int launchGetFinishedKernels(ETKDGContext& context, const int iteration, int* fi
                                                           context.finishedOnIteration.data(),
                                                           context.countFinishedThisIteration.data());
   cudaCheckError(cudaGetLastError());
-  cudaCheckError(cudaMemcpyAsync(finishedCountHost, context.countFinishedThisIteration.data(), sizeof(int), cudaMemcpyDeviceToHost, stream));
+  cudaCheckError(cudaMemcpyAsync(finishedCountHost,
+                                 context.countFinishedThisIteration.data(),
+                                 sizeof(int),
+                                 cudaMemcpyDeviceToHost,
+                                 stream));
   cudaStreamSynchronize(stream);
   return *finishedCountHost;
 }

--- a/src/etkdg_stage_coordgen.cu
+++ b/src/etkdg_stage_coordgen.cu
@@ -95,7 +95,6 @@ void ETKDGCoordGenRDKitStage::execute(ETKDGContext& ctx) {
     positionsScratch_.resize(requiredPositionsSize);
   }
 
-  // Copy active flags using pinned memory (use sized copy)
   ctx.activeThisStage.copyToHost(activeScratch_.data(), requiredActiveSize);
 
   auto& rng = getDoubleRandomSource();

--- a/src/etkdg_stage_coordgen.cu
+++ b/src/etkdg_stage_coordgen.cu
@@ -71,13 +71,13 @@ ETKDGCoordGenRDKitStage::ETKDGCoordGenRDKitStage(const RDKit::DGeomHelpers::Embe
                                                  const std::vector<const RDKit::ROMol*>&     mols,
                                                  const std::vector<EmbedArgs>&               eargs,
                                                  PinnedHostVector<double>&                   positionsScratch,
-PinnedHostVector<uint8_t>&                  activeScratch,
+                                                 PinnedHostVector<uint8_t>&                  activeScratch,
                                                  cudaStream_t                                stream)
     : params_(params),
       mols_(mols),
       eargs_(eargs),
-positionsScratch_(positionsScratch),
-activeScratch_(activeScratch),
+      positionsScratch_(positionsScratch),
+      activeScratch_(activeScratch),
       stream_(stream) {}
 
 void ETKDGCoordGenRDKitStage::execute(ETKDGContext& ctx) {
@@ -115,8 +115,8 @@ void ETKDGCoordGenRDKitStage::execute(ETKDGContext& ctx) {
     for (size_t atomIdx = 0; atomIdx < mols_[molIdx]->getNumAtoms(); ++atomIdx) {
       for (int dim = 0; dim < eargs_[molIdx].dim; ++dim) {
         // Generate random position
-        double    pos      = (rng() - 0.5) * boxSize;
-        const int idx      = (ctx.systemHost.atomStarts[molIdx] + atomIdx) * eargs_[molIdx].dim + dim;
+        double    pos          = (rng() - 0.5) * boxSize;
+        const int idx          = (ctx.systemHost.atomStarts[molIdx] + atomIdx) * eargs_[molIdx].dim + dim;
         positionsScratch_[idx] = pos;
       }
     }

--- a/src/etkdg_stage_coordgen.cu
+++ b/src/etkdg_stage_coordgen.cu
@@ -70,10 +70,14 @@ void ETKDGCoordGenStage::execute(ETKDGContext& ctx) {
 ETKDGCoordGenRDKitStage::ETKDGCoordGenRDKitStage(const RDKit::DGeomHelpers::EmbedParameters& params,
                                                  const std::vector<const RDKit::ROMol*>&     mols,
                                                  const std::vector<EmbedArgs>&               eargs,
+                                                 PinnedHostVector<double>&                   positionsScratch,
+PinnedHostVector<uint8_t>&                  activeScratch,
                                                  cudaStream_t                                stream)
     : params_(params),
       mols_(mols),
       eargs_(eargs),
+positionsScratch_(positionsScratch),
+activeScratch_(activeScratch),
       stream_(stream) {}
 
 void ETKDGCoordGenRDKitStage::execute(ETKDGContext& ctx) {
@@ -81,10 +85,20 @@ void ETKDGCoordGenRDKitStage::execute(ETKDGContext& ctx) {
   if (numSystems == 0) {
     return;
   }
-  std::vector<uint8_t> activeHost(ctx.activeThisStage.size());
-  ctx.activeThisStage.copyToHost(activeHost);
-  std::vector<double> hostPositions(ctx.systemHost.atomStarts.back() * eargs_[0].dim);
-  auto&               rng = getDoubleRandomSource();
+  const size_t requiredActiveSize    = ctx.activeThisStage.size();
+  const size_t requiredPositionsSize = ctx.systemHost.atomStarts.back() * eargs_[0].dim;
+
+  if (activeScratch_.size() < requiredActiveSize) {
+    activeScratch_.resize(requiredActiveSize);
+  }
+  if (positionsScratch_.size() < requiredPositionsSize) {
+    positionsScratch_.resize(requiredPositionsSize);
+  }
+
+  // Copy active flags using pinned memory (use sized copy)
+  ctx.activeThisStage.copyToHost(activeScratch_.data(), requiredActiveSize);
+
+  auto& rng = getDoubleRandomSource();
 
   double boxSize;
   if (params_.boxSizeMult > 0) {
@@ -95,7 +109,7 @@ void ETKDGCoordGenRDKitStage::execute(ETKDGContext& ctx) {
   cudaStreamSynchronize(stream_);  // for status check
   // First pass: Generate coordinates for each active molecule
   for (size_t molIdx = 0; molIdx < ctx.systemHost.atomStarts.size() - 1; ++molIdx) {
-    if (!activeHost[molIdx]) {
+    if (!activeScratch_[molIdx]) {
       continue;
     }
     for (size_t atomIdx = 0; atomIdx < mols_[molIdx]->getNumAtoms(); ++atomIdx) {
@@ -103,14 +117,14 @@ void ETKDGCoordGenRDKitStage::execute(ETKDGContext& ctx) {
         // Generate random position
         double    pos      = (rng() - 0.5) * boxSize;
         const int idx      = (ctx.systemHost.atomStarts[molIdx] + atomIdx) * eargs_[molIdx].dim + dim;
-        hostPositions[idx] = pos;
+        positionsScratch_[idx] = pos;
       }
     }
   }
 
   // Update device positions in one go
-  ctx.systemDevice.positions.resize(hostPositions.size());
-  ctx.systemDevice.positions.copyFromHost(hostPositions);
+  ctx.systemDevice.positions.resize(requiredPositionsSize);
+  ctx.systemDevice.positions.copyFromHost(positionsScratch_.data(), requiredPositionsSize);
 }
 
 }  // namespace detail

--- a/src/etkdg_stage_coordgen.h
+++ b/src/etkdg_stage_coordgen.h
@@ -21,6 +21,7 @@
 
 #include "coord_gen.h"
 #include "etkdg_impl.h"
+#include "host_vector.h"
 
 namespace nvMolKit {
 
@@ -45,6 +46,8 @@ class ETKDGCoordGenRDKitStage final : public ETKDGStage {
   ETKDGCoordGenRDKitStage(const RDKit::DGeomHelpers::EmbedParameters& params,
                           const std::vector<const RDKit::ROMol*>&     mols,
                           const std::vector<EmbedArgs>&               eargs,
+                          PinnedHostVector<double>&                   positionsScratch,
+                          PinnedHostVector<uint8_t>&                  activeScratch,
                           cudaStream_t                                stream = nullptr);
   ~ETKDGCoordGenRDKitStage() override = default;
 
@@ -55,6 +58,8 @@ class ETKDGCoordGenRDKitStage final : public ETKDGStage {
   const RDKit::DGeomHelpers::EmbedParameters& params_;
   const std::vector<const RDKit::ROMol*>&     mols_;
   const std::vector<EmbedArgs>&               eargs_;
+  PinnedHostVector<double>&                   positionsScratch_;
+  PinnedHostVector<uint8_t>&                  activeScratch_;
   cudaStream_t                                stream_;
 };
 

--- a/src/etkdg_stage_update_conformers.cu
+++ b/src/etkdg_stage_update_conformers.cu
@@ -50,10 +50,7 @@ void ETKDGUpdateConformersStage::execute(ETKDGContext& ctx) {
     activeScratch_.resize(requiredActiveSize);
   }
 
-  // Copy positions from device to host using pinned memory (use sized copy)
   ctx.systemDevice.positions.copyToHost(positionsScratch_.data(), requiredPositionsSize);
-
-  // Copy active this stage from device to host using pinned memory (use sized copy)
   ctx.activeThisStage.copyToHost(activeScratch_.data(), requiredActiveSize);
   cudaStreamSynchronize(stream_);
 

--- a/src/etkdg_stage_update_conformers.cu
+++ b/src/etkdg_stage_update_conformers.cu
@@ -25,15 +25,15 @@ ETKDGUpdateConformersStage::ETKDGUpdateConformersStage(
   const std::vector<EmbedArgs>&                                                            eargs,
   std::unordered_map<const RDKit::ROMol*, std::vector<std::unique_ptr<RDKit::Conformer>>>& conformers,
   PinnedHostVector<double>&                                                                positionsScratch,
-PinnedHostVector<uint8_t>&                                                               activeScratch,
+  PinnedHostVector<uint8_t>&                                                               activeScratch,
   cudaStream_t                                                                             stream,
   std::mutex*                                                                              conformer_mutex,
   const int                                                                                maxConformersPerMol)
     : mols_(mols),
       eargs_(eargs),
       conformers_(conformers),
-positionsScratch_(positionsScratch),
-activeScratch_(activeScratch),
+      positionsScratch_(positionsScratch),
+      activeScratch_(activeScratch),
       stream_(stream),
       conformer_mutex_(conformer_mutex),
       maxConformersPerMol_(maxConformersPerMol) {}
@@ -72,7 +72,8 @@ void ETKDGUpdateConformersStage::execute(ETKDGContext& ctx) {
 
     for (int j = 0; j < nAtoms; ++j) {
       const int       posIdx = startPosIdx + j * dim;
-      RDGeom::Point3D pos(positionsScratch_[posIdx], positionsScratch_[posIdx + 1], positionsScratch_[posIdx + 2]);      newConf->setAtomPos(j, pos);
+      RDGeom::Point3D pos(positionsScratch_[posIdx], positionsScratch_[posIdx + 1], positionsScratch_[posIdx + 2]);
+      newConf->setAtomPos(j, pos);
     }
 
     // Thread-safe conformer addition with count checking

--- a/src/etkdg_stage_update_conformers.cu
+++ b/src/etkdg_stage_update_conformers.cu
@@ -24,31 +24,42 @@ ETKDGUpdateConformersStage::ETKDGUpdateConformersStage(
   const std::vector<RDKit::ROMol*>&                                                        mols,
   const std::vector<EmbedArgs>&                                                            eargs,
   std::unordered_map<const RDKit::ROMol*, std::vector<std::unique_ptr<RDKit::Conformer>>>& conformers,
+  PinnedHostVector<double>&                                                                positionsScratch,
+PinnedHostVector<uint8_t>&                                                               activeScratch,
   cudaStream_t                                                                             stream,
   std::mutex*                                                                              conformer_mutex,
   const int                                                                                maxConformersPerMol)
     : mols_(mols),
       eargs_(eargs),
       conformers_(conformers),
+positionsScratch_(positionsScratch),
+activeScratch_(activeScratch),
       stream_(stream),
       conformer_mutex_(conformer_mutex),
       maxConformersPerMol_(maxConformersPerMol) {}
 
 void ETKDGUpdateConformersStage::execute(ETKDGContext& ctx) {
   // Copy positions from device to host
-  std::vector<double> hostPositions;
-  hostPositions.resize(ctx.systemDevice.positions.size());
-  ctx.systemDevice.positions.copyToHost(hostPositions);
+  const size_t requiredPositionsSize = ctx.systemDevice.positions.size();
+  const size_t requiredActiveSize    = ctx.activeThisStage.size();
 
-  // Copy active this stage from device to host
-  std::vector<uint8_t> hostActiveThisStage;
-  hostActiveThisStage.resize(ctx.activeThisStage.size());
-  ctx.activeThisStage.copyToHost(hostActiveThisStage);
+  if (positionsScratch_.size() < requiredPositionsSize) {
+    positionsScratch_.resize(requiredPositionsSize);
+  }
+  if (activeScratch_.size() < requiredActiveSize) {
+    activeScratch_.resize(requiredActiveSize);
+  }
+
+  // Copy positions from device to host using pinned memory (use sized copy)
+  ctx.systemDevice.positions.copyToHost(positionsScratch_.data(), requiredPositionsSize);
+
+  // Copy active this stage from device to host using pinned memory (use sized copy)
+  ctx.activeThisStage.copyToHost(activeScratch_.data(), requiredActiveSize);
   cudaStreamSynchronize(stream_);
 
   for (size_t i = 0; i < mols_.size(); ++i) {
     // Skip if not active this stage
-    if (hostActiveThisStage[i] != 1) {
+    if (activeScratch_[i] != 1) {
       continue;
     }
 
@@ -61,8 +72,7 @@ void ETKDGUpdateConformersStage::execute(ETKDGContext& ctx) {
 
     for (int j = 0; j < nAtoms; ++j) {
       const int       posIdx = startPosIdx + j * dim;
-      RDGeom::Point3D pos(hostPositions[posIdx], hostPositions[posIdx + 1], hostPositions[posIdx + 2]);
-      newConf->setAtomPos(j, pos);
+      RDGeom::Point3D pos(positionsScratch_[posIdx], positionsScratch_[posIdx + 1], positionsScratch_[posIdx + 2]);      newConf->setAtomPos(j, pos);
     }
 
     // Thread-safe conformer addition with count checking

--- a/src/etkdg_stage_update_conformers.h
+++ b/src/etkdg_stage_update_conformers.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "etkdg_impl.h"
+#include "host_vector.h"
 
 namespace nvMolKit {
 namespace detail {
@@ -31,6 +32,8 @@ class ETKDGUpdateConformersStage final : public ETKDGStage {
     const std::vector<RDKit::ROMol*>&                                                        mols,
     const std::vector<EmbedArgs>&                                                            eargs,
     std::unordered_map<const RDKit::ROMol*, std::vector<std::unique_ptr<RDKit::Conformer>>>& conformers,
+    PinnedHostVector<double>&                                                                positionsScratch,
+PinnedHostVector<uint8_t>&                                                               activeScratch,
     cudaStream_t                                                                             stream          = nullptr,
     std::mutex*                                                                              conformer_mutex = nullptr,
     int                                                                                      maxConformersPerMol = -1);
@@ -42,6 +45,8 @@ class ETKDGUpdateConformersStage final : public ETKDGStage {
   const std::vector<RDKit::ROMol*>&                                                        mols_;
   const std::vector<EmbedArgs>&                                                            eargs_;
   std::unordered_map<const RDKit::ROMol*, std::vector<std::unique_ptr<RDKit::Conformer>>>& conformers_;
+  PinnedHostVector<double>&                                                                positionsScratch_;
+  PinnedHostVector<uint8_t>&                                                               activeScratch_;
   cudaStream_t                                                                             stream_;
   std::mutex*                                                                              conformer_mutex_;
   int                                                                                      maxConformersPerMol_;

--- a/src/etkdg_stage_update_conformers.h
+++ b/src/etkdg_stage_update_conformers.h
@@ -33,7 +33,7 @@ class ETKDGUpdateConformersStage final : public ETKDGStage {
     const std::vector<EmbedArgs>&                                                            eargs,
     std::unordered_map<const RDKit::ROMol*, std::vector<std::unique_ptr<RDKit::Conformer>>>& conformers,
     PinnedHostVector<double>&                                                                positionsScratch,
-PinnedHostVector<uint8_t>&                                                               activeScratch,
+    PinnedHostVector<uint8_t>&                                                               activeScratch,
     cudaStream_t                                                                             stream          = nullptr,
     std::mutex*                                                                              conformer_mutex = nullptr,
     int                                                                                      maxConformersPerMol = -1);

--- a/tests/test_etkdg_coordgen.cu
+++ b/tests/test_etkdg_coordgen.cu
@@ -90,7 +90,9 @@ TEST(EtkdgCoordGenTest, TestGenerateInitialCoords) {
   ASSERT_EQ(driver.iterationsComplete(), 2);
   EXPECT_GT(driver.numConfsFinished(), 0);  // Statistically likely at least one conformer finished.
   EXPECT_LE(driver.numConfsFinished(), 8);  // At least two failed first stage both iterations.
-  auto failureCounts = driver.getFailures();
+
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  auto failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 2);
 
   auto stage0Failures = failureCounts[0];

--- a/tests/test_etkdg_coordgen.cu
+++ b/tests/test_etkdg_coordgen.cu
@@ -92,7 +92,7 @@ TEST(EtkdgCoordGenTest, TestGenerateInitialCoords) {
   EXPECT_LE(driver.numConfsFinished(), 8);  // At least two failed first stage both iterations.
 
   nvMolKit::PinnedHostVector<int16_t> failuresScratch;
-  auto failureCounts = driver.getFailures(failuresScratch);
+  auto                                failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 2);
 
   auto stage0Failures = failureCounts[0];

--- a/tests/test_etkdg_etk_minimize.cu
+++ b/tests/test_etkdg_etk_minimize.cu
@@ -266,7 +266,7 @@ TEST_P(ETKStageSingleMolTestFixture, MinimizeCompare) {
   EXPECT_EQ(driver.iterationsComplete(), 1);
 
   nvMolKit::PinnedHostVector<int16_t> failuresScratch;
-  const auto failureCounts = driver.getFailures(failuresScratch);
+  const auto                          failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 1);                      // One stage
   EXPECT_THAT(failureCounts[0], testing::ElementsAre(0));  // FirstMinimizeStage
 
@@ -360,7 +360,7 @@ TEST_P(ETKStageMultiMolTestFixture, MinimizeCompare) {
   ASSERT_EQ(driver.iterationsComplete(), 1);
 
   nvMolKit::PinnedHostVector<int16_t> failuresScratch;
-  const auto failureCounts = driver.getFailures(failuresScratch);
+  const auto                          failureCounts = driver.getFailures(failuresScratch);
   ASSERT_EQ(failureCounts.size(), 1);  // One stage
 
   // Minimize the molecules on the CPU to compare results.

--- a/tests/test_etkdg_etk_minimize.cu
+++ b/tests/test_etkdg_etk_minimize.cu
@@ -265,7 +265,8 @@ TEST_P(ETKStageSingleMolTestFixture, MinimizeCompare) {
   EXPECT_EQ(driver.numConfsFinished(), 1);
   EXPECT_EQ(driver.iterationsComplete(), 1);
 
-  const auto failureCounts = driver.getFailures();
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  const auto failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 1);                      // One stage
   EXPECT_THAT(failureCounts[0], testing::ElementsAre(0));  // FirstMinimizeStage
 
@@ -358,7 +359,8 @@ TEST_P(ETKStageMultiMolTestFixture, MinimizeCompare) {
   // Check other results first
   ASSERT_EQ(driver.iterationsComplete(), 1);
 
-  const auto failureCounts = driver.getFailures();
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  const auto failureCounts = driver.getFailures(failuresScratch);
   ASSERT_EQ(failureCounts.size(), 1);  // One stage
 
   // Minimize the molecules on the CPU to compare results.

--- a/tests/test_etkdg_minimize.cu
+++ b/tests/test_etkdg_minimize.cu
@@ -30,6 +30,7 @@
 #include "etkdg_stage_firstminimization.h"
 #include "etkdg_stage_fourthdimminimization.h"
 #include "test_utils.h"
+#include "utils/host_vector.h"
 
 using namespace ::nvMolKit::detail;
 
@@ -168,6 +169,8 @@ class ETKDGMinimizeSingleMolTestFixture : public ::testing::TestWithParam<ETKDGO
   ETKDGContext                               context_;
   std::vector<nvMolKit::detail::EmbedArgs>   eargs_;
   RDKit::DGeomHelpers::EmbedParameters       embedParam_;
+  nvMolKit::PinnedHostVector<double>         positionsScratch_;
+  nvMolKit::PinnedHostVector<uint8_t>        activeScratch_;
 };
 
 // BFGS Stage Tests
@@ -194,7 +197,7 @@ TEST_P(ETKDGMinimizeSingleMolTestFixture, FirstMinimizeStageBFGSTest) {
   EXPECT_EQ(driver.iterationsComplete(), 1);
 
   nvMolKit::PinnedHostVector<int16_t> failuresScratch;
-  const auto failureCounts = driver.getFailures(failuresScratch);
+  auto                                failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 1);                      // One stage
   EXPECT_THAT(failureCounts[0], testing::ElementsAre(0));  // FirstMinimizeStage
 
@@ -219,7 +222,8 @@ TEST_P(ETKDGMinimizeSingleMolTestFixture, FourthDimMinimizeStageBFGSTest) {
   EXPECT_EQ(driver.iterationsComplete(), 1);
 
   nvMolKit::PinnedHostVector<int16_t> failuresScratch;
-  const auto failureCounts = driver.getFailures(failuresScratch);  EXPECT_EQ(failureCounts.size(), 1);                      // One stage
+  auto                                failureCounts = driver.getFailures(failuresScratch);
+  EXPECT_EQ(failureCounts.size(), 1);                      // One stage
   EXPECT_THAT(failureCounts[0], testing::ElementsAre(0));  // FourthDimMinimizeStage
 
   auto completed = driver.completedConformers();
@@ -250,7 +254,7 @@ TEST_P(ETKDGMinimizeSingleMolTestFixture, FullMinimizationPipelineBFGSTest) {
   EXPECT_EQ(driver.iterationsComplete(), 1);
 
   nvMolKit::PinnedHostVector<int16_t> failuresScratch;
-  const auto failureCounts = driver.getFailures(failuresScratch);
+  auto                                failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 2);                      // Two stages
   EXPECT_THAT(failureCounts[0], testing::ElementsAre(0));  // FirstMinimizeStage
   EXPECT_THAT(failureCounts[1], testing::ElementsAre(0));  // FourthDimMinimizeStage
@@ -272,7 +276,11 @@ TEST_P(ETKDGMinimizeSingleMolTestFixture, FirstPartETKDGPipelineBFGSTest) {
 
   // Create stages in order: coordgen -> first minimize BFGS -> fourthdim BFGS
   std::vector<std::unique_ptr<ETKDGStage>> stages;
-  stages.push_back(std::make_unique<nvMolKit::detail::ETKDGCoordGenRDKitStage>(embedParam_, mols_, eargs_));
+  stages.push_back(std::make_unique<nvMolKit::detail::ETKDGCoordGenRDKitStage>(embedParam_,
+                                                                               mols_,
+                                                                               eargs_,
+                                                                               positionsScratch_,
+                                                                               activeScratch_));
   auto  firstStage    = std::make_unique<nvMolKit::detail::FirstMinimizeStage>(mols_, eargs_, embedParam_, context_);
   auto* firstStagePtr = firstStage.get();  // Store pointer before moving
   stages.push_back(std::move(firstStage));
@@ -290,7 +298,8 @@ TEST_P(ETKDGMinimizeSingleMolTestFixture, FirstPartETKDGPipelineBFGSTest) {
   EXPECT_EQ(driver.numConfsFinished(), 1);
   EXPECT_LE(driver.iterationsComplete(), 2);  // Allow for 1 failure.
 
-  auto failureCounts = driver.getFailures();
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  auto                                failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 3);                                              // Three stages
   EXPECT_THAT(failureCounts[0], testing::Each(0));                                 // CoordGenStage
   EXPECT_THAT(failureCounts[1], testing::Each(testing::Le(maxFailedIterations)));  // FirstMinimizeStage
@@ -342,6 +351,8 @@ class ETKDGMinimizeMultiMolDiverseTestFixture : public ::testing::TestWithParam<
   ETKDGContext                               context_;
   std::vector<nvMolKit::detail::EmbedArgs>   eargs_;
   RDKit::DGeomHelpers::EmbedParameters       embedParam_;
+  nvMolKit::PinnedHostVector<double>         positionsScratch_;
+  nvMolKit::PinnedHostVector<uint8_t>        activeScratch_;
 };
 
 // BFGS Stage Tests for diverse molecules
@@ -366,7 +377,8 @@ TEST_P(ETKDGMinimizeMultiMolDiverseTestFixture, FirstMinimizeStageBFGSTest) {
   stagePtr->molSystemDevice.energyOuts.copyToHost(finalEnergies);
 
   // Get failure counts
-  auto failureCounts = driver.getFailures();
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  auto                                failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 1);                                              // One stage
   EXPECT_THAT(failureCounts[0], testing::Each(testing::Le(maxFailedIterations)));  // FirstMinimizeStage
 
@@ -394,7 +406,8 @@ TEST_P(ETKDGMinimizeMultiMolDiverseTestFixture, FourthDimMinimizeStageBFGSTest) 
   EXPECT_EQ(driver.numConfsFinished(), 5);
   EXPECT_EQ(driver.iterationsComplete(), 1);
 
-  auto failureCounts = driver.getFailures();
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  auto                                failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 1);               // One stage
   EXPECT_THAT(failureCounts[0], testing::Each(0));  // FourthDimMinimizeStage
 
@@ -422,11 +435,12 @@ TEST_P(ETKDGMinimizeMultiMolDiverseTestFixture, FullMinimizationPipelineBFGSTest
   driver.run(2);
 
   // Get final energies from the first stage
-  std::vector<double> finalEnergies(secondStagePtr->molSystemDevice.energyOuts.size());
-  secondStagePtr->molSystemDevice.energyOuts.copyToHost(finalEnergies);
+  std::vector<double> finalEnergies(firstStagePtr->molSystemDevice.energyOuts.size());
+  firstStagePtr->molSystemDevice.energyOuts.copyToHost(finalEnergies);
 
   // Get failure counts
-  auto failureCounts = driver.getFailures();
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  auto                                failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 2);                                              // Two stages
   EXPECT_THAT(failureCounts[0], testing::Each(testing::Le(maxFailedIterations)));  // FirstMinimizeStage
   EXPECT_THAT(failureCounts[1], testing::Each(testing::Le(maxFailedIterations)));  // FourthDimMinimizeStage
@@ -452,7 +466,11 @@ TEST_P(ETKDGMinimizeMultiMolDiverseTestFixture, FirstPartETKDGPipelineBFGSTest) 
 
   // Create stages in order: coordgen -> first minimize BFGS -> fourthdim BFGS
   std::vector<std::unique_ptr<ETKDGStage>> stages;
-  stages.push_back(std::make_unique<nvMolKit::detail::ETKDGCoordGenRDKitStage>(embedParam_, mols_, eargs_));
+  stages.push_back(std::make_unique<nvMolKit::detail::ETKDGCoordGenRDKitStage>(embedParam_,
+                                                                               mols_,
+                                                                               eargs_,
+                                                                               positionsScratch_,
+                                                                               activeScratch_));
   auto firstStage = std::make_unique<nvMolKit::detail::FirstMinimizeStage>(mols_, eargs_, embedParam_, context_);
   stages.push_back(std::move(firstStage));
   auto  secondStage = std::make_unique<nvMolKit::detail::FourthDimMinimizeStage>(mols_, eargs_, embedParam_, context_);
@@ -461,7 +479,8 @@ TEST_P(ETKDGMinimizeMultiMolDiverseTestFixture, FirstPartETKDGPipelineBFGSTest) 
   // Create and run driver
   ETKDGDriver driver(std::make_unique<ETKDGContext>(std::move(context_)), std::move(stages));
   driver.run(3);
-  auto failureCounts = driver.getFailures();
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  auto                                failureCounts = driver.getFailures(failuresScratch);
 
   // Get final energies from the first stage
   std::vector<double> finalEnergies(secondStagePtr->molSystemDevice.energyOuts.size());

--- a/tests/test_etkdg_minimize.cu
+++ b/tests/test_etkdg_minimize.cu
@@ -193,7 +193,8 @@ TEST_P(ETKDGMinimizeSingleMolTestFixture, FirstMinimizeStageBFGSTest) {
   EXPECT_EQ(driver.numConfsFinished(), 1);
   EXPECT_EQ(driver.iterationsComplete(), 1);
 
-  auto failureCounts = driver.getFailures();
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  const auto failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 1);                      // One stage
   EXPECT_THAT(failureCounts[0], testing::ElementsAre(0));  // FirstMinimizeStage
 
@@ -217,8 +218,8 @@ TEST_P(ETKDGMinimizeSingleMolTestFixture, FourthDimMinimizeStageBFGSTest) {
   EXPECT_EQ(driver.numConfsFinished(), 1);
   EXPECT_EQ(driver.iterationsComplete(), 1);
 
-  auto failureCounts = driver.getFailures();
-  EXPECT_EQ(failureCounts.size(), 1);                      // One stage
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  const auto failureCounts = driver.getFailures(failuresScratch);  EXPECT_EQ(failureCounts.size(), 1);                      // One stage
   EXPECT_THAT(failureCounts[0], testing::ElementsAre(0));  // FourthDimMinimizeStage
 
   auto completed = driver.completedConformers();
@@ -248,7 +249,8 @@ TEST_P(ETKDGMinimizeSingleMolTestFixture, FullMinimizationPipelineBFGSTest) {
   EXPECT_EQ(driver.numConfsFinished(), 1);
   EXPECT_EQ(driver.iterationsComplete(), 1);
 
-  auto failureCounts = driver.getFailures();
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  const auto failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 2);                      // Two stages
   EXPECT_THAT(failureCounts[0], testing::ElementsAre(0));  // FirstMinimizeStage
   EXPECT_THAT(failureCounts[1], testing::ElementsAre(0));  // FourthDimMinimizeStage

--- a/tests/test_etkdg_stereochem_checks.cu
+++ b/tests/test_etkdg_stereochem_checks.cu
@@ -106,7 +106,8 @@ void allPassChecks(const ETKDGDriver& driver, int expectedExceptions = 0) {
   EXPECT_EQ(driver.numConfsFinished(), wantNumConfsParsedMMFF - expectedExceptions);
   EXPECT_EQ(driver.iterationsComplete(), 1);
 
-  const auto failureCounts = driver.getFailures();
+  nvMolKit::PinnedHostVector<int16_t> failuresScratch;
+  const auto                          failureCounts = driver.getFailures(failuresScratch);
   EXPECT_EQ(failureCounts.size(), 1);  // One stage
 
   const auto totalFailures =


### PR DESCRIPTION
* Add code to reuse an ETKDG context to not reallocate
* Add per thread scratch buffers for copying statuses and positions, and failure checks