### PR TITLE
Fix stream ordering bug in device pointers

### DIFF
--- a/src/etkdg.cpp
+++ b/src/etkdg.cpp
@@ -230,7 +230,7 @@ void embedMolecules(const std::vector<RDKit::ROMol*>&           mols,
           batchEargs.push_back(eargs[molId]);
         }
 
-        detail::ETKDGContext context;
+        detail::ETKDGContext context(streamPtr);
         detail::setStreams(context, streamPtr);
         // Treat each conformer attempt as an individual molecule (confsPerMolecule = 1)
         detail::initETKDGContext(batchMolsWithConfs, context, 1);

--- a/src/etkdg_impl.h
+++ b/src/etkdg_impl.h
@@ -63,6 +63,8 @@ struct ETKDGSystemDevice {
 
 //! All relevant CPU/GPU data.
 struct ETKDGContext {
+  explicit ETKDGContext(cudaStream_t stream = nullptr) : countFinishedThisIteration(0, stream) {}
+
   //! Host data
   ETKDGSystemHost                         systemHost;
   //! Device data

--- a/src/minimizer/bfgs_minimize.cu
+++ b/src/minimizer/bfgs_minimize.cu
@@ -360,7 +360,8 @@ BfgsBatchMinimizer::BfgsBatchMinimizer(const int    dataDim,
                                        DebugLevel   debugLevel,
                                        bool         scaleGrads,
                                        cudaStream_t stream,
-                                       BfgsBackend  backend) {
+                                       BfgsBackend  backend)
+    : countFinished_(0, stream) {
   debugLevel_ = debugLevel;
   dataDim_    = dataDim;
   scaleGrads_ = scaleGrads;


### PR DESCRIPTION
These were being allocated on the default stream, meaning that very infrequently it was possible to access them before allocation completed. This may have been another source of the user reported sync errors.