### PR TITLE
Fix various possible memory and overflow issues

### DIFF
--- a/src/etkdg.cpp
+++ b/src/etkdg.cpp
@@ -230,7 +230,7 @@ void embedMolecules(const std::vector<RDKit::ROMol*>&           mols,
           batchEargs.push_back(eargs[molId]);
         }
 
-        detail::ETKDGContext context;
+        detail::ETKDGContext context(streamPtr);
         detail::setStreams(context, streamPtr);
         // Treat each conformer attempt as an individual molecule (confsPerMolecule = 1)
         detail::initETKDGContext(batchMolsWithConfs, context, 1);

--- a/src/etkdg_impl.cpp
+++ b/src/etkdg_impl.cpp
@@ -97,6 +97,7 @@ void ETKDGDriver::initialize() {
   context_->finishedOnIteration.resize(context_->nTotalSystems);
   context_->finishedOnIteration.copyFromHost(copyFrom);
   context_->activeThisStage.resize(context_->nTotalSystems);
+  cudaStreamSynchronize(stream_);  // Sync before copyFrom goes out of scope
 }
 
 void ETKDGDriver::recordStageTiming(const std::string& stageName, double duration) {

--- a/src/etkdg_impl.h
+++ b/src/etkdg_impl.h
@@ -63,6 +63,8 @@ struct ETKDGSystemDevice {
 
 //! All relevant CPU/GPU data.
 struct ETKDGContext {
+  explicit ETKDGContext(cudaStream_t stream = nullptr) : countFinishedThisIteration(0, stream) {}
+
   //! Host data
   ETKDGSystemHost                         systemHost;
   //! Device data

--- a/src/etkdg_stage_stereochem_checks.cu
+++ b/src/etkdg_stage_stereochem_checks.cu
@@ -494,6 +494,7 @@ void ETKDGChiralCheckBase::loadChiralDataset(const ETKDGContext&           ctx,
   } else {
     structureFlags.setFromVector(structureFlagsHost);
   }
+  cudaStreamSynchronize(idx0.stream());  // Sync before local vectors go out of scope
 }
 
 void ETKDGChiralCheckBase::setStreams(const cudaStream_t stream) {
@@ -659,6 +660,7 @@ void ETKDGChiralDistMatrixCheckStage::loadDataset(const ETKDGContext& ctx, const
   sysIdx.setFromVector(sysIdxHost);
   matLowerBound.setFromVector(lowerBound);
   matUpperBound.setFromVector(upperBound);
+  cudaStreamSynchronize(idx0.stream());  // Sync before local vectors go out of scope
 }
 
 ETKDGChiralDistMatrixCheckStage::ETKDGChiralDistMatrixCheckStage(const ETKDGContext&           ctx,
@@ -762,6 +764,7 @@ void ETKDGDoubleBondStereoCheckStage::loadDataset(const ETKDGContext& ctx, const
   idx3.setFromVector(idx3Host);
   signs.setFromVector(signsHost);
   sysIdx.setFromVector(sysIdxHost);
+  cudaStreamSynchronize(idx0.stream());  // Sync before local vectors go out of scope
 }
 
 ETKDGDoubleBondGeometryCheckStage::ETKDGDoubleBondGeometryCheckStage(const ETKDGContext&           ctx,
@@ -815,6 +818,7 @@ void ETKDGDoubleBondGeometryCheckStage::loadDataset(const ETKDGContext& ctx, con
   idx1.setFromVector(idx1Host);
   idx2.setFromVector(idx2Host);
   sysIdx.setFromVector(sysIdxHost);
+  cudaStreamSynchronize(idx0.stream());  // Sync before local vectors go out of scope
 }
 
 }  // namespace detail

--- a/src/forcefields/dist_geom.cu
+++ b/src/forcefields/dist_geom.cu
@@ -606,6 +606,8 @@ void sendContribsAndIndicesToDevice3D(const BatchedMolecularSystem3DHost& molSys
   deviceIndices.dist13TermStarts.setFromVector(hostIndices.dist13TermStarts);
   deviceIndices.angle13TermStarts.setFromVector(hostIndices.angle13TermStarts);
   deviceIndices.longRangeDistTermStarts.setFromVector(hostIndices.longRangeDistTermStarts);
+  cudaStreamSynchronize(
+    deviceIndices.longRangeDistTermStarts.stream());  // Sync before isCBoundToOInt goes out of scope
 }
 
 //! Set all DeviceVector streams for the batched molecular device buffers.

--- a/src/forcefields/dist_geom_kernels_device.cuh
+++ b/src/forcefields/dist_geom_kernels_device.cuh
@@ -1040,9 +1040,9 @@ static __device__ __inline__ double molEnergyETK(const Energy3DForceContribsDevi
   namespace cg            = cooperative_groups;
   constexpr int WARP_SIZE = 32;
   auto          tile32    = cg::tiled_partition<WARP_SIZE>(cg::this_thread_block());
-  const int16_t laneId    = tile32.thread_rank();
-  const int16_t warpId    = tile32.meta_group_rank();
-  const int16_t numWarps  = tile32.meta_group_size();
+  const int     laneId    = tile32.thread_rank();
+  const int     warpId    = tile32.meta_group_rank();
+  const int     numWarps  = tile32.meta_group_size();
 
   // Get term ranges
   const int torsionStart  = systemIndices.experimentalTorsionTermStarts[molIdx];
@@ -1077,22 +1077,22 @@ static __device__ __inline__ double molEnergyETK(const Energy3DForceContribsDevi
   constexpr double defaultAngleForceConstant = 1.0;
 
   // Calculate number of warps needed for each term type
-  const int16_t warpsForTorsion  = (numTorsion + WARP_SIZE - 1) / WARP_SIZE;
-  const int16_t warpsForImproper = (numImproper + WARP_SIZE - 1) / WARP_SIZE;
-  const int16_t warpsForDist12   = (numDist12 + WARP_SIZE - 1) / WARP_SIZE;
-  const int16_t warpsForDist13   = (numDist13 + WARP_SIZE - 1) / WARP_SIZE;
-  const int16_t warpsForAngle13  = (numAngle13 + WARP_SIZE - 1) / WARP_SIZE;
-  const int16_t warpsForDistLR   = (numDistLR + WARP_SIZE - 1) / WARP_SIZE;
-  const int16_t totalWarpsNeeded =
+  const int warpsForTorsion  = (numTorsion + WARP_SIZE - 1) / WARP_SIZE;
+  const int warpsForImproper = (numImproper + WARP_SIZE - 1) / WARP_SIZE;
+  const int warpsForDist12   = (numDist12 + WARP_SIZE - 1) / WARP_SIZE;
+  const int warpsForDist13   = (numDist13 + WARP_SIZE - 1) / WARP_SIZE;
+  const int warpsForAngle13  = (numAngle13 + WARP_SIZE - 1) / WARP_SIZE;
+  const int warpsForDistLR   = (numDistLR + WARP_SIZE - 1) / WARP_SIZE;
+  const int totalWarpsNeeded =
     warpsForTorsion + warpsForImproper + warpsForDist12 + warpsForDist13 + warpsForAngle13 + warpsForDistLR;
 
   // Each warp processes chunks in round-robin fashion
-  for (int16_t chunkIdx = warpId; chunkIdx < totalWarpsNeeded; chunkIdx += numWarps) {
+  for (int chunkIdx = warpId; chunkIdx < totalWarpsNeeded; chunkIdx += numWarps) {
     // Determine which term type this chunk belongs to
     if (chunkIdx < warpsForTorsion) {
       // Torsion terms
-      const int16_t baseIdx = chunkIdx * WARP_SIZE;
-      const int16_t termIdx = torsionStart + baseIdx + laneId;
+      const int baseIdx = chunkIdx * WARP_SIZE;
+      const int termIdx = torsionStart + baseIdx + laneId;
       if (baseIdx + laneId < numTorsion) {
         const int localIdx1 = t_idx1s[termIdx] - atomStart;
         const int localIdx2 = t_idx2s[termIdx] - atomStart;
@@ -1108,9 +1108,9 @@ static __device__ __inline__ double molEnergyETK(const Energy3DForceContribsDevi
       }
     } else if (chunkIdx < warpsForTorsion + warpsForImproper) {
       // Improper torsion terms
-      const int16_t warpOffset = chunkIdx - warpsForTorsion;
-      const int16_t baseIdx    = warpOffset * WARP_SIZE;
-      const int16_t termIdx    = improperStart + baseIdx + laneId;
+      const int warpOffset = chunkIdx - warpsForTorsion;
+      const int baseIdx    = warpOffset * WARP_SIZE;
+      const int termIdx    = improperStart + baseIdx + laneId;
       if (baseIdx + laneId < numImproper) {
         const int localIdx1 = i_idx1s[termIdx] - atomStart;
         const int localIdx2 = i_idx2s[termIdx] - atomStart;
@@ -1128,9 +1128,9 @@ static __device__ __inline__ double molEnergyETK(const Energy3DForceContribsDevi
       }
     } else if (chunkIdx < warpsForTorsion + warpsForImproper + warpsForDist12) {
       // 1-2 distance terms
-      const int16_t warpOffset = chunkIdx - warpsForTorsion - warpsForImproper;
-      const int16_t baseIdx    = warpOffset * WARP_SIZE;
-      const int16_t termIdx    = dist12Start + baseIdx + laneId;
+      const int warpOffset = chunkIdx - warpsForTorsion - warpsForImproper;
+      const int baseIdx    = warpOffset * WARP_SIZE;
+      const int termIdx    = dist12Start + baseIdx + laneId;
       if (baseIdx + laneId < numDist12) {
         const int localIdx1 = d12_idx1s[termIdx] - atomStart;
         const int localIdx2 = d12_idx2s[termIdx] - atomStart;
@@ -1143,9 +1143,9 @@ static __device__ __inline__ double molEnergyETK(const Energy3DForceContribsDevi
       }
     } else if (chunkIdx < warpsForTorsion + warpsForImproper + warpsForDist12 + warpsForDist13) {
       // 1-3 distance terms
-      const int16_t warpOffset = chunkIdx - warpsForTorsion - warpsForImproper - warpsForDist12;
-      const int16_t baseIdx    = warpOffset * WARP_SIZE;
-      const int16_t termIdx    = dist13Start + baseIdx + laneId;
+      const int warpOffset = chunkIdx - warpsForTorsion - warpsForImproper - warpsForDist12;
+      const int baseIdx    = warpOffset * WARP_SIZE;
+      const int termIdx    = dist13Start + baseIdx + laneId;
       if (baseIdx + laneId < numDist13) {
         const int localIdx1 = d13_idx1s[termIdx] - atomStart;
         const int localIdx2 = d13_idx2s[termIdx] - atomStart;
@@ -1158,9 +1158,9 @@ static __device__ __inline__ double molEnergyETK(const Energy3DForceContribsDevi
       }
     } else if (chunkIdx < warpsForTorsion + warpsForImproper + warpsForDist12 + warpsForDist13 + warpsForAngle13) {
       // 1-3 angle terms
-      const int16_t warpOffset = chunkIdx - warpsForTorsion - warpsForImproper - warpsForDist12 - warpsForDist13;
-      const int16_t baseIdx    = warpOffset * WARP_SIZE;
-      const int16_t termIdx    = angle13Start + baseIdx + laneId;
+      const int warpOffset = chunkIdx - warpsForTorsion - warpsForImproper - warpsForDist12 - warpsForDist13;
+      const int baseIdx    = warpOffset * WARP_SIZE;
+      const int termIdx    = angle13Start + baseIdx + laneId;
       if (baseIdx + laneId < numAngle13) {
         const int localIdx1 = a13_idx1s[termIdx] - atomStart;
         const int localIdx2 = a13_idx2s[termIdx] - atomStart;
@@ -1205,12 +1205,12 @@ static __device__ __inline__ void molGradETK(const Energy3DForceContribsDevicePt
   const int     atomStart = systemIndices.atomStarts[molIdx];
   const double* molCoords = coords + atomStart * 4;  // ETK uses 4D coordinates
 
-  namespace cg                = cooperative_groups;
-  constexpr int16_t WARP_SIZE = 32;
-  auto              tile32    = cg::tiled_partition<WARP_SIZE>(cg::this_thread_block());
-  const int16_t     laneId    = tile32.thread_rank();
-  const int16_t     warpId    = tile32.meta_group_rank();
-  const int16_t     numWarps  = tile32.meta_group_size();
+  namespace cg            = cooperative_groups;
+  constexpr int WARP_SIZE = 32;
+  auto          tile32    = cg::tiled_partition<WARP_SIZE>(cg::this_thread_block());
+  const int     laneId    = tile32.thread_rank();
+  const int     warpId    = tile32.meta_group_rank();
+  const int     numWarps  = tile32.meta_group_size();
 
   // Get term ranges
   const int torsionStart  = systemIndices.experimentalTorsionTermStarts[molIdx];

--- a/src/minimizer/bfgs_minimize.cu
+++ b/src/minimizer/bfgs_minimize.cu
@@ -517,25 +517,23 @@ void BfgsBatchMinimizer::initialize(const std::vector<int>& atomStartsHost,
 
   activeSystemIndices_.resize(numSystems_);
   allSystemIndices_.resize(numSystems_);
-  std::vector<int> activeSystemIndicesHost(numSystems_);
-  std::iota(activeSystemIndicesHost.begin(), activeSystemIndicesHost.end(), 0);
-  allSystemIndices_.setFromVector(activeSystemIndicesHost);
-  activeSystemIndices_.setFromVector(activeSystemIndicesHost);
+  systemIndicesHost_.resize(numSystems_);
+  std::iota(systemIndicesHost_.begin(), systemIndicesHost_.end(), 0);
+  allSystemIndices_.setFromVector(systemIndicesHost_);
+  activeSystemIndices_.setFromVector(systemIndicesHost_);
 
-  std::vector<int> hessianStartsHost;
-  hessianStartsHost.reserve(numSystems + 1);
-  hessianStartsHost.push_back(0);
-  std::vector<int> blockIdxToSYstemIdxHost;
-  std::vector<int> blockWithinSysHost;
+  hessianStartsHost_.clear();
+  hessianStartsHost_.reserve(numSystems + 1);
+  hessianStartsHost_.push_back(0);
   for (int i = 0; i < numSystems; ++i) {
     const int numAtoms = atomStartsHost[i + 1] - atomStartsHost[i];
     // Note - hessian starts is total term based, not atom based.
     const int numTerms = (dataDim_ * numAtoms) * (dataDim_ * numAtoms);
-    hessianStartsHost.push_back(hessianStartsHost.back() + numTerms);
+    hessianStartsHost_.push_back(hessianStartsHost_.back() + numTerms);
   }
   hessianStarts_.resize(numSystems + 1);
-  hessianStarts_.setFromVector(hessianStartsHost);
-  inverseHessian_.resize(hessianStartsHost.back());
+  hessianStarts_.setFromVector(hessianStartsHost_);
+  inverseHessian_.resize(hessianStartsHost_.back());
   inverseHessian_.zero();
 
   hessDGrad_.resize(atomStartsHost.back() * dataDim_);
@@ -579,6 +577,7 @@ void BfgsBatchMinimizer::initialize(const std::vector<int>& atomStartsHost,
                              stream_);
 
   if (temp_storage_bytes > countTempStorage_.size()) {
+    countTempStorage_.zero();
     countTempStorage_.resize(temp_storage_bytes);
   }
 }

--- a/src/minimizer/bfgs_minimize.cu
+++ b/src/minimizer/bfgs_minimize.cu
@@ -360,7 +360,8 @@ BfgsBatchMinimizer::BfgsBatchMinimizer(const int    dataDim,
                                        DebugLevel   debugLevel,
                                        bool         scaleGrads,
                                        cudaStream_t stream,
-                                       BfgsBackend  backend) {
+                                       BfgsBackend  backend)
+    : countFinished_(0, stream) {
   debugLevel_ = debugLevel;
   dataDim_    = dataDim;
   scaleGrads_ = scaleGrads;

--- a/src/minimizer/bfgs_minimize.h
+++ b/src/minimizer/bfgs_minimize.h
@@ -222,6 +222,10 @@ struct BfgsBatchMinimizer {
   PinnedHostVector<int16_t> convergenceHost_;  // Changed to int16_t to match statuses_
   PinnedHostVector<double*> scratchBufferPointersHost_;
 
+  // Persistent host vectors for async copies (to avoid stack allocation issues)
+  std::vector<int> systemIndicesHost_;
+  std::vector<int> hessianStartsHost_;
+
   cudaStream_t stream_ = nullptr;
 };
 

--- a/src/minimizer/bfgs_minimize_permol_kernels.cu
+++ b/src/minimizer/bfgs_minimize_permol_kernels.cu
@@ -562,9 +562,6 @@ __global__ void bfgsMinimizeKernel(const int               numIters,
                         stride);
   }
   __syncthreads();
-  if (tid == 0) {
-    // printf("Initial grad[0]=%f, grad[%d]=%f\n", localGrad[0], numTerms-1, localGrad[numTerms-1]);
-  }
 
   // Scale gradients
   if (scaleGrads) {

--- a/src/utils/device_vector.h
+++ b/src/utils/device_vector.h
@@ -71,7 +71,11 @@ template <typename T> class AsyncDeviceVector {
   void         setStream(cudaStream_t stream) noexcept { stream_ = stream; }
   cudaStream_t stream() const noexcept { return stream_; }
 
-  void zero() { cudaCheckError(cudaMemsetAsync(data_, 0, size_ * sizeof(T), stream_)); }
+  void zero() {
+    if (size_ > 0) {
+      cudaCheckError(cudaMemsetAsync(data_, 0, size_ * sizeof(T), stream_));
+    }
+  }
 
   //! Returns pointer to an element within the array.
   T* at(size_t index) const {


### PR DESCRIPTION
The main problem fixed here is the use of int16 indices was overflowing on larger batches. Some of these are safe to downcast because they use internal indexing to a molecule, but some are globally indexed. Removed all of them to avoid sharp edges.

Fixed several less likely issues where a memcpy H2D could have the host go out of scope and get destructed before the memcpy was finished. 

Fixed a possible invalid API call if DeviceVector zero() was called on an empty array