### PR TITLE
Use shared memory positions in per molecule small kernels

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,7 @@ target_include_directories(etkdg_stages PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(etkdg etkdg.cpp)
 target_link_libraries(
   etkdg
+        PUBLIC bfgs
   PRIVATE ${RDKit_LIBS}
           conformer_pruning
           device_vector

--- a/src/forcefields/dist_geom_kernels_device.cuh
+++ b/src/forcefields/dist_geom_kernels_device.cuh
@@ -833,15 +833,14 @@ static __device__ __forceinline__ void angleConstraintGrad(const double* pos,
 
 static __device__ __inline__ double molEnergyDG(const EnergyForceContribsDevicePtr& terms,
                                                 const BatchedIndicesDevicePtr&      systemIndices,
-                                                const double*                       coords,
+                                                const double*                       molCoords,
                                                 const int                           molIdx,
                                                 const int                           dimension,
                                                 const double                        chiralWeight,
                                                 const double                        fourthDimWeight,
                                                 const int                           tid,
                                                 const int                           stride) {
-  const int     atomStart = systemIndices.atomStarts[molIdx];
-  const double* molCoords = coords + atomStart * dimension;
+  const int atomStart = systemIndices.atomStarts[molIdx];
 
   double energy = 0.0;
 
@@ -931,17 +930,15 @@ static __device__ __inline__ double molEnergyDG(const EnergyForceContribsDeviceP
 // Consolidated per-molecule gradient calculation
 static __device__ __inline__ void molGradDG(const EnergyForceContribsDevicePtr& terms,
                                             const BatchedIndicesDevicePtr&      systemIndices,
-                                            const double*                       coords,
-                                            double*                             grad,
+                                            const double*                       molCoords,
+                                            double*                             molGrad,
                                             const int                           molIdx,
                                             const int                           dimension,
                                             const double                        chiralWeight,
                                             const double                        fourthDimWeight,
                                             const int                           tid,
                                             const int                           stride) {
-  const int     atomStart = systemIndices.atomStarts[molIdx];
-  const double* molCoords = coords + atomStart * dimension;
-  double*       molGrad   = grad;  // grad is already offset by caller (see combinedGradKernel)
+  const int atomStart = systemIndices.atomStarts[molIdx];
 
   namespace cg            = cooperative_groups;
   constexpr int WARP_SIZE = 32;
@@ -1028,12 +1025,11 @@ static __device__ __inline__ void molGradDG(const EnergyForceContribsDevicePtr& 
 
 static __device__ __inline__ double molEnergyETK(const Energy3DForceContribsDevicePtr& terms,
                                                  const BatchedIndices3DDevicePtr&      systemIndices,
-                                                 const double*                         coords,
+                                                 const double*                         molCoords,
                                                  const int                             molIdx,
                                                  const int                             tid,
                                                  const int                             stride) {
-  const int     atomStart = systemIndices.atomStarts[molIdx];
-  const double* molCoords = coords + atomStart * 4;  // ETK uses 4D coordinates
+  const int atomStart = systemIndices.atomStarts[molIdx];
 
   double energy = 0.0;
 
@@ -1198,13 +1194,12 @@ static __device__ __inline__ double molEnergyETK(const Energy3DForceContribsDevi
 
 static __device__ __inline__ void molGradETK(const Energy3DForceContribsDevicePtr& terms,
                                              const BatchedIndices3DDevicePtr&      systemIndices,
-                                             const double*                         coords,
+                                             const double*                         molCoords,
                                              double*                               grad,
                                              const int                             molIdx,
                                              const int                             tid,
                                              const int                             stride) {
-  const int     atomStart = systemIndices.atomStarts[molIdx];
-  const double* molCoords = coords + atomStart * 4;  // ETK uses 4D coordinates
+  const int atomStart = systemIndices.atomStarts[molIdx];
 
   namespace cg            = cooperative_groups;
   constexpr int WARP_SIZE = 32;

--- a/src/forcefields/mmff_kernels_device.cuh
+++ b/src/forcefields/mmff_kernels_device.cuh
@@ -663,12 +663,11 @@ namespace MMFF {
 
 static __device__ __inline__ double molEnergy(const EnergyForceContribsDevicePtr& terms,
                                               const BatchedIndicesDevicePtr&      systemIndices,
-                                              const double*                       coords,
+                                              const double*                       molCoords,
                                               const int                           molIdx,
                                               const int                           tid,
                                               const int                           stride) {
-  const int     atomStart = systemIndices.atomStarts[molIdx];
-  const double* molCoords = coords + atomStart * 3;
+  const int atomStart = systemIndices.atomStarts[molIdx];
 
   double energy = 0.0;
 
@@ -765,13 +764,12 @@ static __device__ __inline__ double molEnergy(const EnergyForceContribsDevicePtr
 
 static __device__ __inline__ void molGrad(const EnergyForceContribsDevicePtr& terms,
                                           const BatchedIndicesDevicePtr&      systemIndices,
-                                          const double*                       coords,
+                                          const double*                       molCoords,
                                           double*                             grad,
                                           const int                           molIdx,
                                           const int                           tid,
                                           const int                           stride) {
-  const int     atomStart = systemIndices.atomStarts[molIdx];
-  const double* molCoords = coords + atomStart * 3;
+  const int atomStart = systemIndices.atomStarts[molIdx];
 
   const auto& [idx1s, idx2s, r0s, kbs] = terms.bondTerms;
   const int bondStart                  = systemIndices.bondTermStarts[molIdx];

--- a/src/minimizer/bfgs_minimize_permol_kernels.cu
+++ b/src/minimizer/bfgs_minimize_permol_kernels.cu
@@ -620,16 +620,16 @@ __global__ void bfgsMinimizeKernel(const int               numIters,
       }
       __syncthreads();
 
-      // Compute energy at perturbed position
+      // Compute energy at perturbed position (use scratchPos which has the perturbed coordinates)
       double lsThreadEnergy;
       if constexpr (FFType == ForceFieldType::MMFF) {
-        lsThreadEnergy = MMFF::molEnergy(*terms, *systemIndices, localPos, molIdx, tid, stride);
+        lsThreadEnergy = MMFF::molEnergy(*terms, *systemIndices, scratchPos, molIdx, tid, stride);
       } else if constexpr (FFType == ForceFieldType::ETK) {
-        lsThreadEnergy = DistGeom::molEnergyETK(*terms, *systemIndices, localPos, molIdx, tid, stride);
+        lsThreadEnergy = DistGeom::molEnergyETK(*terms, *systemIndices, scratchPos, molIdx, tid, stride);
       } else {  // DG
         lsThreadEnergy = DistGeom::molEnergyDG(*terms,
                                                *systemIndices,
-                                               localPos,
+                                               scratchPos,
                                                molIdx,
                                                dataDim,
                                                chiralWeight,

--- a/src/minimizer/bfgs_minimize_permol_kernels.cu
+++ b/src/minimizer/bfgs_minimize_permol_kernels.cu
@@ -518,13 +518,13 @@ __global__ void bfgsMinimizeKernel(const int               numIters,
   // Compute initial energy
   double threadEnergy;
   if constexpr (FFType == ForceFieldType::MMFF) {
-    threadEnergy = MMFF::molEnergy(*terms, *systemIndices, positions, molIdx, tid, stride);
+    threadEnergy = MMFF::molEnergy(*terms, *systemIndices, localPos, molIdx, tid, stride);
   } else if constexpr (FFType == ForceFieldType::ETK) {
-    threadEnergy = DistGeom::molEnergyETK(*terms, *systemIndices, positions, molIdx, tid, stride);
+    threadEnergy = DistGeom::molEnergyETK(*terms, *systemIndices, localPos, molIdx, tid, stride);
   } else {  // DG
     threadEnergy = DistGeom::molEnergyDG(*terms,
                                          *systemIndices,
-                                         positions,
+                                         localPos,
                                          molIdx,
                                          dataDim,
                                          chiralWeight,
@@ -546,13 +546,13 @@ __global__ void bfgsMinimizeKernel(const int               numIters,
   __syncthreads();
 
   if constexpr (FFType == ForceFieldType::MMFF) {
-    MMFF::molGrad(*terms, *systemIndices, positions, localGrad, molIdx, tid, stride);
+    MMFF::molGrad(*terms, *systemIndices, localPos, localGrad, molIdx, tid, stride);
   } else if constexpr (FFType == ForceFieldType::ETK) {
-    DistGeom::molGradETK(*terms, *systemIndices, positions, localGrad, molIdx, tid, stride);
+    DistGeom::molGradETK(*terms, *systemIndices, localPos, localGrad, molIdx, tid, stride);
   } else {  // DG
     DistGeom::molGradDG(*terms,
                         *systemIndices,
-                        positions,
+                        localPos,
                         localGrad,
                         molIdx,
                         dataDim,
@@ -623,13 +623,13 @@ __global__ void bfgsMinimizeKernel(const int               numIters,
       // Compute energy at perturbed position
       double lsThreadEnergy;
       if constexpr (FFType == ForceFieldType::MMFF) {
-        lsThreadEnergy = MMFF::molEnergy(*terms, *systemIndices, positions, molIdx, tid, stride);
+        lsThreadEnergy = MMFF::molEnergy(*terms, *systemIndices, localPos, molIdx, tid, stride);
       } else if constexpr (FFType == ForceFieldType::ETK) {
-        lsThreadEnergy = DistGeom::molEnergyETK(*terms, *systemIndices, positions, molIdx, tid, stride);
+        lsThreadEnergy = DistGeom::molEnergyETK(*terms, *systemIndices, localPos, molIdx, tid, stride);
       } else {  // DG
         lsThreadEnergy = DistGeom::molEnergyDG(*terms,
                                                *systemIndices,
-                                               positions,
+                                               localPos,
                                                molIdx,
                                                dataDim,
                                                chiralWeight,
@@ -681,13 +681,13 @@ __global__ void bfgsMinimizeKernel(const int               numIters,
     __syncthreads();
 
     if constexpr (FFType == ForceFieldType::MMFF) {
-      MMFF::molGrad(*terms, *systemIndices, positions, localGrad, molIdx, tid, stride);
+      MMFF::molGrad(*terms, *systemIndices, localPos, localGrad, molIdx, tid, stride);
     } else if constexpr (FFType == ForceFieldType::ETK) {
-      DistGeom::molGradETK(*terms, *systemIndices, positions, localGrad, molIdx, tid, stride);
+      DistGeom::molGradETK(*terms, *systemIndices, localPos, localGrad, molIdx, tid, stride);
     } else {  // DG
       DistGeom::molGradDG(*terms,
                           *systemIndices,
-                          positions,
+                          localPos,
                           localGrad,
                           molIdx,
                           dataDim,


### PR DESCRIPTION
We'd migrated gradients and other shared buffers but were still using global arrays for positions. 