### PR TITLE
Fix setup.py (on some python versions), and rework cuda targets

### DIFF
--- a/admin/distribute/verify_conda_version_combinations.sh
+++ b/admin/distribute/verify_conda_version_combinations.sh
@@ -2,13 +2,14 @@
 
 set -uo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 <local_conda_endpoint> <pytest_directory>" >&2
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <local_conda_endpoint> <pytest_directory> <log_dir>" >&2
   exit 1
 fi
 
 LOCAL_CONDA_ENDPOINT=$1
 PYTEST_DIR=$2
+LOG_DIR=$3
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 VERIFY_SCRIPT="$SCRIPT_DIR/verify_conda_distributable.sh"
@@ -22,14 +23,13 @@ if [[ ! -x $VERIFY_SCRIPT ]]; then
   fi
 fi
 
-LOG_DIR="$SCRIPT_DIR/logs"
 mkdir -p "$LOG_DIR"
 
 SUMMARY_LOG="$LOG_DIR/summary.log"
 printf 'Verification Summary - %s\n' "$(date)" >"$SUMMARY_LOG"
 
-PYTHON_VERSIONS=("3.11" "3.12" "3.13")
-RDKIT_VERSIONS=("2025.03.1" "2024.09.6")
+PYTHON_VERSIONS=("3.10" "3.11" "3.12" "3.13")
+RDKIT_VERSIONS=("2024.09.6" "2025.03.1" "2025.03.2"  "2025.03.3"  "2025.03.4"  "2025.03.5"  "2025.03.6" "2025.09.1" "2025.09.2" "2025.09.3")
 
 for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"; do
   for RDKIT_VERSION in "${RDKIT_VERSIONS[@]}"; do

--- a/cmake/cuda_targets.cmake
+++ b/cmake/cuda_targets.cmake
@@ -22,12 +22,16 @@ if(NVMOLKIT_CUDA_TARGET_MODE STREQUAL "native")
       "NVMOLKIT_CUDA_TARGET_MODE=native: Using native CUDA architecture for fast local builds"
   )
 elseif(NVMOLKIT_CUDA_TARGET_MODE STREQUAL "full")
-  set(_nvmolkit_cuda_arch_list "70;75-real;80-real;86-real;89-real;90-real")
+  set(_nvmolkit_cuda_arch_list "70-real;75-real;80-real;86-real;90-real;90")
   if(DEFINED CUDAToolkit_VERSION)
     string(REPLACE "." ";" _cuda_version_list "${CUDAToolkit_VERSION}")
     list(GET _cuda_version_list 0 _cuda_major)
     list(GET _cuda_version_list 1 _cuda_minor)
     math(EXPR _cuda_version_num "${_cuda_major} * 100 + ${_cuda_minor}")
+    if(_cuda_major GREATER_EQUAL 13)
+      list(REMOVE_ITEM _nvmolkit_cuda_arch_list "70-real")
+      message(STATUS "CUDA >= 13 detected, removing Volta (70-real) arch")
+    endif()
     if(_cuda_version_num GREATER_EQUAL 1208)
       list(APPEND _nvmolkit_cuda_arch_list "100-real")
       message(
@@ -64,10 +68,10 @@ else() # default
           "  Resetting to 70.")
     endif()
   else()
-    set(CMAKE_CUDA_ARCHITECTURES 70)
+    set(CMAKE_CUDA_ARCHITECTURES 80)
     message(
       STATUS
-        "NVMOLKIT_CUDA_TARGET_MODE=default: No CMAKE_CUDA_ARCHITECTURES set, defaulting to 70"
+        "NVMOLKIT_CUDA_TARGET_MODE=default: No CMAKE_CUDA_ARCHITECTURES set, defaulting to 80"
     )
   endif()
 endif()

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ if __name__ == "__main__":
             "-DNVMOLKIT_BUILD_PYTHON_BINDINGS=ON",
             "-DNVMOLKIT_BUILD_TESTS=OFF",
             "-DNVMOLKIT_BUILD_BENCHMARKS=OFF",
-            f"-DNVMOLKIT_CUDA_TARGET_MODE={os.getenv("NVMOLKIT_CUDA_TARGET_MODE", 'full')}",
-            f"-DCMAKE_BUILD_TYPE={os.getenv("CMAKE_BUILD_TYPE", 'Release')}",
+            f"-DNVMOLKIT_CUDA_TARGET_MODE={os.getenv('NVMOLKIT_CUDA_TARGET_MODE', 'full')}",
+            f"-DCMAKE_BUILD_TYPE={os.getenv('CMAKE_BUILD_TYPE', 'Release')}",
             #"-DBoost_NO_BOOST_CMAKE=TRUE"
         ] + cmake_extra_args,
         packages=["nvmolkit"],


### PR DESCRIPTION
We now target sm70 only if CUDA < 13.

The PTX version stored is now 90. SM 80 works for 86 and 89. Removed 89 since it's less common and not HPC, doesn't need to be all the way optimized. Kept 86 because torch does too.

Embed PTX for 90 now, so that > 90 has a more recent PTX. Set default to 80

Updated verification script for new versions