### PR TITLE
Add Pinned Host pool and device timing utilities

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -32,6 +32,10 @@ add_library(host_vector INTERFACE)
 target_link_libraries(host_vector INTERFACE CUDA::cudart cuda_error_check)
 target_include_directories(host_vector INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(pinned_host_allocator pinned_host_allocator.cpp)
+target_link_libraries(pinned_host_allocator PUBLIC host_vector)
+target_include_directories(pinned_host_allocator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(device device.cpp)
 target_link_libraries(device PRIVATE CUDA::cudart cuda_error_check)
 target_include_directories(device INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -53,3 +57,7 @@ target_include_directories(openmp_helpers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(cub_helpers INTERFACE)
 target_link_libraries(cub_helpers INTERFACE CUDA::cudart)
 target_include_directories(cub_helpers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(device_timings INTERFACE)
+target_link_libraries(device_timings INTERFACE cuda_error_check)
+target_include_directories(device_timings INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/utils/device_timings.cuh
+++ b/src/utils/device_timings.cuh
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NVMOLKIT_DEVICE_TIMINGS_CUH
+#define NVMOLKIT_DEVICE_TIMINGS_CUH
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "cuda_error_check.h"
+
+namespace nvMolKit {
+
+constexpr bool enableDeviceTimings = false;
+
+// ============================================================================
+// Device-side struct (passed to kernels)
+// ============================================================================
+
+struct DeviceTimingsData {
+  static constexpr int kMaxSections = 20;
+  long long int        totals[kMaxSections];
+  long long int        counts[kMaxSections];
+};
+
+// ============================================================================
+// Device Macros
+// ============================================================================
+
+#define DEVICE_TIMING_START(timings_ptr, section, start_var) \
+  do {                                                       \
+    if constexpr (nvMolKit::enableDeviceTimings) {           \
+      if (blockIdx.x == 0 && threadIdx.x == 0) {             \
+        start_var = clock64();                               \
+      }                                                      \
+      __threadfence_block();                                 \
+    }                                                        \
+  } while (0)
+
+#define DEVICE_TIMING_END(timings_ptr, section, start_var)       \
+  do {                                                           \
+    if constexpr (nvMolKit::enableDeviceTimings) {               \
+      if (blockIdx.x == 0 && threadIdx.x == 0) {                 \
+        (timings_ptr)->totals[section] += clock64() - start_var; \
+        (timings_ptr)->counts[section] += 1;                     \
+      }                                                          \
+      __threadfence_block();                                     \
+    }                                                            \
+  } while (0)
+
+// ============================================================================
+// Host RAII Wrapper
+// ============================================================================
+
+/**
+ * @brief RAII wrapper for device-side kernel timing instrumentation.
+ *
+ * Manages device memory for timing data and provides labeled output.
+ * Enable by setting enableDeviceTimings = true.
+ */
+class DeviceTimings {
+ public:
+  DeviceTimings() : labels_(DeviceTimingsData::kMaxSections) {
+    if constexpr (enableDeviceTimings) {
+      cudaCheckError(cudaMalloc(&d_data_, sizeof(DeviceTimingsData)));
+      reset();
+    }
+  }
+
+  ~DeviceTimings() {
+    if constexpr (enableDeviceTimings) {
+      if (d_data_ != nullptr) {
+        cudaCheckErrorNoThrow(cudaFree(d_data_));
+      }
+    }
+  }
+
+  DeviceTimings(const DeviceTimings&)            = delete;
+  DeviceTimings& operator=(const DeviceTimings&) = delete;
+  DeviceTimings(DeviceTimings&&)                 = delete;
+  DeviceTimings& operator=(DeviceTimings&&)      = delete;
+
+  /// Get device pointer to pass to kernels
+  DeviceTimingsData*       data() { return d_data_; }
+  const DeviceTimingsData* data() const { return d_data_; }
+
+  /// Set a label for a section index
+  void setLabel(int section, const std::string& label) {
+    if (section >= 0 && section < DeviceTimingsData::kMaxSections) {
+      labels_[section] = label;
+    }
+  }
+
+  /// Reset all timings to zero
+  void reset() {
+    if constexpr (enableDeviceTimings) {
+      cudaCheckError(cudaMemset(d_data_, 0, sizeof(DeviceTimingsData)));
+    }
+  }
+
+  /// Copy timings from device to host and print
+  void print() const {
+    if constexpr (enableDeviceTimings) {
+      DeviceTimingsData host_data{};
+      cudaCheckError(cudaMemcpy(&host_data, d_data_, sizeof(DeviceTimingsData), cudaMemcpyDeviceToHost));
+
+      printf("Device Timings:\n");
+      for (int i = 0; i < DeviceTimingsData::kMaxSections; ++i) {
+        if (host_data.counts[i] > 0) {
+          const char*   label = labels_[i].empty() ? "(unlabeled)" : labels_[i].c_str();
+          long long int avg   = host_data.totals[i] / host_data.counts[i];
+          printf("  [%2d] %-20s : %12lld cycles, %6lld hits, avg %12lld cycles/hit\n",
+                 i,
+                 label,
+                 host_data.totals[i],
+                 host_data.counts[i],
+                 avg);
+        }
+      }
+    }
+  }
+
+ private:
+  DeviceTimingsData*       d_data_ = nullptr;
+  std::vector<std::string> labels_;
+};
+
+}  // namespace nvMolKit
+
+#endif  // NVMOLKIT_DEVICE_TIMINGS_CUH

--- a/src/utils/device_timings.cuh
+++ b/src/utils/device_timings.cuh
@@ -26,7 +26,12 @@
 
 namespace nvMolKit {
 
-constexpr bool enableDeviceTimings = false;
+#ifndef NVMOLKIT_ENABLE_DEVICE_TIMINGS
+// Set NVMOLKIT_ENABLE_DEVICE_TIMINGS=1 per translation unit to enable timings.
+#define NVMOLKIT_ENABLE_DEVICE_TIMINGS 0
+#endif
+
+constexpr bool enableDeviceTimings = (NVMOLKIT_ENABLE_DEVICE_TIMINGS != 0);
 
 // ============================================================================
 // Device-side struct (passed to kernels)

--- a/src/utils/host_vector.h
+++ b/src/utils/host_vector.h
@@ -19,10 +19,14 @@
 #include <cuda_runtime.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
+#include <memory>
+#include <span>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "cuda_error_check.h"
 
@@ -169,6 +173,23 @@ template <typename T> class PinnedHostVector {
  private:
   size_t size_ = 0;
   T*     data_ = nullptr;
+};
+
+template <typename T> class PinnedHostView {
+ public:
+  PinnedHostView() = default;
+  PinnedHostView(std::span<T> view, std::shared_ptr<std::byte> owner) : view_(view), owner_(std::move(owner)) {}
+
+  T*     data() const noexcept { return view_.data(); }
+  size_t size() const noexcept { return view_.size(); }
+  bool   empty() const noexcept { return view_.empty(); }
+
+  T&       operator[](size_t index) noexcept { return view_[index]; }
+  const T& operator[](size_t index) const noexcept { return view_[index]; }
+
+ private:
+  std::span<T>               view_{};
+  std::shared_ptr<std::byte> owner_{};
 };
 
 }  // namespace nvMolKit

--- a/src/utils/pinned_host_allocator.cpp
+++ b/src/utils/pinned_host_allocator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/utils/pinned_host_allocator.cpp
+++ b/src/utils/pinned_host_allocator.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pinned_host_allocator.h"
+
+#include <stdexcept>
+
+namespace nvMolKit {
+
+namespace {
+constexpr size_t kAlignment = 256;
+
+size_t alignUp(const size_t offset) {
+  return (offset + kAlignment - 1) & ~(kAlignment - 1);
+}
+}  // namespace
+
+PinnedHostAllocator::PinnedHostAllocator(const size_t estimatedBytes) {
+  if (estimatedBytes > 0) {
+    preallocate(estimatedBytes);
+  }
+}
+
+void PinnedHostAllocator::preallocate(const size_t estimatedBytes) {
+  if (preallocated_) {
+    throw std::runtime_error("PinnedHostAllocator preallocate called more than once.");
+  }
+  if (estimatedBytes == 0) {
+    throw std::invalid_argument("PinnedHostAllocator preallocate requires non-zero size.");
+  }
+  bufferBytes_ = estimatedBytes;
+  buffers_.push_back(BufferEntry{std::make_shared<PinnedHostVector<std::byte>>(estimatedBytes), 0});
+  preallocated_ = true;
+}
+
+PinnedHostAllocator::PinnedHostAllocation PinnedHostAllocator::allocateBytes(const size_t bytes) {
+  if (bytes == 0) {
+    throw std::invalid_argument("PinnedHostAllocator allocate requires non-zero size.");
+  }
+  if (!preallocated_) {
+    throw std::runtime_error("PinnedHostAllocator allocate called before preallocate.");
+  }
+  if (bytes > bufferBytes_) {
+    throw std::runtime_error("PinnedHostAllocator allocation exceeds preallocated buffer size.");
+  }
+
+  for (auto& entry : buffers_) {
+    const size_t alignedOffset = alignUp(entry.offset);
+    if (alignedOffset + bytes <= entry.buffer->size()) {
+      entry.offset = alignedOffset + bytes;
+      std::shared_ptr<std::byte> owner(entry.buffer, entry.buffer->data());
+      return {entry.buffer->data() + alignedOffset, bytes, std::move(owner)};
+    }
+  }
+
+  auto buffer = std::make_shared<PinnedHostVector<std::byte>>(bufferBytes_);
+  buffers_.push_back(BufferEntry{buffer, bytes});
+  std::shared_ptr<std::byte> owner(buffer, buffer->data());
+  return {buffer->data(), bytes, std::move(owner)};
+}
+
+}  // namespace nvMolKit

--- a/src/utils/pinned_host_allocator.h
+++ b/src/utils/pinned_host_allocator.h
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NVMOLKIT_PINNED_HOST_ALLOCATOR_H
+#define NVMOLKIT_PINNED_HOST_ALLOCATOR_H
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "host_vector.h"
+
+namespace nvMolKit {
+
+class PinnedHostAllocator {
+ public:
+  PinnedHostAllocator() = default;
+  explicit PinnedHostAllocator(size_t estimatedBytes);
+
+  PinnedHostAllocator(const PinnedHostAllocator&)            = delete;
+  PinnedHostAllocator& operator=(const PinnedHostAllocator&) = delete;
+  PinnedHostAllocator(PinnedHostAllocator&&) noexcept        = default;
+  PinnedHostAllocator& operator=(PinnedHostAllocator&&) noexcept = default;
+
+  void preallocate(size_t estimatedBytes);
+
+  template <typename T>
+  PinnedHostView<T> allocate(size_t count) {
+    if (count == 0) {
+      throw std::invalid_argument("PinnedHostAllocator allocate requires non-zero size.");
+    }
+    const size_t bytes = count * sizeof(T);
+    PinnedHostAllocation alloc = allocateBytes(bytes);
+    return PinnedHostView<T>(std::span<T>(reinterpret_cast<T*>(alloc.data), count), std::move(alloc.owner));
+  }
+
+ private:
+  struct PinnedHostAllocation {
+    std::byte*                data = nullptr;
+    size_t                    bytes = 0;
+    std::shared_ptr<std::byte> owner;
+  };
+
+  struct BufferEntry {
+    std::shared_ptr<PinnedHostVector<std::byte>> buffer;
+    size_t                                       offset = 0;
+  };
+
+  PinnedHostAllocation allocateBytes(size_t bytes);
+
+  std::vector<BufferEntry> buffers_;
+  size_t                   bufferBytes_ = 0;
+  bool                     preallocated_ = false;
+};
+
+}  // namespace nvMolKit
+
+#endif  // NVMOLKIT_PINNED_HOST_ALLOCATOR_H

--- a/src/utils/pinned_host_allocator.h
+++ b/src/utils/pinned_host_allocator.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,27 +30,26 @@ class PinnedHostAllocator {
   PinnedHostAllocator() = default;
   explicit PinnedHostAllocator(size_t estimatedBytes);
 
-  PinnedHostAllocator(const PinnedHostAllocator&)            = delete;
-  PinnedHostAllocator& operator=(const PinnedHostAllocator&) = delete;
-  PinnedHostAllocator(PinnedHostAllocator&&) noexcept        = default;
+  PinnedHostAllocator(const PinnedHostAllocator&)                = delete;
+  PinnedHostAllocator& operator=(const PinnedHostAllocator&)     = delete;
+  PinnedHostAllocator(PinnedHostAllocator&&) noexcept            = default;
   PinnedHostAllocator& operator=(PinnedHostAllocator&&) noexcept = default;
 
   void preallocate(size_t estimatedBytes);
 
-  template <typename T>
-  PinnedHostView<T> allocate(size_t count) {
+  template <typename T> PinnedHostView<T> allocate(size_t count) {
     if (count == 0) {
       throw std::invalid_argument("PinnedHostAllocator allocate requires non-zero size.");
     }
-    const size_t bytes = count * sizeof(T);
+    const size_t         bytes = count * sizeof(T);
     PinnedHostAllocation alloc = allocateBytes(bytes);
     return PinnedHostView<T>(std::span<T>(reinterpret_cast<T*>(alloc.data), count), std::move(alloc.owner));
   }
 
  private:
   struct PinnedHostAllocation {
-    std::byte*                data = nullptr;
-    size_t                    bytes = 0;
+    std::byte*                 data  = nullptr;
+    size_t                     bytes = 0;
     std::shared_ptr<std::byte> owner;
   };
 
@@ -62,7 +61,7 @@ class PinnedHostAllocator {
   PinnedHostAllocation allocateBytes(size_t bytes);
 
   std::vector<BufferEntry> buffers_;
-  size_t                   bufferBytes_ = 0;
+  size_t                   bufferBytes_  = 0;
   bool                     preallocated_ = false;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -176,6 +176,9 @@ target_link_libraries(test_conformer_checkers PRIVATE ${RDKit_LIBS}
 add_executable(test_host_vector test_host_vector.cu)
 target_link_libraries(test_host_vector PRIVATE host_vector device_vector)
 
+add_executable(test_pinned_host_allocator test_pinned_host_allocator.cpp)
+target_link_libraries(test_pinned_host_allocator PRIVATE pinned_host_allocator)
+
 add_executable(test_etkdg_result_tracker test_etkdg_result_tracker.cpp)
 target_link_libraries(test_etkdg_result_tracker PRIVATE etkdg_impl)
 
@@ -212,6 +215,7 @@ set(TEST_LIST
     test_molecules
     test_mmff
     test_distgeom
+    test_pinned_host_allocator
     test_triangle_smooth
     test_morgan_fingerprint
     test_morgan_fingerprint_ref

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,11 @@ target_link_libraries(test_cuda_error_check PRIVATE cuda_error_check)
 add_executable(test_device test_device.cpp)
 target_link_libraries(test_device PRIVATE device cuda_error_check CUDA::cudart)
 
+add_executable(test_device_timings test_device_timings.cu)
+target_link_libraries(test_device_timings PRIVATE device_timings)
+set_source_files_properties(
+  test_device_timings.cu PROPERTIES COMPILE_DEFINITIONS NVMOLKIT_ENABLE_DEVICE_TIMINGS=1)
+
 add_executable(test_device_vector test_device_vector.cpp)
 target_link_libraries(test_device_vector PRIVATE device_vector cuda_error_check
                                                  CUDA::cudart)
@@ -192,6 +197,7 @@ set(TEST_LIST
     test_coordgen
     test_cuda_error_check
     test_device
+    test_device_timings
     test_device_vector
     test_distgeom_kernels
     test_etkdg

--- a/tests/test_device_timings.cu
+++ b/tests/test_device_timings.cu
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "cuda_error_check.h"
+#include "device_timings.cuh"
+
+using namespace nvMolKit;
+
+namespace {
+
+__device__ __forceinline__ void spinCycles(long long cycles) {
+  const long long start = clock64();
+  while (clock64() - start < cycles) {
+  }
+}
+
+__global__ void timingKernel(DeviceTimingsData* timings, long long short_cycles, long long long_cycles) {
+  unsigned long long start = 0;
+  DEVICE_TIMING_START(timings, 0, start);
+  spinCycles(short_cycles);
+  DEVICE_TIMING_END(timings, 0, start);
+
+  DEVICE_TIMING_START(timings, 1, start);
+  spinCycles(long_cycles);
+  DEVICE_TIMING_END(timings, 1, start);
+}
+
+}  // namespace
+
+TEST(DeviceTimings, RecordsSleepDurations) {
+  int device_count = 0;
+  cudaCheckError(cudaGetDeviceCount(&device_count));
+  if (device_count == 0) {
+    GTEST_SKIP();
+  }
+
+  if (!enableDeviceTimings) {
+    GTEST_SKIP();
+  }
+
+  const long long short_cycles = 5'000'000LL;
+  const long long long_cycles  = 10'000'000LL;
+
+  DeviceTimings timings;
+  ASSERT_NE(timings.data(), nullptr);
+  timings.reset();
+
+  timingKernel<<<1, 1>>>(timings.data(), short_cycles, long_cycles);
+  cudaCheckError(cudaGetLastError());
+  cudaCheckError(cudaDeviceSynchronize());
+
+  DeviceTimingsData host_data{};
+  cudaCheckError(cudaMemcpy(&host_data, timings.data(), sizeof(DeviceTimingsData), cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(host_data.counts[0], 1);
+  EXPECT_EQ(host_data.counts[1], 1);
+
+  EXPECT_GE(host_data.totals[0], short_cycles * 9 / 10);
+  EXPECT_LE(host_data.totals[0], short_cycles * 11 / 10);
+
+  EXPECT_GE(host_data.totals[1], long_cycles * 9 / 10);
+  EXPECT_LE(host_data.totals[1], long_cycles * 11 / 10);
+}

--- a/tests/test_pinned_host_allocator.cpp
+++ b/tests/test_pinned_host_allocator.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+
+#include "pinned_host_allocator.h"
+
+using namespace nvMolKit;
+
+namespace {
+constexpr size_t KB = 1024;
+constexpr size_t MB = 1024 * KB;
+}  // namespace
+
+TEST(PinnedHostAllocator, PreallocateZeroThrows) {
+  PinnedHostAllocator allocator;
+  EXPECT_THROW(allocator.preallocate(0), std::invalid_argument);
+}
+
+TEST(PinnedHostAllocator, PreallocateTwiceThrows) {
+  PinnedHostAllocator allocator;
+  allocator.preallocate(64 * KB);
+  EXPECT_THROW(allocator.preallocate(64 * KB), std::runtime_error);
+}
+
+TEST(PinnedHostAllocator, AllocateZeroThrows) {
+  PinnedHostAllocator allocator(64 * KB);
+  EXPECT_THROW(allocator.allocate<int>(0), std::invalid_argument);
+}
+
+TEST(PinnedHostAllocator, AllocateBeforePreallocateThrows) {
+  PinnedHostAllocator allocator;
+  EXPECT_THROW(allocator.allocate<int>(1), std::runtime_error);
+}
+
+TEST(PinnedHostAllocator, AllocateTooLargeThrows) {
+  PinnedHostAllocator allocator(64 * KB);
+  EXPECT_THROW(allocator.allocate<std::byte>(128 * KB), std::runtime_error);
+}
+
+TEST(PinnedHostAllocator, AllocationAlignment) {
+  constexpr size_t kAlignment = 256;
+
+  PinnedHostAllocator allocator(1 * MB);
+  auto                viewA = allocator.allocate<int>(1);
+  auto                viewB = allocator.allocate<int>(7);
+
+  EXPECT_NE(viewA.data(), nullptr);
+  EXPECT_NE(viewB.data(), nullptr);
+  EXPECT_EQ(reinterpret_cast<std::uintptr_t>(viewA.data()) % kAlignment, 0u);
+  EXPECT_EQ(reinterpret_cast<std::uintptr_t>(viewB.data()) % kAlignment, 0u);
+}
+
+TEST(PinnedHostAllocator, AllocationNoOverlap) {
+  PinnedHostAllocator allocator(1 * MB);
+  auto                viewA = allocator.allocate<int>(16 * KB);
+  auto                viewB = allocator.allocate<int>(16 * KB);
+
+  ASSERT_NE(viewA.data(), nullptr);
+  ASSERT_NE(viewB.data(), nullptr);
+  EXPECT_NE(viewA.data(), viewB.data());
+
+  for (size_t i = 0; i < viewA.size(); ++i) {
+    viewA[i] = 11;
+  }
+  for (size_t i = 0; i < viewB.size(); ++i) {
+    viewB[i] = 22;
+  }
+  for (size_t i = 0; i < viewA.size(); ++i) {
+    EXPECT_EQ(viewA[i], 11);
+  }
+  for (size_t i = 0; i < viewB.size(); ++i) {
+    EXPECT_EQ(viewB[i], 22);
+  }
+}
+
+TEST(PinnedHostAllocator, AllocationsExceedingFirstChunkTriggerNewBlock) {
+  constexpr size_t kPreallocBytes = 10 * MB;
+  constexpr size_t kAlignment     = 256;
+  constexpr size_t kAllocBytes    = 6 * MB;
+
+  PinnedHostAllocator allocator(kPreallocBytes);
+
+  // First allocation: 6 MB
+  auto viewA = allocator.allocate<std::byte>(kAllocBytes);
+  EXPECT_NE(viewA.data(), nullptr);
+  EXPECT_EQ(reinterpret_cast<std::uintptr_t>(viewA.data()) % kAlignment, 0u);
+
+  // Second allocation: 6 MB, would need offset ~6MB + 6MB = 12MB > 10MB
+  // This must trigger a new block allocation
+  auto viewB = allocator.allocate<std::byte>(kAllocBytes);
+  EXPECT_NE(viewB.data(), nullptr);
+  EXPECT_EQ(reinterpret_cast<std::uintptr_t>(viewB.data()) % kAlignment, 0u);
+
+  // Views should not overlap (different blocks in this case)
+  const auto ptrA = reinterpret_cast<std::uintptr_t>(viewA.data());
+  const auto ptrB = reinterpret_cast<std::uintptr_t>(viewB.data());
+  EXPECT_TRUE(ptrA + viewA.size() <= ptrB || ptrB + viewB.size() <= ptrA);
+
+  // Both views should be writable
+  std::memset(viewA.data(), 0xAA, viewA.size());
+  std::memset(viewB.data(), 0xBB, viewB.size());
+  EXPECT_EQ(static_cast<unsigned char>(viewA[0]), 0xAAu);
+  EXPECT_EQ(static_cast<unsigned char>(viewB[0]), 0xBBu);
+}
+
+TEST(PinnedHostView, RetainsOwnership) {
+  PinnedHostView<int> view;
+  {
+    PinnedHostAllocator allocator(1 * MB);
+    view = allocator.allocate<int>(8 * KB);
+    for (size_t i = 0; i < view.size(); ++i) {
+      view[i] = static_cast<int>(i + 5);
+    }
+  }
+
+  EXPECT_EQ(view.size(), 8u * KB);
+  EXPECT_NE(view.data(), nullptr);
+  for (size_t i = 0; i < view.size(); ++i) {
+    EXPECT_EQ(view[i], static_cast<int>(i + 5));
+  }
+}


### PR DESCRIPTION
Pinned Host allocator is used to avoid repeated calls to cudaMallocHost and cudaFreeHost where possible, while allowing flexibility to reallocate if estimates are off.

Device timings are just a dev utility which will be included in some of the kernels. Gets fine-grained breakdowns of CUDA kernel timings that ncu doesn't always give