### PR TITLE
Add thread safe queue

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -61,3 +61,6 @@ target_include_directories(cub_helpers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(device_timings INTERFACE)
 target_link_libraries(device_timings INTERFACE cuda_error_check)
 target_include_directories(device_timings INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(thread_safe_queue INTERFACE)
+target_include_directories(thread_safe_queue INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/utils/thread_safe_queue.h
+++ b/src/utils/thread_safe_queue.h
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NVMOLKIT_THREAD_SAFE_QUEUE_H
+#define NVMOLKIT_THREAD_SAFE_QUEUE_H
+
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <queue>
+
+namespace nvMolKit {
+
+/**
+ * @brief A thread-safe queue supporting multiple producers and consumers.
+ *
+ * Provides blocking and non-blocking operations with graceful shutdown semantics.
+ * Can be used for work queues (items flow through once) or resource pools
+ * (items cycle back via push after pop).
+ *
+ * @tparam T The type of elements stored in the queue. Must be movable.
+ */
+template <typename T> class ThreadSafeQueue {
+ public:
+  ThreadSafeQueue() = default;
+
+  ThreadSafeQueue(const ThreadSafeQueue&)            = delete;
+  ThreadSafeQueue& operator=(const ThreadSafeQueue&) = delete;
+  ThreadSafeQueue(ThreadSafeQueue&&)                 = delete;
+  ThreadSafeQueue& operator=(ThreadSafeQueue&&)      = delete;
+
+  /**
+   * @brief Push an item onto the queue.
+   *
+   * Thread-safe. Notifies one waiting consumer.
+   * If the queue is closed, the item is silently dropped.
+   *
+   * @param item The item to push (moved into the queue)
+   */
+  void push(T item) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (closed_) {
+        return;
+      }
+      queue_.push(std::move(item));
+    }
+    cv_.notify_one();
+  }
+
+  /**
+   * @brief Push multiple items onto the queue.
+   *
+   * Thread-safe. Notifies all waiting consumers.
+   * If the queue is closed, items are silently dropped.
+   *
+   * @tparam Container A container type with begin()/end() iterators
+   * @param items The items to push (each is moved into the queue)
+   */
+  template <typename Container> void pushBatch(Container&& items) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (closed_) {
+        return;
+      }
+      for (auto& item : items) {
+        queue_.push(std::move(item));
+      }
+    }
+    cv_.notify_all();
+  }
+
+  /**
+   * @brief Pop an item from the queue, blocking if empty.
+   *
+   * Blocks until an item is available or the queue is closed.
+   *
+   * @return The popped item, or std::nullopt if the queue is closed and empty
+   */
+  std::optional<T> pop() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait(lock, [this] { return closed_ || !queue_.empty(); });
+    if (queue_.empty()) {
+      return std::nullopt;
+    }
+    T item = std::move(queue_.front());
+    queue_.pop();
+    return item;
+  }
+
+  /**
+   * @brief Try to pop an item without blocking.
+   *
+   * @return The popped item, or std::nullopt if the queue is empty
+   */
+  std::optional<T> tryPop() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (queue_.empty()) {
+      return std::nullopt;
+    }
+    T item = std::move(queue_.front());
+    queue_.pop();
+    return item;
+  }
+
+  /**
+   * @brief Close the queue, signaling consumers to exit.
+   *
+   * After closing:
+   * - push() and pushBatch() silently drop items
+   * - Blocked pop() calls return std::nullopt once queue is empty
+   * - New pop() calls return remaining items, then std::nullopt
+   */
+  void close() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      closed_ = true;
+    }
+    cv_.notify_all();
+  }
+
+  /**
+   * @brief Get the current number of items in the queue.
+   *
+   * Note: The returned value may be stale by the time it's used.
+   */
+  [[nodiscard]] size_t size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return queue_.size();
+  }
+
+  /**
+   * @brief Check if the queue is empty.
+   *
+   * Note: The returned value may be stale by the time it's used.
+   */
+  [[nodiscard]] bool empty() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return queue_.empty();
+  }
+
+ private:
+  std::queue<T>           queue_;
+  mutable std::mutex      mutex_;
+  std::condition_variable cv_;
+  bool                    closed_ = false;
+};
+
+}  // namespace nvMolKit
+
+#endif  // NVMOLKIT_THREAD_SAFE_QUEUE_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,9 @@ target_link_libraries(test_flat_bit_vect_device PRIVATE flatBitVect device
 add_executable(test_work_splitting test_work_splitting.cpp)
 target_link_libraries(test_work_splitting PRIVATE work_splitting)
 
+add_executable(test_thread_safe_queue test_thread_safe_queue.cpp)
+target_link_libraries(test_thread_safe_queue PRIVATE thread_safe_queue)
+
 add_executable(test_openmp_helpers test_openmp_helpers.cpp)
 target_link_libraries(test_openmp_helpers PRIVATE openmp_helpers
                                                   OpenMP::OpenMP_CXX)
@@ -235,6 +238,7 @@ set(TEST_LIST
     test_rdkit_comp
     test_rdkit_bounds_matrix
     test_similarity
+    test_thread_safe_queue
     test_work_splitting)
 
 # Auto populate the NVMOLKIT_TESTDATA environment variable for ctest.

--- a/tests/test_thread_safe_queue.cpp
+++ b/tests/test_thread_safe_queue.cpp
@@ -1,0 +1,342 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "thread_safe_queue.h"
+
+using nvMolKit::ThreadSafeQueue;
+
+// =============================================================================
+// Basic Operations
+// =============================================================================
+
+TEST(ThreadSafeQueueTest, PushPopSingleItem) {
+  ThreadSafeQueue<int> queue;
+  queue.push(42);
+  const auto result = queue.pop();
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, 42);
+}
+
+TEST(ThreadSafeQueueTest, TryPopEmpty) {
+  ThreadSafeQueue<int> queue;
+  const auto           result = queue.tryPop();
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(ThreadSafeQueueTest, TryPopNonEmpty) {
+  ThreadSafeQueue<int> queue;
+  queue.push(42);
+  const auto result = queue.tryPop();
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, 42);
+}
+
+TEST(ThreadSafeQueueTest, FifoOrder) {
+  ThreadSafeQueue<int> queue;
+  queue.push(1);
+  queue.push(2);
+  queue.push(3);
+
+  EXPECT_EQ(*queue.pop(), 1);
+  EXPECT_EQ(*queue.pop(), 2);
+  EXPECT_EQ(*queue.pop(), 3);
+}
+
+TEST(ThreadSafeQueueTest, SizeTracking) {
+  ThreadSafeQueue<int> queue;
+  EXPECT_EQ(queue.size(), 0u);
+  EXPECT_TRUE(queue.empty());
+
+  queue.push(1);
+  EXPECT_EQ(queue.size(), 1u);
+  EXPECT_FALSE(queue.empty());
+
+  queue.push(2);
+  EXPECT_EQ(queue.size(), 2u);
+
+  queue.pop();
+  EXPECT_EQ(queue.size(), 1u);
+
+  queue.pop();
+  EXPECT_EQ(queue.size(), 0u);
+  EXPECT_TRUE(queue.empty());
+}
+
+TEST(ThreadSafeQueueTest, MoveOnlyType) {
+  ThreadSafeQueue<std::unique_ptr<int>> queue;
+  queue.push(std::make_unique<int>(42));
+
+  const auto result = queue.pop();
+  ASSERT_TRUE(result.has_value());
+  ASSERT_NE(*result, nullptr);
+  EXPECT_EQ(**result, 42);
+}
+
+// =============================================================================
+// Close Semantics
+// =============================================================================
+
+TEST(ThreadSafeQueueTest, CloseWithItems) {
+  ThreadSafeQueue<int> queue;
+  queue.push(1);
+  queue.push(2);
+  queue.close();
+
+  EXPECT_EQ(*queue.pop(), 1);
+  EXPECT_EQ(*queue.pop(), 2);
+  EXPECT_FALSE(queue.pop().has_value());
+}
+
+TEST(ThreadSafeQueueTest, PushAfterClose) {
+  ThreadSafeQueue<int> queue;
+  queue.push(1);
+  queue.close();
+  queue.push(2);
+
+  EXPECT_EQ(*queue.pop(), 1);
+  EXPECT_FALSE(queue.pop().has_value());
+}
+
+// =============================================================================
+// Batch Operations
+// =============================================================================
+
+TEST(ThreadSafeQueueTest, PushBatch) {
+  ThreadSafeQueue<int> queue;
+  std::vector<int>     items = {1, 2, 3, 4, 5};
+  queue.pushBatch(items);
+
+  EXPECT_EQ(queue.size(), 5u);
+  for (int i = 1; i <= 5; ++i) {
+    EXPECT_EQ(*queue.pop(), i);
+  }
+}
+
+TEST(ThreadSafeQueueTest, PushBatchMoveOnly) {
+  ThreadSafeQueue<std::unique_ptr<int>> queue;
+  std::vector<std::unique_ptr<int>>     items;
+  items.push_back(std::make_unique<int>(1));
+  items.push_back(std::make_unique<int>(2));
+  queue.pushBatch(std::move(items));
+
+  EXPECT_EQ(queue.size(), 2u);
+  EXPECT_EQ(**queue.pop(), 1);
+  EXPECT_EQ(**queue.pop(), 2);
+}
+
+TEST(ThreadSafeQueueTest, PushBatchAfterClose) {
+  ThreadSafeQueue<int> queue;
+  queue.close();
+  std::vector<int> items = {1, 2, 3};
+  queue.pushBatch(items);
+
+  EXPECT_TRUE(queue.empty());
+}
+
+// =============================================================================
+// Concurrent Operations
+// =============================================================================
+
+TEST(ThreadSafeQueueTest, SingleProducerSingleConsumer) {
+  ThreadSafeQueue<int> queue;
+  const int            numItems = 1000;
+  std::atomic<int>     consumed{0};
+
+  std::thread consumer([&] {
+    for (int i = 0; i < numItems; ++i) {
+      auto val = queue.pop();
+      EXPECT_TRUE(val.has_value());
+      ++consumed;
+    }
+  });
+
+  std::thread producer([&] {
+    for (int i = 0; i < numItems; ++i) {
+      queue.push(i);
+    }
+  });
+
+  producer.join();
+  consumer.join();
+
+  EXPECT_EQ(consumed.load(), numItems);
+  EXPECT_TRUE(queue.empty());
+}
+
+TEST(ThreadSafeQueueTest, MultipleProducersSingleConsumer) {
+  ThreadSafeQueue<int> queue;
+  const int            numProducers     = 4;
+  const int            itemsPerProducer = 250;
+  const int            totalItems       = numProducers * itemsPerProducer;
+  std::atomic<int>     consumed{0};
+
+  std::thread consumer([&] {
+    for (int i = 0; i < totalItems; ++i) {
+      auto val = queue.pop();
+      EXPECT_TRUE(val.has_value());
+      ++consumed;
+    }
+  });
+
+  std::vector<std::thread> producers;
+  for (int p = 0; p < numProducers; ++p) {
+    producers.emplace_back([&, p] {
+      for (int i = 0; i < itemsPerProducer; ++i) {
+        queue.push(p * itemsPerProducer + i);
+      }
+    });
+  }
+
+  for (auto& t : producers) {
+    t.join();
+  }
+  consumer.join();
+
+  EXPECT_EQ(consumed.load(), totalItems);
+  EXPECT_TRUE(queue.empty());
+}
+
+TEST(ThreadSafeQueueTest, SingleProducerMultipleConsumers) {
+  ThreadSafeQueue<int> queue;
+  const int            numConsumers = 4;
+  const int            totalItems   = 1000;
+  std::atomic<int>     consumed{0};
+
+  std::vector<std::thread> consumers;
+  for (int c = 0; c < numConsumers; ++c) {
+    consumers.emplace_back([&] {
+      while (true) {
+        auto val = queue.pop();
+        if (!val.has_value()) {
+          break;
+        }
+        ++consumed;
+      }
+    });
+  }
+
+  std::thread producer([&] {
+    for (int i = 0; i < totalItems; ++i) {
+      queue.push(i);
+    }
+    queue.close();
+  });
+
+  producer.join();
+  for (auto& t : consumers) {
+    t.join();
+  }
+
+  EXPECT_EQ(consumed.load(), totalItems);
+}
+
+TEST(ThreadSafeQueueTest, CloseWhileWaiting) {
+  ThreadSafeQueue<int> queue;
+  std::atomic<bool>    popReturned{false};
+  std::atomic<bool>    gotNullopt{false};
+
+  std::thread consumer([&] {
+    auto val = queue.pop();
+    popReturned.store(true);
+    gotNullopt.store(!val.has_value());
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_FALSE(popReturned.load());
+
+  queue.close();
+  consumer.join();
+
+  EXPECT_TRUE(popReturned.load());
+  EXPECT_TRUE(gotNullopt.load());
+}
+
+// =============================================================================
+// Resource Pool Pattern (items cycle back)
+// =============================================================================
+
+TEST(ThreadSafeQueueTest, ResourcePoolPattern) {
+  ThreadSafeQueue<int*> pool;
+  int                   resources[3] = {1, 2, 3};
+
+  for (int& r : resources) {
+    pool.push(&r);
+  }
+  EXPECT_EQ(pool.size(), 3u);
+
+  auto r1 = pool.pop();
+  auto r2 = pool.pop();
+  EXPECT_EQ(pool.size(), 1u);
+
+  pool.push(*r1);
+  EXPECT_EQ(pool.size(), 2u);
+
+  pool.push(*r2);
+  EXPECT_EQ(pool.size(), 3u);
+
+  auto r3 = pool.pop();
+  auto r4 = pool.pop();
+  auto r5 = pool.pop();
+  EXPECT_TRUE(r3.has_value());
+  EXPECT_TRUE(r4.has_value());
+  EXPECT_TRUE(r5.has_value());
+  EXPECT_TRUE(pool.empty());
+}
+
+TEST(ThreadSafeQueueTest, ResourcePoolConcurrent) {
+  ThreadSafeQueue<int> pool;
+  const int            poolSize      = 4;
+  const int            numIterations = 100;
+
+  for (int i = 0; i < poolSize; ++i) {
+    pool.push(i);
+  }
+
+  std::atomic<int>         acquireCount{0};
+  std::atomic<int>         releaseCount{0};
+  std::vector<std::thread> workers;
+
+  for (int w = 0; w < 8; ++w) {
+    workers.emplace_back([&] {
+      for (int i = 0; i < numIterations; ++i) {
+        auto resource = pool.pop();
+        if (!resource.has_value()) {
+          break;
+        }
+        ++acquireCount;
+        std::this_thread::yield();
+        pool.push(*resource);
+        ++releaseCount;
+      }
+    });
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  pool.close();
+
+  for (auto& t : workers) {
+    t.join();
+  }
+
+  EXPECT_EQ(acquireCount.load(), releaseCount.load());
+}


### PR DESCRIPTION
This will be used for several producer/consumer interfaces, including worker threads receiving from preprocessor threads, and an RDKit fallback path for molecules we can't handle.