### PR TITLE
Remove cudaMemSetAsync calls by fusing with initial kernels.

### DIFF
--- a/src/substruct/recursive_preprocessor.cu
+++ b/src/substruct/recursive_preprocessor.cu
@@ -168,6 +168,8 @@ void RecursivePatternPreprocessor::preprocessMiniBatch(
 
   const int maxPaintPairsPerSubBatch = std::max(miniBatchSize, 1024);
 
+  bool isFirstLabelKernel = true;
+
   for (int currentDepth = 0; currentDepth <= maxDepth; ++currentDepth) {
     ScopedNvtxRange depthRange("Process recursive depth level " + std::to_string(currentDepth));
 
@@ -220,6 +222,12 @@ void RecursivePatternPreprocessor::preprocessMiniBatch(
 
       const uint32_t* recursiveBitsForLabel = (currentDepth > 0) ? miniBatchResults.recursiveMatchBits() : nullptr;
 
+      uint32_t* recursiveBitsToZero      = isFirstLabelKernel ? miniBatchResults.recursiveMatchBits() : nullptr;
+      const int recursiveBitsSizeToZero = isFirstLabelKernel ? (miniBatchSize * miniBatchResults.maxTargetAtoms()) : 0;
+      uint8_t*  overflowFlagsToZero     = isFirstLabelKernel ? miniBatchResults.overflowFlags() : nullptr;
+      const int overflowFlagsSizeToZero = isFirstLabelKernel ? miniBatchSize : 0;
+      isFirstLabelKernel                = false;
+
       launchLabelMatrixPaintKernel(templateConfig,
                                    targetsDevice.view<MoleculeType::Target>(),
                                    leafSubpatterns_.view(),
@@ -233,6 +241,10 @@ void RecursivePatternPreprocessor::preprocessMiniBatch(
                                    firstTargetInMiniBatch,
                                    recursiveBitsForLabel,
                                    miniBatchResults.maxTargetAtoms(),
+                                   recursiveBitsToZero,
+                                   recursiveBitsSizeToZero,
+                                   overflowFlagsToZero,
+                                   overflowFlagsSizeToZero,
                                    stream);
 
       launchSubstructPaintKernel(templateConfig,
@@ -343,6 +355,8 @@ void preprocessRecursiveSmarts(SubstructTemplateConfig           templateConfig,
   const int maxPaintPairsPerSubBatch = std::max(miniBatchSize, 1024);
   processRecursiveRangeSetup.pop();
 
+  bool isFirstLabelKernel = true;
+
   for (int currentDepth = 0; currentDepth <= maxDepth; ++currentDepth) {
     ScopedNvtxRange depthRange("Process recursive depth level " + std::to_string(currentDepth));
 
@@ -400,6 +414,12 @@ void preprocessRecursiveSmarts(SubstructTemplateConfig           templateConfig,
 
       const uint32_t* recursiveBitsForLabel = (currentDepth > 0) ? miniBatchResults.recursiveMatchBits() : nullptr;
 
+      uint32_t* recursiveBitsToZero      = isFirstLabelKernel ? miniBatchResults.recursiveMatchBits() : nullptr;
+      const int recursiveBitsSizeToZero = isFirstLabelKernel ? (miniBatchSize * miniBatchResults.maxTargetAtoms()) : 0;
+      uint8_t*  overflowFlagsToZero     = isFirstLabelKernel ? miniBatchResults.overflowFlags() : nullptr;
+      const int overflowFlagsSizeToZero = isFirstLabelKernel ? miniBatchSize : 0;
+      isFirstLabelKernel                = false;
+
       launchLabelMatrixPaintKernel(templateConfig,
                                    targetsDevice.view<MoleculeType::Target>(),
                                    leafSubpatterns.view(),
@@ -413,6 +433,10 @@ void preprocessRecursiveSmarts(SubstructTemplateConfig           templateConfig,
                                    firstTargetInMiniBatch,
                                    recursiveBitsForLabel,
                                    miniBatchResults.maxTargetAtoms(),
+                                   recursiveBitsToZero,
+                                   recursiveBitsSizeToZero,
+                                   overflowFlagsToZero,
+                                   overflowFlagsSizeToZero,
                                    stream);
 
       launchSubstructPaintKernel(templateConfig,

--- a/src/substruct/recursive_preprocessor.cu
+++ b/src/substruct/recursive_preprocessor.cu
@@ -222,11 +222,14 @@ void RecursivePatternPreprocessor::preprocessMiniBatch(
 
       const uint32_t* recursiveBitsForLabel = (currentDepth > 0) ? miniBatchResults.recursiveMatchBits() : nullptr;
 
-      uint32_t* recursiveBitsToZero      = isFirstLabelKernel ? miniBatchResults.recursiveMatchBits() : nullptr;
-      const int recursiveBitsSizeToZero = isFirstLabelKernel ? (miniBatchSize * miniBatchResults.maxTargetAtoms()) : 0;
-      uint8_t*  overflowFlagsToZero     = isFirstLabelKernel ? miniBatchResults.overflowFlags() : nullptr;
-      const int overflowFlagsSizeToZero = isFirstLabelKernel ? miniBatchSize : 0;
-      isFirstLabelKernel                = false;
+      std::optional<ZeroBuffersSpec> zeroBuffers;
+      if (isFirstLabelKernel) {
+        zeroBuffers = ZeroBuffersSpec{miniBatchResults.recursiveMatchBits(),
+                                      miniBatchSize * miniBatchResults.maxTargetAtoms(),
+                                      miniBatchResults.overflowFlags(),
+                                      miniBatchSize};
+      }
+      isFirstLabelKernel = false;
 
       launchLabelMatrixPaintKernel(templateConfig,
                                    targetsDevice.view<MoleculeType::Target>(),
@@ -241,10 +244,7 @@ void RecursivePatternPreprocessor::preprocessMiniBatch(
                                    firstTargetInMiniBatch,
                                    recursiveBitsForLabel,
                                    miniBatchResults.maxTargetAtoms(),
-                                   recursiveBitsToZero,
-                                   recursiveBitsSizeToZero,
-                                   overflowFlagsToZero,
-                                   overflowFlagsSizeToZero,
+                                   zeroBuffers,
                                    stream);
 
       launchSubstructPaintKernel(templateConfig,
@@ -414,11 +414,14 @@ void preprocessRecursiveSmarts(SubstructTemplateConfig           templateConfig,
 
       const uint32_t* recursiveBitsForLabel = (currentDepth > 0) ? miniBatchResults.recursiveMatchBits() : nullptr;
 
-      uint32_t* recursiveBitsToZero      = isFirstLabelKernel ? miniBatchResults.recursiveMatchBits() : nullptr;
-      const int recursiveBitsSizeToZero = isFirstLabelKernel ? (miniBatchSize * miniBatchResults.maxTargetAtoms()) : 0;
-      uint8_t*  overflowFlagsToZero     = isFirstLabelKernel ? miniBatchResults.overflowFlags() : nullptr;
-      const int overflowFlagsSizeToZero = isFirstLabelKernel ? miniBatchSize : 0;
-      isFirstLabelKernel                = false;
+      std::optional<ZeroBuffersSpec> zeroBuffers;
+      if (isFirstLabelKernel) {
+        zeroBuffers = ZeroBuffersSpec{miniBatchResults.recursiveMatchBits(),
+                                      miniBatchSize * miniBatchResults.maxTargetAtoms(),
+                                      miniBatchResults.overflowFlags(),
+                                      miniBatchSize};
+      }
+      isFirstLabelKernel = false;
 
       launchLabelMatrixPaintKernel(templateConfig,
                                    targetsDevice.view<MoleculeType::Target>(),
@@ -433,10 +436,7 @@ void preprocessRecursiveSmarts(SubstructTemplateConfig           templateConfig,
                                    firstTargetInMiniBatch,
                                    recursiveBitsForLabel,
                                    miniBatchResults.maxTargetAtoms(),
-                                   recursiveBitsToZero,
-                                   recursiveBitsSizeToZero,
-                                   overflowFlagsToZero,
-                                   overflowFlagsSizeToZero,
+                                   zeroBuffers,
                                    stream);
 
       launchSubstructPaintKernel(templateConfig,

--- a/src/substruct/substruct_kernels.h
+++ b/src/substruct/substruct_kernels.h
@@ -18,6 +18,8 @@
 
 #include <cuda_runtime.h>
 
+#include <optional>
+
 #include "molecules.h"
 #include "substruct_types.h"
 
@@ -80,30 +82,24 @@ void launchLabelMatrixKernel(SubstructTemplateConfig   config,
  * @param firstTargetIdx First target index for block offset calculation
  * @param recursiveMatchBits Per-pair recursive bits (for nested patterns)
  * @param maxTargetAtoms Stride for recursiveMatchBits indexing
- * @param recursiveBitsToZero Buffer to zero (may be same as recursiveMatchBits), or nullptr
- * @param recursiveBitsSizeToZero Number of uint32_t elements to zero, or 0 to skip
- * @param overflowFlagsToZero Overflow flags buffer to zero, or nullptr
- * @param overflowFlagsSizeToZero Number of uint8_t elements to zero, or 0 to skip
+ * @param zeroBuffers Buffers to zero on first launch (nullopt to skip)
  * @param stream CUDA stream
  */
-void launchLabelMatrixPaintKernel(SubstructTemplateConfig    config,
-                                  TargetMoleculesDeviceView  targets,
-                                  QueryMoleculesDeviceView   patterns,
-                                  const BatchedPatternEntry* patternEntries,
-                                  int                        numPatterns,
-                                  int                        numBlocks,
-                                  int                        numQueries,
-                                  int                        miniBatchPairOffset,
-                                  int                        miniBatchSize,
-                                  uint32_t*                  labelMatrixBuffer,
-                                  int                        firstTargetIdx,
-                                  const uint32_t*            recursiveMatchBits,
-                                  int                        maxTargetAtoms,
-                                  uint32_t*                  recursiveBitsToZero,
-                                  int                        recursiveBitsSizeToZero,
-                                  uint8_t*                   overflowFlagsToZero,
-                                  int                        overflowFlagsSizeToZero,
-                                  cudaStream_t               stream);
+void launchLabelMatrixPaintKernel(SubstructTemplateConfig        config,
+                                  TargetMoleculesDeviceView      targets,
+                                  QueryMoleculesDeviceView       patterns,
+                                  const BatchedPatternEntry*     patternEntries,
+                                  int                            numPatterns,
+                                  int                            numBlocks,
+                                  int                            numQueries,
+                                  int                            miniBatchPairOffset,
+                                  int                            miniBatchSize,
+                                  uint32_t*                      labelMatrixBuffer,
+                                  int                            firstTargetIdx,
+                                  const uint32_t*                recursiveMatchBits,
+                                  int                            maxTargetAtoms,
+                                  std::optional<ZeroBuffersSpec> zeroBuffers,
+                                  cudaStream_t                   stream);
 
 /**
  * @brief Launch substructure matching kernel with template configuration dispatch.

--- a/src/substruct/substruct_kernels.h
+++ b/src/substruct/substruct_kernels.h
@@ -80,6 +80,10 @@ void launchLabelMatrixKernel(SubstructTemplateConfig   config,
  * @param firstTargetIdx First target index for block offset calculation
  * @param recursiveMatchBits Per-pair recursive bits (for nested patterns)
  * @param maxTargetAtoms Stride for recursiveMatchBits indexing
+ * @param recursiveBitsToZero Buffer to zero (may be same as recursiveMatchBits), or nullptr
+ * @param recursiveBitsSizeToZero Number of uint32_t elements to zero, or 0 to skip
+ * @param overflowFlagsToZero Overflow flags buffer to zero, or nullptr
+ * @param overflowFlagsSizeToZero Number of uint8_t elements to zero, or 0 to skip
  * @param stream CUDA stream
  */
 void launchLabelMatrixPaintKernel(SubstructTemplateConfig    config,
@@ -95,6 +99,10 @@ void launchLabelMatrixPaintKernel(SubstructTemplateConfig    config,
                                   int                        firstTargetIdx,
                                   const uint32_t*            recursiveMatchBits,
                                   int                        maxTargetAtoms,
+                                  uint32_t*                  recursiveBitsToZero,
+                                  int                        recursiveBitsSizeToZero,
+                                  uint8_t*                   overflowFlagsToZero,
+                                  int                        overflowFlagsSizeToZero,
                                   cudaStream_t               stream);
 
 /**

--- a/src/substruct/substruct_search.cu
+++ b/src/substruct/substruct_search.cu
@@ -190,7 +190,7 @@ void uploadAndLaunchMiniBatch(GpuExecutor&                        executor,
                             executor.plan.numPairsInMiniBatch,
                             ctx.numQueries,
                             executor.deviceResults.labelMatrixBuffer(),
-                            executor.deviceResults.recursiveMatchBits(),
+                            nullptr,
                             executor.deviceResults.maxTargetAtoms(),
                             nullptr,
                             executorStream);

--- a/src/substruct/substruct_search_internal.cpp
+++ b/src/substruct/substruct_search_internal.cpp
@@ -93,7 +93,6 @@ void MiniBatchResultsDevice::allocateMiniBatch(int        miniBatchSize,
   if (recursiveMatchBits_.size() < recursiveBitsSize) {
     recursiveMatchBits_.resize(static_cast<size_t>(recursiveBitsSize * 1.5));
   }
-  recursiveMatchBits_.zero();
 
   const size_t labelMatrixSize = static_cast<size_t>(miniBatchSize) * kLabelMatrixWords;
   if (labelMatrixBuffer_.size() < labelMatrixSize) {
@@ -103,7 +102,6 @@ void MiniBatchResultsDevice::allocateMiniBatch(int        miniBatchSize,
   if (overflowFlags_.size() < static_cast<size_t>(miniBatchSize)) {
     overflowFlags_.resize(static_cast<size_t>(miniBatchSize * 1.5));
   }
-  overflowFlags_.zero();
 }
 
 void MiniBatchResultsDevice::setQueryAtomCounts(const int* queryAtomCounts, size_t count) {

--- a/src/substruct/substruct_types.h
+++ b/src/substruct/substruct_types.h
@@ -25,6 +25,19 @@
 namespace nvMolKit {
 
 /**
+ * @brief Buffers to zero on the first label matrix kernel launch in a mini-batch.
+ *
+ * Passed as an optional parameter to launchLabelMatrixPaintKernel; when absent
+ * (std::nullopt), no zeroing is performed.
+ */
+struct ZeroBuffersSpec {
+  uint32_t* recursiveBits     = nullptr;
+  int       recursiveBitsSize = 0;
+  uint8_t*  overflowFlags     = nullptr;
+  int       overflowFlagsSize = 0;
+};
+
+/**
  * @brief Per-pattern metadata for batched recursive preprocessing kernel.
  *
  * Each entry describes one recursive pattern in the combined batch:


### PR DESCRIPTION
cudamemsetAsync was taking nontrivial CPU time to dispatch, and is part of the bottleneck for tight loops where both preprocessing and compute kernels are fast (such as large query datasets of simple queries). 

This moves the initial resetting into the first called kernel per minibatch and reduces the number of API calls. 