### PR TITLE
Consolidate several memcpyAsync calls

### DIFF
--- a/src/substruct/gpu_executor.cu
+++ b/src/substruct/gpu_executor.cu
@@ -51,7 +51,7 @@ void GpuExecutor::applyMiniBatchPlan(MiniBatchPlan&& plan) {
 // =============================================================================
 
 void ConsolidatedDeviceBuffer::allocate(int maxBatchSize, cudaStream_t stream) {
-  maxBatchSize_ = maxBatchSize;
+  maxBatchSize_           = maxBatchSize;
   const size_t totalBytes = computeConsolidatedBufferBytes(maxBatchSize);
   data_.setStream(stream);
   if (data_.size() < totalBytes) {
@@ -134,12 +134,12 @@ uint8_t* ConsolidatedDeviceBuffer::overflowFlags() const {
   return reinterpret_cast<uint8_t*>(data_.data() + overflowFlagsOffset());
 }
 
-int* ConsolidatedDeviceBuffer::matchGlobalPairIndices(int depth) const {
-  return reinterpret_cast<int*>(data_.data() + matchGlobalPairIndicesOffset(depth));
+const int* ConsolidatedDeviceBuffer::matchGlobalPairIndices(int depth) const {
+  return reinterpret_cast<const int*>(data_.data() + matchGlobalPairIndicesOffset(depth));
 }
 
-int* ConsolidatedDeviceBuffer::matchBatchLocalIndices(int depth) const {
-  return reinterpret_cast<int*>(data_.data() + matchBatchLocalIndicesOffset(depth));
+const int* ConsolidatedDeviceBuffer::matchBatchLocalIndices(int depth) const {
+  return reinterpret_cast<const int*>(data_.data() + matchBatchLocalIndicesOffset(depth));
 }
 
 }  // namespace nvMolKit

--- a/src/substruct/gpu_executor.h
+++ b/src/substruct/gpu_executor.h
@@ -24,11 +24,53 @@
 #include "device_vector.h"
 #include "minibatch_planner.h"
 #include "molecules_device.cuh"
+#include "pinned_buffer_pool.h"
 #include "recursive_preprocessor.h"
 #include "substruct_search_internal.h"
 #include "substruct_types.h"
 
 namespace nvMolKit {
+
+/**
+ * @brief Device-side consolidated buffer mirroring the fixed-width portion of PinnedHostBuffer.
+ *
+ * All fixed-width buffers (based on maxBatchSize) are stored contiguously for single-copy H2D transfers.
+ * Accessors compute offsets using the same layout as the host allocation.
+ */
+class ConsolidatedDeviceBuffer {
+ public:
+  void allocate(int maxBatchSize, cudaStream_t stream);
+  void copyFromHost(const PinnedHostBuffer& host, cudaStream_t stream);
+  void setStream(cudaStream_t stream);
+
+  [[nodiscard]] int* pairIndices() const;
+  [[nodiscard]] int* miniBatchPairMatchStarts() const;
+  [[nodiscard]] int* matchCounts() const;
+  [[nodiscard]] int* reportedCounts() const;
+  [[nodiscard]] uint8_t* overflowFlags() const;
+  [[nodiscard]] int* matchGlobalPairIndices(int depth) const;
+  [[nodiscard]] int* matchBatchLocalIndices(int depth) const;
+
+  [[nodiscard]] int maxBatchSize() const { return maxBatchSize_; }
+
+ private:
+  static constexpr size_t kAlignment = 256;
+
+  [[nodiscard]] size_t alignOffset(size_t offset) const {
+    return (offset + kAlignment - 1) & ~(kAlignment - 1);
+  }
+
+  [[nodiscard]] size_t pairIndicesOffset() const { return 0; }
+  [[nodiscard]] size_t miniBatchPairMatchStartsOffset() const;
+  [[nodiscard]] size_t matchCountsOffset() const;
+  [[nodiscard]] size_t reportedCountsOffset() const;
+  [[nodiscard]] size_t overflowFlagsOffset() const;
+  [[nodiscard]] size_t matchGlobalPairIndicesOffset(int depth) const;
+  [[nodiscard]] size_t matchBatchLocalIndicesOffset(int depth) const;
+
+  AsyncDeviceVector<std::byte> data_;
+  int                          maxBatchSize_ = 0;
+};
 
 /**
  * @brief Owns CUDA resources and device buffers for a worker executor.
@@ -43,17 +85,15 @@ struct GpuExecutor {
   ScopedCudaEvent targetsReadyEvent;
 
   // Recursive pipeline
-  ScopedStreamWithPriority                                       recursiveStream;
-  ScopedStreamWithPriority                                       postRecursionStream;
-  std::array<ScopedCudaEvent, kMaxSmartsNestingDepth>            depthEvents;
-  ScopedCudaEvent                                                recursiveDoneEvent;
-  ScopedCudaEvent                                                postRecursionDoneEvent;
-  std::array<AsyncDeviceVector<int>, kMaxSmartsNestingDepth + 1> matchGlobalPairIndices;
-  std::array<AsyncDeviceVector<int>, kMaxSmartsNestingDepth + 1> matchMiniBatchLocalIndices;
-  RecursiveScratchBuffers                                        recursiveScratch;
-  MiniBatchResultsDevice                                         deviceResults;
-  AsyncDeviceVector<int>                                         pairIndicesDev;
-  MoleculesDevice                                                targetsDevice;
+  ScopedStreamWithPriority                            recursiveStream;
+  ScopedStreamWithPriority                            postRecursionStream;
+  std::array<ScopedCudaEvent, kMaxSmartsNestingDepth> depthEvents;
+  ScopedCudaEvent                                     recursiveDoneEvent;
+  ScopedCudaEvent                                     postRecursionDoneEvent;
+  RecursiveScratchBuffers                             recursiveScratch;
+  MiniBatchResultsDevice                              deviceResults;
+  ConsolidatedDeviceBuffer                            consolidatedBuffer;
+  MoleculesDevice                                     targetsDevice;
 
   int deviceId = 0;  ///< GPU device ID this executor is assigned to
 

--- a/src/substruct/gpu_executor.h
+++ b/src/substruct/gpu_executor.h
@@ -43,22 +43,20 @@ class ConsolidatedDeviceBuffer {
   void copyFromHost(const PinnedHostBuffer& host, cudaStream_t stream);
   void setStream(cudaStream_t stream);
 
-  [[nodiscard]] int* pairIndices() const;
-  [[nodiscard]] int* miniBatchPairMatchStarts() const;
-  [[nodiscard]] int* matchCounts() const;
-  [[nodiscard]] int* reportedCounts() const;
-  [[nodiscard]] uint8_t* overflowFlags() const;
-  [[nodiscard]] int* matchGlobalPairIndices(int depth) const;
-  [[nodiscard]] int* matchBatchLocalIndices(int depth) const;
+  [[nodiscard]] int*       pairIndices() const;
+  [[nodiscard]] int*       miniBatchPairMatchStarts() const;
+  [[nodiscard]] int*       matchCounts() const;
+  [[nodiscard]] int*       reportedCounts() const;
+  [[nodiscard]] uint8_t*   overflowFlags() const;
+  [[nodiscard]] const int* matchGlobalPairIndices(int depth) const;
+  [[nodiscard]] const int* matchBatchLocalIndices(int depth) const;
 
   [[nodiscard]] int maxBatchSize() const { return maxBatchSize_; }
 
  private:
   static constexpr size_t kAlignment = 256;
 
-  [[nodiscard]] size_t alignOffset(size_t offset) const {
-    return (offset + kAlignment - 1) & ~(kAlignment - 1);
-  }
+  [[nodiscard]] size_t alignOffset(size_t offset) const { return (offset + kAlignment - 1) & ~(kAlignment - 1); }
 
   [[nodiscard]] size_t pairIndicesOffset() const { return 0; }
   [[nodiscard]] size_t miniBatchPairMatchStartsOffset() const;

--- a/src/substruct/substruct_kernels.cu
+++ b/src/substruct/substruct_kernels.cu
@@ -34,7 +34,7 @@ namespace {
 template <std::size_t MaxQueryAtoms = kMaxQueryAtoms> struct SubstructMatchResultsDeviceViewT {
   int*                          matchCounts;
   int*                          reportedCounts;
-  int*                          pairMatchStarts;
+  const int*                    pairMatchStarts;
   int16_t*                      matchIndices;
   int                           numQueries;
   const int*                    queryAtomCounts;

--- a/src/substruct/substruct_search_internal.cpp
+++ b/src/substruct/substruct_search_internal.cpp
@@ -46,14 +46,14 @@ void MiniBatchResultsDevice::setStream(cudaStream_t stream) {
   labelMatrixBuffer_.setStream(stream);
 }
 
-void MiniBatchResultsDevice::allocateMiniBatch(int  miniBatchSize,
-                                               int* pairMatchStartsDevice,
-                                               int  totalMiniBatchMatchIndices,
-                                               int  numQueries,
-                                               int  maxTargetAtoms,
-                                               int  numBuffersPerBlock,
-                                               int  maxMatchesToFind,
-                                               bool countOnly) {
+void MiniBatchResultsDevice::allocateMiniBatch(int        miniBatchSize,
+                                               const int* pairMatchStartsDevice,
+                                               int        totalMiniBatchMatchIndices,
+                                               int        numQueries,
+                                               int        maxTargetAtoms,
+                                               int        numBuffersPerBlock,
+                                               int        maxMatchesToFind,
+                                               bool       countOnly) {
   ScopedNvtxRange allocRange("MiniBatchResultsDevice::allocateMiniBatch");
 
   miniBatchSize_              = miniBatchSize;

--- a/src/substruct/substruct_search_internal.h
+++ b/src/substruct/substruct_search_internal.h
@@ -77,14 +77,14 @@ class MiniBatchResultsDevice {
    * @param maxMatchesToFind Stop searching after this many matches (-1 = no limit)
    * @param countOnly If true, count matches but don't store them
    */
-  void allocateMiniBatch(int  miniBatchSize,
-                         int* pairMatchStartsDevice,
-                         int  totalMiniBatchMatchIndices,
-                         int  numQueries,
-                         int  maxTargetAtoms,
-                         int  numBuffersPerBlock,
-                         int  maxMatchesToFind = -1,
-                         bool countOnly        = false);
+  void allocateMiniBatch(int        miniBatchSize,
+                         const int* pairMatchStartsDevice,
+                         int        totalMiniBatchMatchIndices,
+                         int        numQueries,
+                         int        maxTargetAtoms,
+                         int        numBuffersPerBlock,
+                         int        maxMatchesToFind = -1,
+                         bool       countOnly        = false);
 
   void setStream(cudaStream_t stream);
 
@@ -127,7 +127,7 @@ class MiniBatchResultsDevice {
 
   [[nodiscard]] int*          matchCounts() const { return matchCounts_.data(); }
   [[nodiscard]] int*          reportedCounts() const { return reportedCounts_.data(); }
-  [[nodiscard]] int*          pairMatchStarts() const { return pairMatchStarts_; }
+  [[nodiscard]] const int*    pairMatchStarts() const { return pairMatchStarts_; }
   [[nodiscard]] int16_t*      matchIndices() const { return matchIndices_.data(); }
   [[nodiscard]] const int*    queryAtomCounts() const { return queryAtomCounts_.data(); }
   [[nodiscard]] PartialMatch* overflowBuffer() const { return overflowBuffer_.data(); }
@@ -144,7 +144,7 @@ class MiniBatchResultsDevice {
 
   AsyncDeviceVector<int>     matchCounts_;
   AsyncDeviceVector<int>     reportedCounts_;
-  int*                       pairMatchStarts_ = nullptr;  ///< External device pointer, not owned
+  const int*                 pairMatchStarts_ = nullptr;  ///< External device pointer, not owned
   AsyncDeviceVector<int16_t> matchIndices_;
   AsyncDeviceVector<int>     queryAtomCounts_;
 

--- a/src/substruct/substruct_search_internal.h
+++ b/src/substruct/substruct_search_internal.h
@@ -68,7 +68,8 @@ class MiniBatchResultsDevice {
    * @brief Allocate mini-batch-local buffers for a specific mini-batch.
    *
    * @param miniBatchSize Number of pairs in this mini-batch
-   * @param miniBatchPairMatchStarts Mini-batch-local offsets into matchIndices [miniBatchSize + 1]
+   * @param pairMatchStartsDevice Device pointer to mini-batch-local offsets into matchIndices [miniBatchSize + 1].
+   *                              Must remain valid until the mini-batch is complete.
    * @param totalMiniBatchMatchIndices Total match indices capacity for this mini-batch
    * @param numQueries Total number of queries (for kernel view)
    * @param maxTargetAtoms Max atoms per target (stride for recursiveMatchBits)
@@ -76,14 +77,14 @@ class MiniBatchResultsDevice {
    * @param maxMatchesToFind Stop searching after this many matches (-1 = no limit)
    * @param countOnly If true, count matches but don't store them
    */
-  void allocateMiniBatch(int        miniBatchSize,
-                         const int* miniBatchPairMatchStarts,
-                         int        totalMiniBatchMatchIndices,
-                         int        numQueries,
-                         int        maxTargetAtoms,
-                         int        numBuffersPerBlock,
-                         int        maxMatchesToFind = -1,
-                         bool       countOnly        = false);
+  void allocateMiniBatch(int  miniBatchSize,
+                         int* pairMatchStartsDevice,
+                         int  totalMiniBatchMatchIndices,
+                         int  numQueries,
+                         int  maxTargetAtoms,
+                         int  numBuffersPerBlock,
+                         int  maxMatchesToFind = -1,
+                         bool countOnly        = false);
 
   void setStream(cudaStream_t stream);
 
@@ -126,7 +127,7 @@ class MiniBatchResultsDevice {
 
   [[nodiscard]] int*          matchCounts() const { return matchCounts_.data(); }
   [[nodiscard]] int*          reportedCounts() const { return reportedCounts_.data(); }
-  [[nodiscard]] int*          pairMatchStarts() const { return pairMatchStarts_.data(); }
+  [[nodiscard]] int*          pairMatchStarts() const { return pairMatchStarts_; }
   [[nodiscard]] int16_t*      matchIndices() const { return matchIndices_.data(); }
   [[nodiscard]] const int*    queryAtomCounts() const { return queryAtomCounts_.data(); }
   [[nodiscard]] PartialMatch* overflowBuffer() const { return overflowBuffer_.data(); }
@@ -143,7 +144,7 @@ class MiniBatchResultsDevice {
 
   AsyncDeviceVector<int>     matchCounts_;
   AsyncDeviceVector<int>     reportedCounts_;
-  AsyncDeviceVector<int>     pairMatchStarts_;
+  int*                       pairMatchStarts_ = nullptr;  ///< External device pointer, not owned
   AsyncDeviceVector<int16_t> matchIndices_;
   AsyncDeviceVector<int>     queryAtomCounts_;
 

--- a/src/testutils/substruct_validation.cu
+++ b/src/testutils/substruct_validation.cu
@@ -21,6 +21,7 @@
 #include <set>
 
 #include "cuda_error_check.h"
+#include "device_vector.h"
 #include "graph_labeler.cuh"
 #include "molecules_device.cuh"
 #include "substruct_search_internal.h"
@@ -323,11 +324,12 @@ std::vector<std::vector<uint8_t>> computeGpuLabelMatrix(const RDKit::ROMol& targ
   const int numTargetAtoms = static_cast<int>(targetHost.totalAtoms());
   const int numQueryAtoms  = static_cast<int>(queryHost.totalAtoms());
 
-  std::vector<int> queryAtomCounts          = {numQueryAtoms};
-  std::vector<int> miniBatchPairMatchStarts = {0, 0};
+  std::vector<int>       queryAtomCounts = {numQueryAtoms};
+  AsyncDeviceVector<int> pairMatchStartsDev(2, stream);
+  pairMatchStartsDev.zero();
 
   MiniBatchResultsDevice miniBatchResults(stream);
-  miniBatchResults.allocateMiniBatch(1, miniBatchPairMatchStarts.data(), 0, 1, numTargetAtoms, 2);
+  miniBatchResults.allocateMiniBatch(1, pairMatchStartsDev.data(), 0, 1, numTargetAtoms, 2);
   miniBatchResults.setQueryAtomCounts(queryAtomCounts.data(), queryAtomCounts.size());
   miniBatchResults.zeroRecursiveBits();
 

--- a/tests/test_recursive_preprocessor.cu
+++ b/tests/test_recursive_preprocessor.cu
@@ -25,12 +25,14 @@
 
 #include "cuda_error_check.h"
 #include "device.h"
+#include "device_vector.h"
 #include "molecules.h"
 #include "molecules_device.cuh"
 #include "recursive_preprocessor.h"
 #include "substruct_search_internal.h"
 #include "substruct_types.h"
 
+using nvMolKit::AsyncDeviceVector;
 using nvMolKit::BatchedPatternEntry;
 using nvMolKit::checkReturnCode;
 using nvMolKit::kMaxSmartsNestingDepth;
@@ -110,9 +112,10 @@ TEST(RecursivePreprocessorTest, PaintsBitsForSimpleRecursivePattern) {
   const int maxTargetAtoms = maxAtomsPerTarget(targetsHost);
   ASSERT_GT(maxTargetAtoms, 0);
 
-  std::vector<int>       pairMatchStarts(static_cast<size_t>(miniBatchSize + 1), 0);
+  AsyncDeviceVector<int> pairMatchStartsDev(static_cast<size_t>(miniBatchSize + 1), stream.stream());
+  pairMatchStartsDev.zero();
   MiniBatchResultsDevice miniBatchResults(stream.stream());
-  miniBatchResults.allocateMiniBatch(miniBatchSize, pairMatchStarts.data(), 0, numQueries, maxTargetAtoms, 2);
+  miniBatchResults.allocateMiniBatch(miniBatchSize, pairMatchStartsDev.data(), 0, numQueries, maxTargetAtoms, 2);
   const std::vector<int> atomCounts = queryAtomCounts(queriesHost);
   miniBatchResults.setQueryAtomCounts(atomCounts.data(), atomCounts.size());
   miniBatchResults.zeroRecursiveBits();


### PR DESCRIPTION
In tight executor loops, CUDA API calls are the bottleneck. This merges several previously separate memory allocations into a single allocation + views, allowing us to consolidate the calls. 