### PR TITLE
Fix empty results in uniquify if all results were unique to start with

### DIFF
--- a/src/substruct/substruct_search.cu
+++ b/src/substruct/substruct_search.cu
@@ -921,9 +921,7 @@ void uniquifyResults(SubstructSearchResults& results) {
       }
     }
 
-    if (uniqueMatches.size() < matchList.size()) {
-      matchList = std::move(uniqueMatches);
-    }
+    matchList = std::move(uniqueMatches);
   }
 }
 

--- a/src/testutils/substruct_validation.cu
+++ b/src/testutils/substruct_validation.cu
@@ -89,13 +89,14 @@ std::vector<std::vector<int>> extractGpuMatches(const SubstructSearchResults& re
 
 SubstructValidationResult validateAgainstRDKit(const SubstructSearchResults&                     results,
                                                const std::vector<std::unique_ptr<RDKit::ROMol>>& targetMols,
-                                               const std::vector<std::unique_ptr<RDKit::ROMol>>& queryMols) {
+                                               const std::vector<std::unique_ptr<RDKit::ROMol>>& queryMols,
+                                               bool                                              uniquify) {
   SubstructValidationResult validation;
   validation.totalPairs = results.numTargets * results.numQueries;
 
   for (int t = 0; t < results.numTargets; ++t) {
     for (int q = 0; q < results.numQueries; ++q) {
-      const auto rdkitMatches    = getRDKitSubstructMatches(*targetMols[t], *queryMols[q], false);
+      const auto rdkitMatches    = getRDKitSubstructMatches(*targetMols[t], *queryMols[q], uniquify);
       const int  gpuMatchCount   = results.matchCount(t, q);
       const int  rdkitMatchCount = static_cast<int>(rdkitMatches.size());
 
@@ -217,7 +218,8 @@ void printValidationResultDetailed(const SubstructValidationResult&             
                                    const std::vector<std::string>&                   targetSmiles,
                                    const std::vector<std::string>&                   querySmarts,
                                    const std::string&                                algoName,
-                                   int                                               maxDetails) {
+                                   int                                               maxDetails,
+                                   bool                                              uniquify) {
   std::string prefix = algoName.empty() ? "" : "[" + algoName + "] ";
 
   std::cout << prefix << "Validation: " << result.matchingPairs << "/" << result.totalPairs << " pairs match RDKit";
@@ -242,11 +244,9 @@ void printValidationResultDetailed(const SubstructValidationResult&             
       std::cout << "  Target[" << t << "]: " << targetSmiles[t] << std::endl;
       std::cout << "  Query[" << q << "]:  " << querySmarts[q] << std::endl;
 
-      // Get RDKit matches
-      auto rdkitMatches = getRDKitSubstructMatches(*targetMols[t], *queryMols[q], false);
+      auto rdkitMatches = getRDKitSubstructMatches(*targetMols[t], *queryMols[q], uniquify);
       printMatches("Expected (RDKit)", rdkitMatches);
 
-      // Get GPU matches
       const int numQueryAtoms = static_cast<int>(queryMols[q]->getNumAtoms());
       auto      gpuMatches    = extractGpuMatchesForPrint(gpuResults, t, q, numQueryAtoms);
       printMatches("Actual (GPU)", gpuMatches);
@@ -266,8 +266,7 @@ void printValidationResultDetailed(const SubstructValidationResult&             
       std::cout << "  Target[" << t << "]: " << targetSmiles[t] << std::endl;
       std::cout << "  Query[" << q << "]:  " << querySmarts[q] << std::endl;
 
-      // Get RDKit matches
-      auto rdkitMatches = getRDKitSubstructMatches(*targetMols[t], *queryMols[q], false);
+      auto rdkitMatches = getRDKitSubstructMatches(*targetMols[t], *queryMols[q], uniquify);
       printMatches("Expected (RDKit)", rdkitMatches);
 
       // Get GPU matches

--- a/src/testutils/substruct_validation.h
+++ b/src/testutils/substruct_validation.h
@@ -86,7 +86,7 @@ struct SubstructValidationResult {
 SubstructValidationResult validateAgainstRDKit(const SubstructSearchResults&                     results,
                                                const std::vector<std::unique_ptr<RDKit::ROMol>>& targetMols,
                                                const std::vector<std::unique_ptr<RDKit::ROMol>>& queryMols,
-                                               bool uniquify = false);
+                                               bool                                              uniquify = false);
 
 /**
  * @brief Print validation results to stdout.

--- a/src/testutils/substruct_validation.h
+++ b/src/testutils/substruct_validation.h
@@ -77,16 +77,16 @@ struct SubstructValidationResult {
 /**
  * @brief Compare GPU substructure match results against RDKit ground truth.
  *
- * Uses uniquify=false to match our non-uniquifying GPU algorithm.
- *
  * @param results GPU results from getSubstructMatches
  * @param targetMols Target molecules (parallel to results.numTargets)
  * @param queryMols Query molecules (parallel to results.numQueries)
+ * @param uniquify If true, compare against uniquified RDKit matches
  * @return Validation result with mismatch details
  */
 SubstructValidationResult validateAgainstRDKit(const SubstructSearchResults&                     results,
                                                const std::vector<std::unique_ptr<RDKit::ROMol>>& targetMols,
-                                               const std::vector<std::unique_ptr<RDKit::ROMol>>& queryMols);
+                                               const std::vector<std::unique_ptr<RDKit::ROMol>>& queryMols,
+                                               bool uniquify = false);
 
 /**
  * @brief Print validation results to stdout.
@@ -113,7 +113,8 @@ void printValidationResultDetailed(const SubstructValidationResult&             
                                    const std::vector<std::string>&                   targetSmiles,
                                    const std::vector<std::string>&                   querySmarts,
                                    const std::string&                                algorithmName = "",
-                                   int                                               maxDetails    = 5);
+                                   int                                               maxDetails    = 5,
+                                   bool                                              uniquify      = false);
 
 /**
  * @brief Compute the expected label matrix using RDKit atom matching.

--- a/tests/test_substruct_integration.cu
+++ b/tests/test_substruct_integration.cu
@@ -92,18 +92,18 @@ const ThreadingConfig kThreadingConfigs[] = {
 // clang-format on
 
 constexpr DatasetConfig kDatasets[] = {
-  {           "pwalters_alert_collection_supported.txt",            "PwaltersAlertCollection"},
-  {         "openbabel_functional_groups_supported.txt",          "OpenBabelFunctionalGroups"},
-  {                     "BMS_2006_filter_supported.txt",                      "BMS2006Filter"},
-  {          "rdkit_fragment_descriptors_supported.txt",           "RDKitFragmentDescriptors"},
-  {           "rdkit_tautomer_transforms_supported.txt",            "RDKitTautomerTransforms"},
-  {           "rdkit_tautomer_transforms_supported.txt", "RDKitTautomerTransformsUniquified", true},
-  {         "rdkit_torsionPreferences_v2_supported.txt",          "RDKitTorsionPreferencesV2"},
-  { "rdkit_torsionPreferences_smallrings_supported.txt",  "RDKitTorsionPreferencesSmallRings"},
-  {           "rdkit_pattern_fingerprint_supported.txt",           "RDKitPatternFingerprints"},
+  {"pwalters_alert_collection_supported.txt", "PwaltersAlertCollection"},
+  {"openbabel_functional_groups_supported.txt", "OpenBabelFunctionalGroups"},
+  {"BMS_2006_filter_supported.txt", "BMS2006Filter"},
+  {"rdkit_fragment_descriptors_supported.txt", "RDKitFragmentDescriptors"},
+  {"rdkit_tautomer_transforms_supported.txt", "RDKitTautomerTransforms"},
+  {"rdkit_tautomer_transforms_supported.txt", "RDKitTautomerTransformsUniquified", /*uniquify=*/true},
+  {"rdkit_torsionPreferences_v2_supported.txt", "RDKitTorsionPreferencesV2"},
+  {"rdkit_torsionPreferences_smallrings_supported.txt", "RDKitTorsionPreferencesSmallRings"},
+  {"rdkit_pattern_fingerprint_supported.txt", "RDKitPatternFingerprints"},
   {"rdkit_torsionPreferences_macrocycles_supported.txt", "RDKitTorsionPreferencesMacrocycles"},
-  {                       "RLewis_smarts_supported.txt",                       "RLewisSMARTS"},
-  {                          "wehi_pains_supported.txt",                          "WEHIPAINS"},
+  {"RLewis_smarts_supported.txt", "RLewisSMARTS"},
+  {"wehi_pains_supported.txt", "WEHIPAINS"},
 };
 
 struct SmallestRepro {
@@ -231,13 +231,25 @@ void printSmallestRepros(const SmallestRepros&                             repro
                        gpuResults,
                        uniquify);
     if (repros.smallestQ.t != repros.smallestSum.t || repros.smallestQ.q != repros.smallestSum.q) {
-      printSmallestRepro(
-        "smallest q", repros.smallestQ, targetSmiles, querySmarts, targetMols, queryMols, gpuResults, uniquify);
+      printSmallestRepro("smallest q",
+                         repros.smallestQ,
+                         targetSmiles,
+                         querySmarts,
+                         targetMols,
+                         queryMols,
+                         gpuResults,
+                         uniquify);
     }
     if (repros.smallestT.t != repros.smallestSum.t || repros.smallestT.q != repros.smallestSum.q) {
       if (repros.smallestT.t != repros.smallestQ.t || repros.smallestT.q != repros.smallestQ.q) {
-        printSmallestRepro(
-          "smallest t", repros.smallestT, targetSmiles, querySmarts, targetMols, queryMols, gpuResults, uniquify);
+        printSmallestRepro("smallest t",
+                           repros.smallestT,
+                           targetSmiles,
+                           querySmarts,
+                           targetMols,
+                           queryMols,
+                           gpuResults,
+                           uniquify);
       }
     }
   }
@@ -502,8 +514,14 @@ TEST_P(SubstructureIntegrationTest, ChemblVsSmarts) {
           validationResult.mismatches,
           [](const auto& m) { return std::get<0>(m); },
           [](const auto& m) { return std::get<1>(m); });
-        printSmallestRepros(
-          repros, targetSmiles, querySmarts, targetMols, queryMols, results, "count mismatch", dataset().uniquify);
+        printSmallestRepros(repros,
+                            targetSmiles,
+                            querySmarts,
+                            targetMols,
+                            queryMols,
+                            results,
+                            "count mismatch",
+                            dataset().uniquify);
       }
 
       if (!validationResult.mappingMismatches.empty()) {
@@ -511,8 +529,14 @@ TEST_P(SubstructureIntegrationTest, ChemblVsSmarts) {
           validationResult.mappingMismatches,
           [](const auto& m) { return m.first; },
           [](const auto& m) { return m.second; });
-        printSmallestRepros(
-          repros, targetSmiles, querySmarts, targetMols, queryMols, results, "mapping mismatch", dataset().uniquify);
+        printSmallestRepros(repros,
+                            targetSmiles,
+                            querySmarts,
+                            targetMols,
+                            queryMols,
+                            results,
+                            "mapping mismatch",
+                            dataset().uniquify);
       }
     }
 

--- a/tests/test_substruct_integration.cu
+++ b/tests/test_substruct_integration.cu
@@ -65,6 +65,7 @@ std::unique_ptr<RDKit::ROMol> makeSmartsQuery(const std::string& smarts) {
 struct DatasetConfig {
   const char* smartsFile;
   const char* name;
+  bool        uniquify = false;
 };
 
 struct ThreadingConfig {
@@ -96,6 +97,7 @@ constexpr DatasetConfig kDatasets[] = {
   {                     "BMS_2006_filter_supported.txt",                      "BMS2006Filter"},
   {          "rdkit_fragment_descriptors_supported.txt",           "RDKitFragmentDescriptors"},
   {           "rdkit_tautomer_transforms_supported.txt",            "RDKitTautomerTransforms"},
+  {           "rdkit_tautomer_transforms_supported.txt", "RDKitTautomerTransformsUniquified", true},
   {         "rdkit_torsionPreferences_v2_supported.txt",          "RDKitTorsionPreferencesV2"},
   { "rdkit_torsionPreferences_smallrings_supported.txt",  "RDKitTorsionPreferencesSmallRings"},
   {           "rdkit_pattern_fingerprint_supported.txt",           "RDKitPatternFingerprints"},
@@ -181,12 +183,13 @@ void printSmallestRepro(const char*                                       label,
                         const std::vector<std::string>&                   querySmarts,
                         const std::vector<std::unique_ptr<RDKit::ROMol>>& targetMols,
                         const std::vector<std::unique_ptr<RDKit::ROMol>>& queryMols,
-                        const SubstructSearchResults&                     gpuResults) {
+                        const SubstructSearchResults&                     gpuResults,
+                        bool                                              uniquify) {
   std::cout << "  --- " << label << " (t=" << r.t << " q=" << r.q << " sum=" << (r.t + r.q) << ") ---\n";
   std::cout << "  Target[" << r.t << "]: " << targetSmiles[r.t] << "\n";
   std::cout << "  Query[" << r.q << "]:  " << querySmarts[r.q] << "\n";
 
-  auto rdkitMatches = nvMolKit::getRDKitSubstructMatches(*targetMols[r.t], *queryMols[r.q], false);
+  auto rdkitMatches = nvMolKit::getRDKitSubstructMatches(*targetMols[r.t], *queryMols[r.q], uniquify);
   printMatches("Expected (RDKit)", rdkitMatches);
 
   const int numQueryAtoms = static_cast<int>(queryMols[r.q]->getNumAtoms());
@@ -202,7 +205,8 @@ void printSmallestRepros(const SmallestRepros&                             repro
                          const std::vector<std::unique_ptr<RDKit::ROMol>>& targetMols,
                          const std::vector<std::unique_ptr<RDKit::ROMol>>& queryMols,
                          const SubstructSearchResults&                     gpuResults,
-                         const std::string&                                category) {
+                         const std::string&                                category,
+                         bool                                              uniquify) {
   if (!repros.hasAny())
     return;
 
@@ -215,7 +219,8 @@ void printSmallestRepros(const SmallestRepros&                             repro
                        querySmarts,
                        targetMols,
                        queryMols,
-                       gpuResults);
+                       gpuResults,
+                       uniquify);
   } else {
     printSmallestRepro("smallest sum (t+q)",
                        repros.smallestSum,
@@ -223,19 +228,16 @@ void printSmallestRepros(const SmallestRepros&                             repro
                        querySmarts,
                        targetMols,
                        queryMols,
-                       gpuResults);
+                       gpuResults,
+                       uniquify);
     if (repros.smallestQ.t != repros.smallestSum.t || repros.smallestQ.q != repros.smallestSum.q) {
-      printSmallestRepro("smallest q", repros.smallestQ, targetSmiles, querySmarts, targetMols, queryMols, gpuResults);
+      printSmallestRepro(
+        "smallest q", repros.smallestQ, targetSmiles, querySmarts, targetMols, queryMols, gpuResults, uniquify);
     }
     if (repros.smallestT.t != repros.smallestSum.t || repros.smallestT.q != repros.smallestSum.q) {
       if (repros.smallestT.t != repros.smallestQ.t || repros.smallestT.q != repros.smallestQ.q) {
-        printSmallestRepro("smallest t",
-                           repros.smallestT,
-                           targetSmiles,
-                           querySmarts,
-                           targetMols,
-                           queryMols,
-                           gpuResults);
+        printSmallestRepro(
+          "smallest t", repros.smallestT, targetSmiles, querySmarts, targetMols, queryMols, gpuResults, uniquify);
       }
     }
   }
@@ -378,18 +380,21 @@ TEST_P(SubstructureIntegrationTest, ChemblVsSmarts) {
     EXPECT_EQ(mismatches, 0) << "HasSubstructMatch results do not match RDKit for algorithm "
                              << algorithmName(algorithm());
   } else if (mode() == SubstructMode::CountMatches) {
+    auto config     = threading().config;
+    config.uniquify = dataset().uniquify;
+
     std::vector<int> counts;
     countSubstructMatches(makeMolsView(targetMols),
                           makeMolsView(queryMols),
                           counts,
                           algorithm(),
                           stream_.stream(),
-                          threading().config);
+                          config);
 
     EXPECT_EQ(counts.size(), static_cast<size_t>(numTargets * numQueries));
 
     RDKit::SubstructMatchParameters params;
-    params.uniquify   = false;
+    params.uniquify   = dataset().uniquify;
     params.maxMatches = 0;
 
     int                              mismatches = 0;
@@ -428,13 +433,16 @@ TEST_P(SubstructureIntegrationTest, ChemblVsSmarts) {
     EXPECT_EQ(mismatches, 0) << "CountSubstructMatches results do not match RDKit for algorithm "
                              << algorithmName(algorithm());
   } else {
+    auto config     = threading().config;
+    config.uniquify = dataset().uniquify;
+
     SubstructSearchResults results;
     getSubstructMatches(makeMolsView(targetMols),
                         makeMolsView(queryMols),
                         results,
                         algorithm(),
                         stream_.stream(),
-                        threading().config);
+                        config);
 
     EXPECT_EQ(results.numTargets, numTargets);
     EXPECT_EQ(results.numQueries, numQueries);
@@ -476,7 +484,7 @@ TEST_P(SubstructureIntegrationTest, ChemblVsSmarts) {
       }
     }
 
-    auto validationResult = validateAgainstRDKit(results, targetMols, queryMols);
+    auto validationResult = validateAgainstRDKit(results, targetMols, queryMols, dataset().uniquify);
 
     if (!validationResult.allMatch) {
       printValidationResultDetailed(validationResult,
@@ -485,14 +493,17 @@ TEST_P(SubstructureIntegrationTest, ChemblVsSmarts) {
                                     queryMols,
                                     targetSmiles,
                                     querySmarts,
-                                    algorithmName(algorithm()));
+                                    algorithmName(algorithm()),
+                                    5,
+                                    dataset().uniquify);
 
       if (!validationResult.mismatches.empty()) {
         auto repros = findSmallestRepros(
           validationResult.mismatches,
           [](const auto& m) { return std::get<0>(m); },
           [](const auto& m) { return std::get<1>(m); });
-        printSmallestRepros(repros, targetSmiles, querySmarts, targetMols, queryMols, results, "count mismatch");
+        printSmallestRepros(
+          repros, targetSmiles, querySmarts, targetMols, queryMols, results, "count mismatch", dataset().uniquify);
       }
 
       if (!validationResult.mappingMismatches.empty()) {
@@ -500,7 +511,8 @@ TEST_P(SubstructureIntegrationTest, ChemblVsSmarts) {
           validationResult.mappingMismatches,
           [](const auto& m) { return m.first; },
           [](const auto& m) { return m.second; });
-        printSmallestRepros(repros, targetSmiles, querySmarts, targetMols, queryMols, results, "mapping mismatch");
+        printSmallestRepros(
+          repros, targetSmiles, querySmarts, targetMols, queryMols, results, "mapping mismatch", dataset().uniquify);
       }
     }
 


### PR DESCRIPTION
There was an invalid guard which would cause us to not return the results.

Most of the diff is expanding our integration tests to cover this case. New tests failed before fix.

Addresses #112 