### PR TITLE
Expose MMFF forcefield API to python

### DIFF
--- a/nvmolkit/CMakeLists.txt
+++ b/nvmolkit/CMakeLists.txt
@@ -59,8 +59,9 @@ add_library(_batchedForcefield MODULE batchedForcefield.cpp)
 target_link_libraries(_batchedForcefield PUBLIC ${Boost_LIBRARIES}
                                                 ${PYTHON_LIBRARIES})
 target_link_libraries(
-  _batchedForcefield PRIVATE ${RDKit_LIBS} batched_forcefield rdkit_mmff_flattened
-                             device_vector ff_utils)
+  _batchedForcefield
+  PRIVATE ${RDKit_LIBS} mmff_batched_forcefield batched_forcefield
+          rdkit_mmff_flattened device_vector ff_utils)
 target_include_directories(
   _batchedForcefield PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/utils
                             ${Python_INCLUDE_DIRS})

--- a/nvmolkit/CMakeLists.txt
+++ b/nvmolkit/CMakeLists.txt
@@ -55,6 +55,19 @@ target_include_directories(_mmffOptimization SYSTEM
                            PUBLIC ${Boost_INCLUDE_DIRS})
 installpythontarget(_mmffOptimization ./)
 
+add_library(_batchedForcefield MODULE batchedForcefield.cpp)
+target_link_libraries(_batchedForcefield PUBLIC ${Boost_LIBRARIES}
+                                                ${PYTHON_LIBRARIES})
+target_link_libraries(
+  _batchedForcefield PRIVATE ${RDKit_LIBS} batched_forcefield rdkit_mmff_flattened
+                             device_vector ff_utils)
+target_include_directories(
+  _batchedForcefield PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/utils
+                            ${Python_INCLUDE_DIRS})
+target_include_directories(_batchedForcefield SYSTEM
+                           PUBLIC ${Boost_INCLUDE_DIRS})
+installpythontarget(_batchedForcefield ./)
+
 add_library(_embedMolecules MODULE embedMolecules.cpp)
 target_link_libraries(_embedMolecules PUBLIC ${Boost_LIBRARIES}
                                              ${PYTHON_LIBRARIES} device_vector)

--- a/nvmolkit/_mmff_bridge.py
+++ b/nvmolkit/_mmff_bridge.py
@@ -11,6 +11,7 @@ into the native extension.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import weakref
 
 from rdkit.Chem import rdForceFieldHelpers
 from rdkit.ForceField import rdForceField as _rdForceField  # noqa: F401
@@ -34,7 +35,7 @@ _DEFAULT_MMFF_SETTINGS = {
     "vdw_term": True,
     "ele_term": True,
 }
-_CAPTURED_MMFF_SETTINGS_BY_ID: dict[int, dict] = {}
+_CAPTURED_MMFF_SETTINGS_BY_OBJECT: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
 
 def _normalize_mmff_settings(settings: dict | None) -> dict:
@@ -53,7 +54,7 @@ def capture_mmff_settings(properties: "RDKitMMFFMolProperties", settings: dict |
     every setting in a given build.
     """
 
-    _CAPTURED_MMFF_SETTINGS_BY_ID[id(properties)] = _normalize_mmff_settings(settings)
+    _CAPTURED_MMFF_SETTINGS_BY_OBJECT[properties] = _normalize_mmff_settings(settings)
     return properties
 
 
@@ -74,7 +75,7 @@ def extract_mmff_settings(properties: "RDKitMMFFMolProperties") -> dict:
     them.
     """
 
-    captured = _CAPTURED_MMFF_SETTINGS_BY_ID.get(id(properties))
+    captured = _CAPTURED_MMFF_SETTINGS_BY_OBJECT.get(properties)
     if captured is not None:
         return dict(captured)
 

--- a/nvmolkit/_mmff_bridge.py
+++ b/nvmolkit/_mmff_bridge.py
@@ -1,0 +1,138 @@
+"""Bridge RDKit MMFF property objects into nvMolKit's internal MMFF config.
+
+This shim exists because RDKit ``Mol`` objects pass cleanly across the Python/C++
+extension boundary as ``ROMol*``, but RDKit's Python ``MMFFMolProperties`` object
+does not. It is a separate Boost.Python wrapper type owned by RDKit's forcefield
+module, so nvMolKit accepts that object at the public Python API and converts it
+into its own plain internal ``MMFFProperties`` transport object before calling
+into the native extension.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rdkit.Chem import rdForceFieldHelpers
+from rdkit.ForceField import rdForceField as _rdForceField  # noqa: F401
+
+from nvmolkit import _batchedForcefield  # type: ignore
+
+if TYPE_CHECKING:
+    from rdkit.Chem import Mol
+    from rdkit.ForceField.rdForceField import MMFFMolProperties as RDKitMMFFMolProperties
+
+
+_DEFAULT_MMFF_SETTINGS = {
+    "variant": "MMFF94",
+    "dielectric_constant": 1.0,
+    "dielectric_model": 1,
+    "bond_term": True,
+    "angle_term": True,
+    "stretch_bend_term": True,
+    "oop_term": True,
+    "torsion_term": True,
+    "vdw_term": True,
+    "ele_term": True,
+}
+_CAPTURED_MMFF_SETTINGS_BY_ID: dict[int, dict] = {}
+
+
+def _normalize_mmff_settings(settings: dict | None) -> dict:
+    normalized = dict(_DEFAULT_MMFF_SETTINGS)
+    if settings is not None:
+        normalized.update(settings)
+    return normalized
+
+
+def capture_mmff_settings(properties: "RDKitMMFFMolProperties", settings: dict | None):
+    """Associate explicit MMFF settings with an RDKit MMFF properties object.
+
+    We use this when nvmolkit itself creates/configures a Python
+    ``MMFFMolProperties`` object so later conversion back into nvMolKit's
+    internal MMFF transport does not depend on RDKit exposing Python getters for
+    every setting in a given build.
+    """
+
+    _CAPTURED_MMFF_SETTINGS_BY_ID[id(properties)] = _normalize_mmff_settings(settings)
+    return properties
+
+
+def default_rdkit_mmff_properties(mol: "Mol"):
+    """Create default RDKit MMFF properties and capture their default settings."""
+
+    properties = rdForceFieldHelpers.MMFFGetMoleculeProperties(mol)
+    if properties is None:
+        raise ValueError("RDKit could not create MMFF properties for molecule")
+    return capture_mmff_settings(properties, None)
+
+
+def extract_mmff_settings(properties: "RDKitMMFFMolProperties") -> dict:
+    """Return MMFF settings for an RDKit MMFF properties object.
+
+    Captured settings take precedence. If we did not create/configure the object
+    ourselves, fall back to RDKit getter methods when the current build exposes
+    them.
+    """
+
+    captured = _CAPTURED_MMFF_SETTINGS_BY_ID.get(id(properties))
+    if captured is not None:
+        return dict(captured)
+
+    getter_candidates = {
+        "variant": ("GetMMFFVariant", "getMMFFVariant"),
+        "dielectric_constant": ("GetMMFFDielectricConstant", "getMMFFDielectricConstant"),
+        "dielectric_model": ("GetMMFFDielectricModel", "getMMFFDielectricModel"),
+        "bond_term": ("GetMMFFBondTerm", "getMMFFBondTerm"),
+        "angle_term": ("GetMMFFAngleTerm", "getMMFFAngleTerm"),
+        "stretch_bend_term": ("GetMMFFStretchBendTerm", "getMMFFStretchBendTerm"),
+        "oop_term": ("GetMMFFOopTerm", "getMMFFOopTerm"),
+        "torsion_term": ("GetMMFFTorsionTerm", "getMMFFTorsionTerm"),
+        "vdw_term": ("GetMMFFVdWTerm", "getMMFFVdWTerm"),
+        "ele_term": ("GetMMFFEleTerm", "getMMFFEleTerm"),
+    }
+    extracted = {}
+    for key, names in getter_candidates.items():
+        getter = None
+        for name in names:
+            if hasattr(properties, name):
+                getter = getattr(properties, name)
+                break
+        if getter is None:
+            raise TypeError(
+                "Could not read MMFF settings from the supplied RDKit MMFFMolProperties object. "
+                "Use an object created via rdForceFieldHelpers.MMFFGetMoleculeProperties() and "
+                "configured before passing it to nvmolkit."
+            )
+        extracted[key] = getter()
+    return _normalize_mmff_settings(extracted)
+
+
+def make_internal_mmff_properties(
+    properties: "RDKitMMFFMolProperties",
+    *,
+    non_bonded_threshold: float,
+    ignore_interfrag_interactions: bool,
+):
+    """Convert an RDKit MMFF properties object into nvMolKit's internal transport.
+
+    Unlike RDKit ``Mol`` objects, RDKit's Python ``MMFFMolProperties`` wrapper is
+    not passed directly into nvMolKit's extension module. The native code instead
+    receives this plain internal ``MMFFProperties`` object with the RDKit settings
+    copied onto it.
+    """
+
+    settings = extract_mmff_settings(properties)
+    internal = _batchedForcefield.MMFFProperties()
+    internal.variant = str(settings["variant"])
+    internal.dielectricConstant = float(settings["dielectric_constant"])
+    internal.dielectricModel = int(settings["dielectric_model"])
+    internal.nonBondedThreshold = float(non_bonded_threshold)
+    internal.ignoreInterfragInteractions = bool(ignore_interfrag_interactions)
+    internal.bondTerm = bool(settings["bond_term"])
+    internal.angleTerm = bool(settings["angle_term"])
+    internal.stretchBendTerm = bool(settings["stretch_bend_term"])
+    internal.oopTerm = bool(settings["oop_term"])
+    internal.torsionTerm = bool(settings["torsion_term"])
+    internal.vdwTerm = bool(settings["vdw_term"])
+    internal.eleTerm = bool(settings["ele_term"])
+    return internal

--- a/nvmolkit/batchedForcefield.cpp
+++ b/nvmolkit/batchedForcefield.cpp
@@ -15,9 +15,7 @@
 
 #include <GraphMol/ROMol.h>
 
-#include <algorithm>
 #include <boost/python.hpp>
-#include <cmath>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -82,11 +80,10 @@ static void throwIfCudaError(cudaError_t err, const std::string& context) {
   }
 }
 
-template <typename T> static std::vector<T> copyDeviceVector(nvMolKit::AsyncDeviceVector<T>& deviceVec) {
+template <typename T> std::vector<T> copyDeviceVector(nvMolKit::AsyncDeviceVector<T>& deviceVec) {
   std::vector<T> hostVec(deviceVec.size());
-  cudaDeviceSynchronize();
   deviceVec.copyToHost(hostVec);
-  cudaDeviceSynchronize();
+  cudaStreamSynchronize(deviceVec.stream());
   return hostVec;
 }
 
@@ -139,16 +136,18 @@ class NativeMMFFBatchedForcefield {
     const auto props    = extractMMFFPropertiesList(properties, numMols);
     const auto confList = extractIntList(confIds, numMols, "conf_id");
 
+    nvMolKit::MMFF::BatchedMolecularSystemHost systemHost;
+    nvMolKit::BatchedForcefieldMetadata        metadata;
     for (int molIdx = 0; molIdx < numMols; ++molIdx) {
       std::vector<double> positions;
       nvMolKit::confPosToVect(*mols[molIdx], positions, confList[molIdx]);
       auto ffParams = nvMolKit::MMFF::constructForcefieldContribs(*mols[molIdx], props[molIdx], confList[molIdx]);
-      nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost_, &metadata_, molIdx, 0);
+      nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost, &metadata, molIdx, 0);
     }
-    forcefield_ = std::make_unique<nvMolKit::MMFFBatchedForcefield>(systemHost_, metadata_);
-    positionsDevice_.setFromVector(systemHost_.positions);
-    gradDevice_.resize(systemHost_.positions.size());
-    energyOutsDevice_.resize(numMols);
+    forcefield_ = std::make_unique<nvMolKit::MMFFBatchedForcefield>(systemHost, metadata);
+    positionsDevice_.setFromVector(systemHost.positions);
+    gradDevice_.resize(forcefield_->totalPositions());
+    energyOutsDevice_.resize(forcefield_->numMolecules());
   }
 
   bp::list computeEnergy() {
@@ -160,65 +159,16 @@ class NativeMMFFBatchedForcefield {
   bp::list computeGradients() {
     gradDevice_.zero();
     throwIfCudaError(forcefield_->computeGradients(gradDevice_.data(), positionsDevice_.data()), "computeGradients");
-    return vectorOfVectorsToList(splitGradients(copyDeviceVector(gradDevice_), systemHost_.indices.atomStarts, 3));
+    return vectorOfVectorsToList(
+      splitGradients(copyDeviceVector(gradDevice_), forcefield_->atomStartsHost(), 3));
   }
 
  private:
-  nvMolKit::MMFF::BatchedMolecularSystemHost       systemHost_;
-  nvMolKit::BatchedForcefieldMetadata              metadata_;
   std::unique_ptr<nvMolKit::MMFFBatchedForcefield> forcefield_;
   nvMolKit::AsyncDeviceVector<double>              positionsDevice_;
   nvMolKit::AsyncDeviceVector<double>              gradDevice_;
   nvMolKit::AsyncDeviceVector<double>              energyOutsDevice_;
 };
-
-static bp::list computeMMFFEnergies(const bp::list& molecules, const double nonBondedThreshold) {
-  auto                                       mols = extractMolecules(molecules);
-  nvMolKit::MMFF::BatchedMolecularSystemHost systemHost;
-  nvMolKit::BatchedForcefieldMetadata        metadata;
-
-  for (int i = 0; i < static_cast<int>(mols.size()); ++i) {
-    nvMolKit::MMFFProperties props;
-    props.nonBondedThreshold = nonBondedThreshold;
-    std::vector<double> positions;
-    nvMolKit::confPosToVect(*mols[i], positions);
-    auto ffParams = nvMolKit::MMFF::constructForcefieldContribs(*mols[i], props);
-    nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost, &metadata, i, 0);
-  }
-
-  nvMolKit::MMFFBatchedForcefield     forcefield(systemHost, metadata);
-  nvMolKit::AsyncDeviceVector<double> positionsDevice;
-  nvMolKit::AsyncDeviceVector<double> energyOutsDevice;
-  positionsDevice.setFromVector(systemHost.positions);
-  energyOutsDevice.resize(mols.size());
-  energyOutsDevice.zero();
-  throwIfCudaError(forcefield.computeEnergy(energyOutsDevice.data(), positionsDevice.data()), "MMFFComputeEnergies");
-  return vectorToList(copyDeviceVector(energyOutsDevice));
-}
-
-static bp::list computeMMFFGradients(const bp::list& molecules, const double nonBondedThreshold) {
-  auto                                       mols = extractMolecules(molecules);
-  nvMolKit::MMFF::BatchedMolecularSystemHost systemHost;
-  nvMolKit::BatchedForcefieldMetadata        metadata;
-
-  for (int i = 0; i < static_cast<int>(mols.size()); ++i) {
-    nvMolKit::MMFFProperties props;
-    props.nonBondedThreshold = nonBondedThreshold;
-    std::vector<double> positions;
-    nvMolKit::confPosToVect(*mols[i], positions);
-    auto ffParams = nvMolKit::MMFF::constructForcefieldContribs(*mols[i], props);
-    nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost, &metadata, i, 0);
-  }
-
-  nvMolKit::MMFFBatchedForcefield     forcefield(systemHost, metadata);
-  nvMolKit::AsyncDeviceVector<double> positionsDevice;
-  nvMolKit::AsyncDeviceVector<double> gradDevice;
-  positionsDevice.setFromVector(systemHost.positions);
-  gradDevice.resize(systemHost.positions.size());
-  gradDevice.zero();
-  throwIfCudaError(forcefield.computeGradients(gradDevice.data(), positionsDevice.data()), "MMFFComputeGradients");
-  return vectorOfVectorsToList(splitGradients(copyDeviceVector(gradDevice), systemHost.indices.atomStarts, 3));
-}
 
 BOOST_PYTHON_MODULE(_batchedForcefield) {
   bp::class_<nvMolKit::MMFFProperties>("MMFFProperties")
@@ -240,7 +190,4 @@ BOOST_PYTHON_MODULE(_batchedForcefield) {
     bp::init<const bp::list&, const bp::list&, const bp::list&>())
     .def("computeEnergy", &NativeMMFFBatchedForcefield::computeEnergy)
     .def("computeGradients", &NativeMMFFBatchedForcefield::computeGradients);
-
-  bp::def("MMFFComputeEnergies", computeMMFFEnergies, (bp::arg("molecules"), bp::arg("nonBondedThreshold") = 100.0));
-  bp::def("MMFFComputeGradients", computeMMFFGradients, (bp::arg("molecules"), bp::arg("nonBondedThreshold") = 100.0));
 }

--- a/nvmolkit/batchedForcefield.cpp
+++ b/nvmolkit/batchedForcefield.cpp
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <GraphMol/ROMol.h>
+
+#include <boost/python.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "device_vector.h"
+#include "ff_utils.h"
+#include "mmff_batched_forcefield.h"
+#include "mmff_flattened_builder.h"
+#include "mmff_properties.h"
+
+namespace bp = boost::python;
+
+template <typename T> bp::list vectorToList(const std::vector<T>& vec) {
+  bp::list list;
+  for (const auto& value : vec) {
+    list.append(value);
+  }
+  return list;
+}
+
+template <typename T> bp::list vectorOfVectorsToList(const std::vector<std::vector<T>>& vecOfVecs) {
+  bp::list outerList;
+  for (const auto& innerVec : vecOfVecs) {
+    outerList.append(vectorToList(innerVec));
+  }
+  return outerList;
+}
+
+static std::vector<RDKit::ROMol*> extractMolecules(const bp::list& molecules) {
+  const int                  n = bp::len(molecules);
+  std::vector<RDKit::ROMol*> mols;
+  mols.reserve(n);
+  for (int i = 0; i < n; ++i) {
+    auto* mol = bp::extract<RDKit::ROMol*>(bp::object(molecules[i]))();
+    if (mol == nullptr) {
+      throw std::invalid_argument("Invalid molecule at index " + std::to_string(i));
+    }
+    mols.push_back(mol);
+  }
+  return mols;
+}
+
+static void throwIfCudaError(cudaError_t err, const std::string& context) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(context + ": " + cudaGetErrorString(err));
+  }
+}
+
+template <typename T> static std::vector<T> copyDeviceVector(nvMolKit::AsyncDeviceVector<T>& deviceVec) {
+  std::vector<T> hostVec(deviceVec.size());
+  cudaDeviceSynchronize();
+  deviceVec.copyToHost(hostVec);
+  cudaDeviceSynchronize();
+  return hostVec;
+}
+
+static nvMolKit::MMFFProperties extractInternalMMFFProperties(const bp::object& obj,
+                                                              double            nonBondedThreshold          = 100.0,
+                                                              bool              ignoreInterfragInteractions = true) {
+  nvMolKit::MMFFProperties props;
+  if (obj.is_none()) {
+    props.nonBondedThreshold          = nonBondedThreshold;
+    props.ignoreInterfragInteractions = ignoreInterfragInteractions;
+    return props;
+  }
+  props = bp::extract<nvMolKit::MMFFProperties>(obj);
+  return props;
+}
+
+static std::vector<nvMolKit::MMFFProperties> extractMMFFPropertiesList(const bp::list& properties, int numMols) {
+  const int                            n = bp::len(properties);
+  std::vector<nvMolKit::MMFFProperties> props;
+  props.reserve(numMols);
+  for (int i = 0; i < numMols; ++i) {
+    if (i < n) {
+      props.push_back(extractInternalMMFFProperties(bp::object(properties[i])));
+    } else {
+      props.emplace_back();
+    }
+  }
+  return props;
+}
+
+static std::vector<int> extractIntList(const bp::list& pyList, int expectedSize, const std::string& name) {
+  const int n = bp::len(pyList);
+  if (n != expectedSize) {
+    throw std::invalid_argument(name + " list size " + std::to_string(n) +
+                                " does not match expected size " + std::to_string(expectedSize));
+  }
+  std::vector<int> result;
+  result.reserve(n);
+  for (int i = 0; i < n; ++i) {
+    result.push_back(bp::extract<int>(pyList[i]));
+  }
+  return result;
+}
+
+class NativeMMFFBatchedForcefield {
+ public:
+  NativeMMFFBatchedForcefield(const bp::list& molecules,
+                              const bp::list& properties,
+                              const bp::list& confIds) {
+    const auto mols     = extractMolecules(molecules);
+    const int  numMols  = static_cast<int>(mols.size());
+    const auto props    = extractMMFFPropertiesList(properties, numMols);
+    const auto confList = extractIntList(confIds, numMols, "conf_id");
+
+    for (int molIdx = 0; molIdx < numMols; ++molIdx) {
+      std::vector<double> positions;
+      nvMolKit::confPosToVect(*mols[molIdx], positions, confList[molIdx]);
+      auto ffParams =
+        nvMolKit::MMFF::constructForcefieldContribs(*mols[molIdx], props[molIdx], confList[molIdx]);
+      nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost_, metadata_, molIdx, 0);
+    }
+    forcefield_ = std::make_unique<nvMolKit::MMFFBatchedForcefield>(systemHost_, metadata_);
+    positionsDevice_.setFromVector(systemHost_.positions);
+    gradDevice_.resize(systemHost_.positions.size());
+    energyOutsDevice_.resize(numMols);
+  }
+
+  bp::list computeEnergy() {
+    energyOutsDevice_.zero();
+    throwIfCudaError(forcefield_->computeEnergy(energyOutsDevice_.data(), positionsDevice_.data()), "computeEnergy");
+    return vectorToList(copyDeviceVector(energyOutsDevice_));
+  }
+
+  bp::list computeGradients() {
+    gradDevice_.zero();
+    throwIfCudaError(forcefield_->computeGradients(gradDevice_.data(), positionsDevice_.data()), "computeGradients");
+    return vectorOfVectorsToList(
+      nvMolKit::splitGradients(copyDeviceVector(gradDevice_), systemHost_.indices.atomStarts, 3));
+  }
+
+ private:
+  nvMolKit::MMFF::BatchedMolecularSystemHost       systemHost_;
+  nvMolKit::BatchedForcefieldMetadata               metadata_;
+  std::unique_ptr<nvMolKit::MMFFBatchedForcefield>  forcefield_;
+  nvMolKit::AsyncDeviceVector<double>               positionsDevice_;
+  nvMolKit::AsyncDeviceVector<double>               gradDevice_;
+  nvMolKit::AsyncDeviceVector<double>               energyOutsDevice_;
+};
+
+static bp::list computeMMFFEnergies(const bp::list& molecules, const double nonBondedThreshold) {
+  auto                                       mols = extractMolecules(molecules);
+  nvMolKit::MMFF::BatchedMolecularSystemHost systemHost;
+  nvMolKit::BatchedForcefieldMetadata        metadata;
+
+  for (int i = 0; i < static_cast<int>(mols.size()); ++i) {
+    nvMolKit::MMFFProperties props;
+    props.nonBondedThreshold = nonBondedThreshold;
+    std::vector<double> positions;
+    nvMolKit::confPosToVect(*mols[i], positions);
+    auto ffParams = nvMolKit::MMFF::constructForcefieldContribs(*mols[i], props);
+    nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost, metadata, i, 0);
+  }
+
+  nvMolKit::MMFFBatchedForcefield     forcefield(systemHost, metadata);
+  nvMolKit::AsyncDeviceVector<double> positionsDevice;
+  nvMolKit::AsyncDeviceVector<double> energyOutsDevice;
+  positionsDevice.setFromVector(systemHost.positions);
+  energyOutsDevice.resize(mols.size());
+  energyOutsDevice.zero();
+  throwIfCudaError(forcefield.computeEnergy(energyOutsDevice.data(), positionsDevice.data()), "MMFFComputeEnergies");
+  return vectorToList(copyDeviceVector(energyOutsDevice));
+}
+
+static bp::list computeMMFFGradients(const bp::list& molecules, const double nonBondedThreshold) {
+  auto                                       mols = extractMolecules(molecules);
+  nvMolKit::MMFF::BatchedMolecularSystemHost systemHost;
+  nvMolKit::BatchedForcefieldMetadata        metadata;
+
+  for (int i = 0; i < static_cast<int>(mols.size()); ++i) {
+    nvMolKit::MMFFProperties props;
+    props.nonBondedThreshold = nonBondedThreshold;
+    std::vector<double> positions;
+    nvMolKit::confPosToVect(*mols[i], positions);
+    auto ffParams = nvMolKit::MMFF::constructForcefieldContribs(*mols[i], props);
+    nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost, metadata, i, 0);
+  }
+
+  nvMolKit::MMFFBatchedForcefield     forcefield(systemHost, metadata);
+  nvMolKit::AsyncDeviceVector<double> positionsDevice;
+  nvMolKit::AsyncDeviceVector<double> gradDevice;
+  positionsDevice.setFromVector(systemHost.positions);
+  gradDevice.resize(systemHost.positions.size());
+  gradDevice.zero();
+  throwIfCudaError(forcefield.computeGradients(gradDevice.data(), positionsDevice.data()), "MMFFComputeGradients");
+  return vectorOfVectorsToList(
+    nvMolKit::splitGradients(copyDeviceVector(gradDevice), systemHost.indices.atomStarts, 3));
+}
+
+BOOST_PYTHON_MODULE(_batchedForcefield) {
+  bp::class_<nvMolKit::MMFFProperties>("MMFFProperties")
+    .def_readwrite("variant",                     &nvMolKit::MMFFProperties::variant)
+    .def_readwrite("dielectricConstant",          &nvMolKit::MMFFProperties::dielectricConstant)
+    .def_readwrite("dielectricModel",             &nvMolKit::MMFFProperties::dielectricModel)
+    .def_readwrite("nonBondedThreshold",          &nvMolKit::MMFFProperties::nonBondedThreshold)
+    .def_readwrite("ignoreInterfragInteractions", &nvMolKit::MMFFProperties::ignoreInterfragInteractions)
+    .def_readwrite("bondTerm",                    &nvMolKit::MMFFProperties::bondTerm)
+    .def_readwrite("angleTerm",                   &nvMolKit::MMFFProperties::angleTerm)
+    .def_readwrite("stretchBendTerm",             &nvMolKit::MMFFProperties::stretchBendTerm)
+    .def_readwrite("oopTerm",                     &nvMolKit::MMFFProperties::oopTerm)
+    .def_readwrite("torsionTerm",                 &nvMolKit::MMFFProperties::torsionTerm)
+    .def_readwrite("vdwTerm",                     &nvMolKit::MMFFProperties::vdwTerm)
+    .def_readwrite("eleTerm",                     &nvMolKit::MMFFProperties::eleTerm);
+
+  bp::class_<NativeMMFFBatchedForcefield, boost::noncopyable>("NativeMMFFBatchedForcefield",
+                                                            bp::init<const bp::list&, const bp::list&, const bp::list&>())
+    .def("computeEnergy",    &NativeMMFFBatchedForcefield::computeEnergy)
+    .def("computeGradients", &NativeMMFFBatchedForcefield::computeGradients);
+
+  bp::def("MMFFComputeEnergies",  computeMMFFEnergies,
+          (bp::arg("molecules"), bp::arg("nonBondedThreshold") = 100.0));
+  bp::def("MMFFComputeGradients", computeMMFFGradients,
+          (bp::arg("molecules"), bp::arg("nonBondedThreshold") = 100.0));
+}

--- a/nvmolkit/batchedForcefield.cpp
+++ b/nvmolkit/batchedForcefield.cpp
@@ -159,8 +159,7 @@ class NativeMMFFBatchedForcefield {
   bp::list computeGradients() {
     gradDevice_.zero();
     throwIfCudaError(forcefield_->computeGradients(gradDevice_.data(), positionsDevice_.data()), "computeGradients");
-    return vectorOfVectorsToList(
-      splitGradients(copyDeviceVector(gradDevice_), forcefield_->atomStartsHost(), 3));
+    return vectorOfVectorsToList(splitGradients(copyDeviceVector(gradDevice_), forcefield_->atomStartsHost(), 3));
   }
 
  private:

--- a/nvmolkit/batchedForcefield.cpp
+++ b/nvmolkit/batchedForcefield.cpp
@@ -15,9 +15,8 @@
 
 #include <GraphMol/ROMol.h>
 
-#include <boost/python.hpp>
-
 #include <algorithm>
+#include <boost/python.hpp>
 #include <cmath>
 #include <memory>
 #include <stdexcept>
@@ -47,6 +46,21 @@ template <typename T> bp::list vectorOfVectorsToList(const std::vector<std::vect
   }
   return outerList;
 }
+
+namespace {
+std::vector<std::vector<double>> splitGradients(const std::vector<double>& flatGrad,
+                                                const std::vector<int>&    atomStarts,
+                                                int                        dim) {
+  std::vector<std::vector<double>> result;
+  result.reserve(atomStarts.size() - 1);
+  for (size_t i = 0; i + 1 < atomStarts.size(); ++i) {
+    const int start = atomStarts[i] * dim;
+    const int end   = atomStarts[i + 1] * dim;
+    result.emplace_back(flatGrad.begin() + start, flatGrad.begin() + end);
+  }
+  return result;
+}
+}  // namespace
 
 static std::vector<RDKit::ROMol*> extractMolecules(const bp::list& molecules) {
   const int                  n = bp::len(molecules);
@@ -90,7 +104,7 @@ static nvMolKit::MMFFProperties extractInternalMMFFProperties(const bp::object& 
 }
 
 static std::vector<nvMolKit::MMFFProperties> extractMMFFPropertiesList(const bp::list& properties, int numMols) {
-  const int                            n = bp::len(properties);
+  const int                             n = bp::len(properties);
   std::vector<nvMolKit::MMFFProperties> props;
   props.reserve(numMols);
   for (int i = 0; i < numMols; ++i) {
@@ -106,8 +120,8 @@ static std::vector<nvMolKit::MMFFProperties> extractMMFFPropertiesList(const bp:
 static std::vector<int> extractIntList(const bp::list& pyList, int expectedSize, const std::string& name) {
   const int n = bp::len(pyList);
   if (n != expectedSize) {
-    throw std::invalid_argument(name + " list size " + std::to_string(n) +
-                                " does not match expected size " + std::to_string(expectedSize));
+    throw std::invalid_argument(name + " list size " + std::to_string(n) + " does not match expected size " +
+                                std::to_string(expectedSize));
   }
   std::vector<int> result;
   result.reserve(n);
@@ -119,9 +133,7 @@ static std::vector<int> extractIntList(const bp::list& pyList, int expectedSize,
 
 class NativeMMFFBatchedForcefield {
  public:
-  NativeMMFFBatchedForcefield(const bp::list& molecules,
-                              const bp::list& properties,
-                              const bp::list& confIds) {
+  NativeMMFFBatchedForcefield(const bp::list& molecules, const bp::list& properties, const bp::list& confIds) {
     const auto mols     = extractMolecules(molecules);
     const int  numMols  = static_cast<int>(mols.size());
     const auto props    = extractMMFFPropertiesList(properties, numMols);
@@ -130,9 +142,8 @@ class NativeMMFFBatchedForcefield {
     for (int molIdx = 0; molIdx < numMols; ++molIdx) {
       std::vector<double> positions;
       nvMolKit::confPosToVect(*mols[molIdx], positions, confList[molIdx]);
-      auto ffParams =
-        nvMolKit::MMFF::constructForcefieldContribs(*mols[molIdx], props[molIdx], confList[molIdx]);
-      nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost_, metadata_, molIdx, 0);
+      auto ffParams = nvMolKit::MMFF::constructForcefieldContribs(*mols[molIdx], props[molIdx], confList[molIdx]);
+      nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost_, &metadata_, molIdx, 0);
     }
     forcefield_ = std::make_unique<nvMolKit::MMFFBatchedForcefield>(systemHost_, metadata_);
     positionsDevice_.setFromVector(systemHost_.positions);
@@ -149,17 +160,16 @@ class NativeMMFFBatchedForcefield {
   bp::list computeGradients() {
     gradDevice_.zero();
     throwIfCudaError(forcefield_->computeGradients(gradDevice_.data(), positionsDevice_.data()), "computeGradients");
-    return vectorOfVectorsToList(
-      nvMolKit::splitGradients(copyDeviceVector(gradDevice_), systemHost_.indices.atomStarts, 3));
+    return vectorOfVectorsToList(splitGradients(copyDeviceVector(gradDevice_), systemHost_.indices.atomStarts, 3));
   }
 
  private:
   nvMolKit::MMFF::BatchedMolecularSystemHost       systemHost_;
-  nvMolKit::BatchedForcefieldMetadata               metadata_;
-  std::unique_ptr<nvMolKit::MMFFBatchedForcefield>  forcefield_;
-  nvMolKit::AsyncDeviceVector<double>               positionsDevice_;
-  nvMolKit::AsyncDeviceVector<double>               gradDevice_;
-  nvMolKit::AsyncDeviceVector<double>               energyOutsDevice_;
+  nvMolKit::BatchedForcefieldMetadata              metadata_;
+  std::unique_ptr<nvMolKit::MMFFBatchedForcefield> forcefield_;
+  nvMolKit::AsyncDeviceVector<double>              positionsDevice_;
+  nvMolKit::AsyncDeviceVector<double>              gradDevice_;
+  nvMolKit::AsyncDeviceVector<double>              energyOutsDevice_;
 };
 
 static bp::list computeMMFFEnergies(const bp::list& molecules, const double nonBondedThreshold) {
@@ -173,7 +183,7 @@ static bp::list computeMMFFEnergies(const bp::list& molecules, const double nonB
     std::vector<double> positions;
     nvMolKit::confPosToVect(*mols[i], positions);
     auto ffParams = nvMolKit::MMFF::constructForcefieldContribs(*mols[i], props);
-    nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost, metadata, i, 0);
+    nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost, &metadata, i, 0);
   }
 
   nvMolKit::MMFFBatchedForcefield     forcefield(systemHost, metadata);
@@ -197,7 +207,7 @@ static bp::list computeMMFFGradients(const bp::list& molecules, const double non
     std::vector<double> positions;
     nvMolKit::confPosToVect(*mols[i], positions);
     auto ffParams = nvMolKit::MMFF::constructForcefieldContribs(*mols[i], props);
-    nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost, metadata, i, 0);
+    nvMolKit::MMFF::addMoleculeToBatch(ffParams, positions, systemHost, &metadata, i, 0);
   }
 
   nvMolKit::MMFFBatchedForcefield     forcefield(systemHost, metadata);
@@ -207,32 +217,30 @@ static bp::list computeMMFFGradients(const bp::list& molecules, const double non
   gradDevice.resize(systemHost.positions.size());
   gradDevice.zero();
   throwIfCudaError(forcefield.computeGradients(gradDevice.data(), positionsDevice.data()), "MMFFComputeGradients");
-  return vectorOfVectorsToList(
-    nvMolKit::splitGradients(copyDeviceVector(gradDevice), systemHost.indices.atomStarts, 3));
+  return vectorOfVectorsToList(splitGradients(copyDeviceVector(gradDevice), systemHost.indices.atomStarts, 3));
 }
 
 BOOST_PYTHON_MODULE(_batchedForcefield) {
   bp::class_<nvMolKit::MMFFProperties>("MMFFProperties")
-    .def_readwrite("variant",                     &nvMolKit::MMFFProperties::variant)
-    .def_readwrite("dielectricConstant",          &nvMolKit::MMFFProperties::dielectricConstant)
-    .def_readwrite("dielectricModel",             &nvMolKit::MMFFProperties::dielectricModel)
-    .def_readwrite("nonBondedThreshold",          &nvMolKit::MMFFProperties::nonBondedThreshold)
+    .def_readwrite("variant", &nvMolKit::MMFFProperties::variant)
+    .def_readwrite("dielectricConstant", &nvMolKit::MMFFProperties::dielectricConstant)
+    .def_readwrite("dielectricModel", &nvMolKit::MMFFProperties::dielectricModel)
+    .def_readwrite("nonBondedThreshold", &nvMolKit::MMFFProperties::nonBondedThreshold)
     .def_readwrite("ignoreInterfragInteractions", &nvMolKit::MMFFProperties::ignoreInterfragInteractions)
-    .def_readwrite("bondTerm",                    &nvMolKit::MMFFProperties::bondTerm)
-    .def_readwrite("angleTerm",                   &nvMolKit::MMFFProperties::angleTerm)
-    .def_readwrite("stretchBendTerm",             &nvMolKit::MMFFProperties::stretchBendTerm)
-    .def_readwrite("oopTerm",                     &nvMolKit::MMFFProperties::oopTerm)
-    .def_readwrite("torsionTerm",                 &nvMolKit::MMFFProperties::torsionTerm)
-    .def_readwrite("vdwTerm",                     &nvMolKit::MMFFProperties::vdwTerm)
-    .def_readwrite("eleTerm",                     &nvMolKit::MMFFProperties::eleTerm);
+    .def_readwrite("bondTerm", &nvMolKit::MMFFProperties::bondTerm)
+    .def_readwrite("angleTerm", &nvMolKit::MMFFProperties::angleTerm)
+    .def_readwrite("stretchBendTerm", &nvMolKit::MMFFProperties::stretchBendTerm)
+    .def_readwrite("oopTerm", &nvMolKit::MMFFProperties::oopTerm)
+    .def_readwrite("torsionTerm", &nvMolKit::MMFFProperties::torsionTerm)
+    .def_readwrite("vdwTerm", &nvMolKit::MMFFProperties::vdwTerm)
+    .def_readwrite("eleTerm", &nvMolKit::MMFFProperties::eleTerm);
 
-  bp::class_<NativeMMFFBatchedForcefield, boost::noncopyable>("NativeMMFFBatchedForcefield",
-                                                            bp::init<const bp::list&, const bp::list&, const bp::list&>())
-    .def("computeEnergy",    &NativeMMFFBatchedForcefield::computeEnergy)
+  bp::class_<NativeMMFFBatchedForcefield, boost::noncopyable>(
+    "NativeMMFFBatchedForcefield",
+    bp::init<const bp::list&, const bp::list&, const bp::list&>())
+    .def("computeEnergy", &NativeMMFFBatchedForcefield::computeEnergy)
     .def("computeGradients", &NativeMMFFBatchedForcefield::computeGradients);
 
-  bp::def("MMFFComputeEnergies",  computeMMFFEnergies,
-          (bp::arg("molecules"), bp::arg("nonBondedThreshold") = 100.0));
-  bp::def("MMFFComputeGradients", computeMMFFGradients,
-          (bp::arg("molecules"), bp::arg("nonBondedThreshold") = 100.0));
+  bp::def("MMFFComputeEnergies", computeMMFFEnergies, (bp::arg("molecules"), bp::arg("nonBondedThreshold") = 100.0));
+  bp::def("MMFFComputeGradients", computeMMFFGradients, (bp::arg("molecules"), bp::arg("nonBondedThreshold") = 100.0));
 }

--- a/nvmolkit/batchedForcefield.py
+++ b/nvmolkit/batchedForcefield.py
@@ -1,4 +1,13 @@
-"""Python API for batched forcefield energy and gradient evaluation."""
+"""Python API for batched forcefield energy and gradient evaluation.
+
+.. note::
+   Calling :meth:`~MMFFBatchedForcefield.compute_energy` or
+   :meth:`~MMFFBatchedForcefield.compute_gradients` individually from Python
+   incurs per-call overhead that dominates the GPU computation time.
+   Acceleration over RDKit should only be expected when these evaluations run
+   inside the minimizer, where the native loop avoids repeated Python
+   round-trips.
+"""
 
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -111,14 +120,22 @@ class MMFFBatchedForcefield:
             self._build()
 
     def compute_energy(self) -> list[float]:
-        """Compute one MMFF energy value per molecule in the batch."""
+        """Compute one MMFF energy value per molecule in the batch.
+
+        Note: Per-call Python overhead makes standalone calls slower than
+        expected.  Prefer the minimizer for performance-sensitive workloads.
+        """
         if not self._molecules:
             return []
         self._ensure_built()
         return self._native_ff.computeEnergy()
 
     def compute_gradients(self) -> list[list[float]]:
-        """Compute one flattened 3D gradient vector per molecule in the batch."""
+        """Compute one flattened 3D gradient vector per molecule in the batch.
+
+        Note: Per-call Python overhead makes standalone calls slower than
+        expected.  Prefer the minimizer for performance-sensitive workloads.
+        """
         if not self._molecules:
             return []
         self._ensure_built()

--- a/nvmolkit/batchedForcefield.py
+++ b/nvmolkit/batchedForcefield.py
@@ -1,0 +1,125 @@
+"""Python API for batched forcefield energy and gradient evaluation."""
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from nvmolkit import _batchedForcefield  # type: ignore
+from nvmolkit._mmff_bridge import default_rdkit_mmff_properties, make_internal_mmff_properties
+
+if TYPE_CHECKING:
+    from rdkit.Chem import Mol
+    from rdkit.ForceField.rdForceField import MMFFMolProperties as RDKitMMFFMolProperties
+
+
+class MMFFBatchedForcefield:
+    """Evaluate MMFF energies and gradients for a batch of molecules."""
+
+    def __init__(
+        self,
+        molecules: list["Mol"],
+        properties: "RDKitMMFFMolProperties | Sequence[RDKitMMFFMolProperties | None] | None" = None,
+        conf_id: int | Sequence[int] = -1,
+        nonBondedThreshold: float | Sequence[float] = 100.0,
+        ignoreInterfragInteractions: bool | Sequence[bool] = True,
+    ):
+        """Create a batched MMFF forcefield wrapper.
+
+        Args:
+            molecules: Molecules to evaluate.
+            properties: RDKit ``MMFFMolProperties`` object, a per-molecule list
+                of those objects, or ``None`` to use default MMFF94 settings.
+            conf_id: Conformer id or per-molecule conformer ids to use.
+            nonBondedThreshold: Non-bonded cutoff distance or per-molecule values.
+            ignoreInterfragInteractions: Whether to omit interfragment non-bonded
+                interactions, as a scalar or per-molecule list.
+        """
+        self._molecules = molecules
+        self._properties = self._normalize_properties(properties)
+        self._conf_ids = self._normalize_conf_ids(conf_id)
+        self._non_bonded_thresholds = self._normalize_scalar_or_list(
+            nonBondedThreshold, "nonBondedThreshold"
+        )
+        self._ignore_interfrag_interactions = self._normalize_scalar_or_list(
+            ignoreInterfragInteractions, "ignoreInterfragInteractions"
+        )
+        self._native_ff = None
+        self.num_molecules = len(molecules)
+        self.data_dim = 3
+
+    def __len__(self) -> int:
+        """Return the number of molecules in the batch."""
+        return len(self._molecules)
+
+    def _normalize_properties(
+        self, properties: "RDKitMMFFMolProperties | Sequence[RDKitMMFFMolProperties | None] | None"
+    ) -> list["RDKitMMFFMolProperties | None"]:
+        if properties is None:
+            return [None for _ in self._molecules]
+        if isinstance(properties, Sequence) and not hasattr(properties, "SetMMFFVariant"):
+            if len(properties) != len(self._molecules):
+                raise ValueError(
+                    f"Expected {len(self._molecules)} MMFFMolProperties objects, got {len(properties)}"
+                )
+            return list(properties)
+        return [properties for _ in self._molecules]
+
+    def _normalize_scalar_or_list(self, value, name: str):
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            if len(value) != len(self._molecules):
+                raise ValueError(f"Expected {len(self._molecules)} values for {name}, got {len(value)}")
+            return list(value)
+        return [value for _ in self._molecules]
+
+    def _normalize_conf_ids(self, conf_id: int | Sequence[int]) -> list[int]:
+        if isinstance(conf_id, int):
+            return [conf_id for _ in self._molecules]
+        if len(conf_id) != len(self._molecules):
+            raise ValueError(f"Expected {len(self._molecules)} conf_id values, got {len(conf_id)}")
+        return list(conf_id)
+
+    def _copy_mmff_properties(self, mol: "Mol", properties, non_bonded_threshold: float, ignore_interfrag_interactions: bool):
+        """Convert public RDKit MMFF properties into nvMolKit's internal transport."""
+        source = default_rdkit_mmff_properties(mol) if properties is None else properties
+        return make_internal_mmff_properties(
+            source,
+            non_bonded_threshold=float(non_bonded_threshold),
+            ignore_interfrag_interactions=bool(ignore_interfrag_interactions),
+        )
+
+    def _build(self) -> None:
+        """Build the native batched forcefield from the current state."""
+        if not self._molecules:
+            self._native_ff = None
+            return
+        native_properties = [
+            self._copy_mmff_properties(mol, props, threshold, ignore)
+            for mol, props, threshold, ignore in zip(
+                self._molecules,
+                self._properties,
+                self._non_bonded_thresholds,
+                self._ignore_interfrag_interactions,
+            )
+        ]
+        self._native_ff = _batchedForcefield.NativeMMFFBatchedForcefield(
+            self._molecules,
+            native_properties,
+            self._conf_ids,
+        )
+
+    def _ensure_built(self) -> None:
+        if self._native_ff is None:
+            self._build()
+
+    def compute_energy(self) -> list[float]:
+        """Compute one MMFF energy value per molecule in the batch."""
+        if not self._molecules:
+            return []
+        self._ensure_built()
+        return self._native_ff.computeEnergy()
+
+    def compute_gradients(self) -> list[list[float]]:
+        """Compute one flattened 3D gradient vector per molecule in the batch."""
+        if not self._molecules:
+            return []
+        self._ensure_built()
+        return self._native_ff.computeGradients()

--- a/nvmolkit/tests/test_batched_forcefield.py
+++ b/nvmolkit/tests/test_batched_forcefield.py
@@ -1,0 +1,258 @@
+import os
+
+import pytest
+from rdkit import Chem
+from rdkit.Chem import rdDistGeom, rdForceFieldHelpers
+from rdkit.ForceField import rdForceField as _rdForceField  # noqa: F401
+from rdkit.Geometry import Point3D
+
+from nvmolkit._mmff_bridge import capture_mmff_settings
+from nvmolkit.batchedForcefield import MMFFBatchedForcefield
+
+
+def load_reference_mol():
+    mol2_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "tests",
+        "test_data",
+        "rdkit_smallmol_1.mol2",
+    )
+    if not os.path.exists(mol2_path):
+        pytest.skip(f"Test data file not found: {mol2_path}")
+    mol = Chem.MolFromMol2File(mol2_path, sanitize=False, removeHs=False)
+    if mol is None:
+        pytest.skip("Failed to load rdkit_smallmol_1.mol2")
+    Chem.SanitizeMol(mol)
+    return mol
+
+
+def make_embedded_mol(smiles: str, num_confs: int = 1, seed: int = 0xC0FFEE):
+    mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
+    params = rdDistGeom.ETKDGv3()
+    params.randomSeed = seed
+    params.useRandomCoords = True
+    rdDistGeom.EmbedMultipleConfs(mol, numConfs=num_confs, params=params)
+    return mol
+
+
+def make_fragmented_mol():
+    mol = make_embedded_mol("CC.CC")
+    conf = mol.GetConformer()
+    fragments = Chem.GetMolFrags(mol)
+    if len(fragments) != 2:
+        raise AssertionError("Expected two fragments for interfragment interaction test")
+    anchor = conf.GetAtomPosition(fragments[0][0])
+    moved = conf.GetAtomPosition(fragments[1][0])
+    shift = Point3D(anchor.x - moved.x + 2.0, anchor.y - moved.y, anchor.z - moved.z)
+    for atom_idx in fragments[1]:
+        pos = conf.GetAtomPosition(atom_idx)
+        conf.SetAtomPosition(atom_idx, Point3D(pos.x + shift.x, pos.y + shift.y, pos.z + shift.z))
+    return mol
+
+
+def clone_mols(molecules):
+    return [Chem.Mol(mol) for mol in molecules]
+
+
+def make_rdkit_mmff_properties(mol, settings: dict | None = None):
+    settings = {} if settings is None else settings
+    variant = settings.get("variant", "MMFF94")
+    mmff_props = rdForceFieldHelpers.MMFFGetMoleculeProperties(mol, mmffVariant=variant)
+    if mmff_props is None:
+        raise ValueError("RDKit could not create MMFF properties for molecule")
+    mmff_props.SetMMFFVariant(variant)
+    mmff_props.SetMMFFDielectricConstant(settings.get("dielectric_constant", 1.0))
+    mmff_props.SetMMFFDielectricModel(settings.get("dielectric_model", 1))
+    mmff_props.SetMMFFBondTerm(settings.get("bond_term", True))
+    mmff_props.SetMMFFAngleTerm(settings.get("angle_term", True))
+    mmff_props.SetMMFFStretchBendTerm(settings.get("stretch_bend_term", True))
+    mmff_props.SetMMFFOopTerm(settings.get("oop_term", True))
+    mmff_props.SetMMFFTorsionTerm(settings.get("torsion_term", True))
+    mmff_props.SetMMFFVdWTerm(settings.get("vdw_term", True))
+    mmff_props.SetMMFFEleTerm(settings.get("ele_term", True))
+    return capture_mmff_settings(mmff_props, settings)
+
+
+def make_rdkit_mmff_forcefield(
+    mol,
+    properties=None,
+    conf_id: int = -1,
+    nonBondedThreshold: float = 100.0,
+    ignoreInterfragInteractions: bool = True,
+):
+    mmff_props = make_rdkit_mmff_properties(mol) if properties is None else properties
+    return rdForceFieldHelpers.MMFFGetMoleculeForceField(
+        mol,
+        mmff_props,
+        nonBondedThresh=nonBondedThreshold,
+        confId=conf_id,
+        ignoreInterfragInteractions=ignoreInterfragInteractions,
+    )
+
+
+def get_mmff_reference_energy_and_grad(
+    mol,
+    properties=None,
+    conf_id: int = -1,
+    nonBondedThreshold: float = 100.0,
+    ignoreInterfragInteractions: bool = True,
+):
+    ff = make_rdkit_mmff_forcefield(
+        mol,
+        properties=properties,
+        conf_id=conf_id,
+        nonBondedThreshold=nonBondedThreshold,
+        ignoreInterfragInteractions=ignoreInterfragInteractions,
+    )
+    return ff.CalcEnergy(), list(ff.CalcGrad())
+
+
+def assert_energy_and_gradient_close(got_energy, want_energy, got_grad, want_grad):
+    assert got_energy == pytest.approx(want_energy, rel=1e-5, abs=1e-5)
+    assert got_grad == pytest.approx(want_grad, rel=1e-4, abs=1e-4)
+
+
+def assert_single_batched_matches_rdkit(
+    mol,
+    properties=None,
+    conf_id: int = -1,
+    nonBondedThreshold: float = 100.0,
+    ignoreInterfragInteractions: bool = True,
+):
+    nvmolkit_mol = Chem.Mol(mol)
+    ff = MMFFBatchedForcefield(
+        [nvmolkit_mol],
+        properties=properties,
+        conf_id=conf_id,
+        nonBondedThreshold=nonBondedThreshold,
+        ignoreInterfragInteractions=ignoreInterfragInteractions,
+    )
+    got_energy = ff.compute_energy()[0]
+    got_grad = ff.compute_gradients()[0]
+    want_energy, want_grad = get_mmff_reference_energy_and_grad(
+        Chem.Mol(mol),
+        properties=properties,
+        conf_id=conf_id,
+        nonBondedThreshold=nonBondedThreshold,
+        ignoreInterfragInteractions=ignoreInterfragInteractions,
+    )
+    assert_energy_and_gradient_close(got_energy, want_energy, got_grad, want_grad)
+
+
+def test_mmff_batched_forcefield_matches_rdkit():
+    assert_single_batched_matches_rdkit(load_reference_mol())
+
+
+def test_mmff_batched_forcefield_batch_matches_single():
+    mols = [load_reference_mol(), load_reference_mol()]
+
+    batch_ff = MMFFBatchedForcefield(clone_mols(mols))
+    batch_energies = batch_ff.compute_energy()
+    batch_grads = batch_ff.compute_gradients()
+
+    single_energies = []
+    single_grads = []
+    for mol in clone_mols(mols):
+        single_ff = MMFFBatchedForcefield([mol])
+        single_energies.append(single_ff.compute_energy()[0])
+        single_grads.append(single_ff.compute_gradients()[0])
+
+    assert batch_energies == pytest.approx(single_energies, rel=1e-5, abs=1e-5)
+    for got_grad, want_grad in zip(batch_grads, single_grads):
+        assert got_grad == pytest.approx(want_grad, rel=1e-4, abs=1e-4)
+
+
+@pytest.mark.parametrize(
+    ("mol_factory", "property_settings", "non_bonded_threshold", "ignore_interfrag_interactions"),
+    [
+        pytest.param(
+            lambda: make_embedded_mol("CC(=O)NC"),
+            {"variant": "MMFF94s"},
+            100.0,
+            True,
+            id="variant-mmff94s",
+        ),
+        pytest.param(
+            load_reference_mol,
+            {"dielectric_constant": 2.5, "dielectric_model": 2},
+            100.0,
+            True,
+            id="dielectric-settings",
+        ),
+        pytest.param(
+            load_reference_mol,
+            {
+                "bond_term": False,
+                "angle_term": False,
+                "stretch_bend_term": False,
+                "oop_term": False,
+                "torsion_term": False,
+            },
+            100.0,
+            True,
+            id="term-toggles",
+        ),
+        pytest.param(
+            make_fragmented_mol,
+            None,
+            25.0,
+            False,
+            id="interfragment-interactions",
+        ),
+    ],
+)
+def test_mmff_batched_forcefield_properties_match_rdkit(
+    mol_factory, property_settings, non_bonded_threshold, ignore_interfrag_interactions
+):
+    mol = mol_factory()
+    properties = None if property_settings is None else make_rdkit_mmff_properties(mol, property_settings)
+    assert_single_batched_matches_rdkit(
+        mol,
+        properties=properties,
+        nonBondedThreshold=non_bonded_threshold,
+        ignoreInterfragInteractions=ignore_interfrag_interactions,
+    )
+
+
+def test_mmff_batched_forcefield_per_molecule_properties_match_rdkit():
+    mols = [make_embedded_mol("CCO"), make_fragmented_mol()]
+    properties = [
+        make_rdkit_mmff_properties(mols[0], {"dielectric_constant": 3.0, "dielectric_model": 2}),
+        make_rdkit_mmff_properties(mols[1]),
+    ]
+    non_bonded_thresholds = [100.0, 20.0]
+    ignore_interfrag_interactions = [True, False]
+
+    ff = MMFFBatchedForcefield(
+        clone_mols(mols),
+        properties=properties,
+        nonBondedThreshold=non_bonded_thresholds,
+        ignoreInterfragInteractions=ignore_interfrag_interactions,
+    )
+    got_energies = ff.compute_energy()
+    got_grads = ff.compute_gradients()
+
+    for idx, (mol, prop) in enumerate(zip(mols, properties)):
+        want_energy, want_grad = get_mmff_reference_energy_and_grad(
+            Chem.Mol(mol),
+            properties=prop,
+            nonBondedThreshold=non_bonded_thresholds[idx],
+            ignoreInterfragInteractions=ignore_interfrag_interactions[idx],
+        )
+        assert_energy_and_gradient_close(got_energies[idx], want_energy, got_grads[idx], want_grad)
+
+
+def test_mmff_batched_forcefield_conf_ids_match_rdkit():
+    mol = make_embedded_mol("CCCO", num_confs=2)
+    ff = MMFFBatchedForcefield([Chem.Mol(mol), Chem.Mol(mol)], conf_id=[0, 1])
+
+    got_energies = ff.compute_energy()
+    got_grads = ff.compute_gradients()
+
+    for idx, conf_id in enumerate([0, 1]):
+        want_energy, want_grad = get_mmff_reference_energy_and_grad(Chem.Mol(mol), conf_id=conf_id)
+        assert_energy_and_gradient_close(got_energies[idx], want_energy, got_grads[idx], want_grad)
+
+


### PR DESCRIPTION
    Add Python bindings for MMFF batched forcefield energy and gradient
    computation via Boost.Python. Includes property bridge from RDKit
    MMFFMolProperties to internal MMFFProperties transport.
    
    - NativeMMFFBatchedForcefield C++ binding with compute_energy/compute_gradients
    - MMFFBatchedForcefield Python wrapper with per-molecule properties, conf_id,
      nonBondedThreshold, and ignoreInterfragInteractions support
    - _mmff_bridge module for RDKit MMFFMolProperties to native conversion
    - MMFFComputeEnergies/MMFFComputeGradients convenience functions
    - Tests for single-mol, batched, property variants, per-molecule properties,
      and conformer id selection vs RDKit reference
