### PR TITLE
Add UFF forcefield C++ implementation

### DIFF
--- a/rdkit_extensions/CMakeLists.txt
+++ b/rdkit_extensions/CMakeLists.txt
@@ -21,6 +21,14 @@ target_link_libraries(
 target_include_directories(rdkit_mmff_flattened
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(rdkit_uff_flattened uff_flattened_builder.cpp)
+target_link_libraries(
+  rdkit_uff_flattened
+  PRIVATE ${RDKit_LIBS} device_vector
+  PUBLIC uff)
+target_include_directories(rdkit_uff_flattened
+                           PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(mmff_contribs mmff_contribs.cpp)
 target_link_libraries(
   mmff_contribs

--- a/rdkit_extensions/uff_flattened_builder.cpp
+++ b/rdkit_extensions/uff_flattened_builder.cpp
@@ -1,0 +1,560 @@
+#include "uff_flattened_builder.h"
+
+#include <ForceField/UFF/AngleBend.h>
+#include <ForceField/UFF/BondStretch.h>
+#include <ForceField/UFF/Nonbonded.h>
+#include <ForceField/UFF/Params.h>
+#include <ForceField/UFF/TorsionAngle.h>
+#include <ForceField/UFF/Utils.h>
+#include <GraphMol/Atom.h>
+#include <GraphMol/ForceFieldHelpers/UFF/AtomTyper.h>
+#include <GraphMol/ForceFieldHelpers/UFF/Builder.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/ROMol.h>
+#include <GraphMol/Substruct/SubstructMatch.h>
+#include <RDGeneral/Invariant.h>
+
+#include <cmath>
+#include <tuple>
+#include <vector>
+
+namespace RDKit {
+namespace UFF {
+using namespace ForceFields::UFF;
+
+namespace Tools {
+
+namespace {
+void addAngleTerm(nvMolKit::UFF::EnergyForceContribsHost& contribs,
+                  const unsigned int                      idx1,
+                  const unsigned int                      idx2,
+                  const unsigned int                      idx3,
+                  const double                            bondOrder12,
+                  const double                            bondOrder23,
+                  const AtomicParams*                     at1Params,
+                  const AtomicParams*                     at2Params,
+                  const AtomicParams*                     at3Params,
+                  unsigned int                            order) {
+  double theta0 = at2Params->theta0;
+  if (order >= 30) {
+    switch (order) {
+      case 30:
+        theta0 = 150.0 / 180.0 * M_PI;
+        break;
+      case 35:
+        theta0 = 60.0 / 180.0 * M_PI;
+        break;
+      case 40:
+        theta0 = 135.0 / 180.0 * M_PI;
+        break;
+      case 45:
+        theta0 = 90.0 / 180.0 * M_PI;
+        break;
+      default:
+        break;
+    }
+    order = 0;
+  }
+
+  const double forceConstant =
+    ForceFields::UFF::Utils::calcAngleForceConstant(theta0, bondOrder12, bondOrder23, at1Params, at2Params, at3Params);
+  double C0 = 0.0;
+  double C1 = 0.0;
+  double C2 = 0.0;
+  if (order == 0) {
+    const double sinTheta0 = std::sin(theta0);
+    const double cosTheta0 = std::cos(theta0);
+    C2                    = 1.0 / (4.0 * std::max(sinTheta0 * sinTheta0, 1.0e-8));
+    C1                    = -4.0 * C2 * cosTheta0;
+    C0                    = C2 * (2.0 * cosTheta0 * cosTheta0 + 1.0);
+  }
+
+  auto& terms = contribs.angleTerms;
+  terms.idx1.push_back(static_cast<int>(idx1));
+  terms.idx2.push_back(static_cast<int>(idx2));
+  terms.idx3.push_back(static_cast<int>(idx3));
+  terms.theta0.push_back(theta0);
+  terms.forceConstant.push_back(forceConstant);
+  terms.order.push_back(static_cast<std::uint8_t>(order));
+  terms.C0.push_back(C0);
+  terms.C1.push_back(C1);
+  terms.C2.push_back(C2);
+}
+
+std::tuple<double, std::uint8_t, double> calcTorsionParams(const double              bondOrder23,
+                                                           const int                 atNum2,
+                                                           const int                 atNum3,
+                                                           RDKit::Atom::HybridizationType hyb2,
+                                                           RDKit::Atom::HybridizationType hyb3,
+                                                           const AtomicParams*       at2Params,
+                                                           const AtomicParams*       at3Params,
+                                                           const bool                endAtomIsSP2) {
+  PRECONDITION((hyb2 == RDKit::Atom::SP2 || hyb2 == RDKit::Atom::SP3) &&
+                   (hyb3 == RDKit::Atom::SP2 || hyb3 == RDKit::Atom::SP3),
+               "bad hybridizations");
+
+  if (hyb2 == RDKit::Atom::SP3 && hyb3 == RDKit::Atom::SP3) {
+    double       forceConstant = std::sqrt(at2Params->V1 * at3Params->V1);
+    std::uint8_t order         = 3;
+    double       cosTerm       = -1.0;
+
+    if (bondOrder23 == 1.0 && ForceFields::UFF::Utils::isInGroup6(atNum2) &&
+        ForceFields::UFF::Utils::isInGroup6(atNum3)) {
+      double V2 = 6.8;
+      double V3 = 6.8;
+      if (atNum2 == 8) {
+        V2 = 2.0;
+      }
+      if (atNum3 == 8) {
+        V3 = 2.0;
+      }
+      forceConstant = std::sqrt(V2 * V3);
+      order         = 2;
+      cosTerm       = -1.0;
+    }
+    return {forceConstant, order, cosTerm};
+  }
+
+  if (hyb2 == RDKit::Atom::SP2 && hyb3 == RDKit::Atom::SP2) {
+    return {ForceFields::UFF::Utils::equation17(bondOrder23, at2Params, at3Params), 2, 1.0};
+  }
+
+  double       forceConstant = 1.0;
+  std::uint8_t order         = 6;
+  double       cosTerm       = 1.0;
+  if (bondOrder23 == 1.0) {
+    if ((hyb2 == RDKit::Atom::SP3 && ForceFields::UFF::Utils::isInGroup6(atNum2) &&
+         !ForceFields::UFF::Utils::isInGroup6(atNum3)) ||
+        (hyb3 == RDKit::Atom::SP3 && ForceFields::UFF::Utils::isInGroup6(atNum3) &&
+         !ForceFields::UFF::Utils::isInGroup6(atNum2))) {
+      forceConstant = ForceFields::UFF::Utils::equation17(bondOrder23, at2Params, at3Params);
+      order         = 2;
+      cosTerm       = -1.0;
+    } else if (endAtomIsSP2) {
+      forceConstant = 2.0;
+      order         = 3;
+      cosTerm       = -1.0;
+    }
+  }
+  return {forceConstant, order, cosTerm};
+}
+}  // namespace
+
+void addBonds(const ROMol& mol, const AtomicParamVect& params, nvMolKit::UFF::EnergyForceContribsHost& contribs) {
+  PRECONDITION(mol.getNumAtoms() == params.size(), "bad parameters");
+  for (ROMol::ConstBondIterator bi = mol.beginBonds(); bi != mol.endBonds(); ++bi) {
+    const unsigned int idx1 = (*bi)->getBeginAtomIdx();
+    const unsigned int idx2 = (*bi)->getEndAtomIdx();
+    if (!params[idx1] || !params[idx2]) {
+      continue;
+    }
+    const double bondOrder = (*bi)->getBondTypeAsDouble();
+    auto&        terms     = contribs.bondTerms;
+    terms.idx1.push_back(static_cast<int>(idx1));
+    terms.idx2.push_back(static_cast<int>(idx2));
+    terms.restLen.push_back(ForceFields::UFF::Utils::calcBondRestLength(bondOrder, params[idx1], params[idx2]));
+    terms.forceConstant.push_back(
+      ForceFields::UFF::Utils::calcBondForceConstant(terms.restLen.back(), params[idx1], params[idx2]));
+  }
+}
+
+void addAngles(const ROMol& mol, const AtomicParamVect& params, nvMolKit::UFF::EnergyForceContribsHost& contribs) {
+  PRECONDITION(mol.getNumAtoms() == params.size(), "bad parameters");
+  RingInfo* ringInfo = mol.getRingInfo();
+  for (unsigned int j = 0; j < mol.getNumAtoms(); ++j) {
+    if (!params[j]) {
+      continue;
+    }
+    const Atom* atomJ = mol.getAtomWithIdx(j);
+    if (atomJ->getDegree() == 1) {
+      continue;
+    }
+    ROMol::ADJ_ITER nbr1Idx, end1Nbrs, nbr2Idx, end2Nbrs;
+    boost::tie(nbr1Idx, end1Nbrs) = mol.getAtomNeighbors(atomJ);
+    for (; nbr1Idx != end1Nbrs; ++nbr1Idx) {
+      const Atom* atomI = mol[*nbr1Idx];
+      const auto  i     = atomI->getIdx();
+      if (!params[i]) {
+        continue;
+      }
+      boost::tie(nbr2Idx, end2Nbrs) = mol.getAtomNeighbors(atomJ);
+      for (; nbr2Idx != end2Nbrs; ++nbr2Idx) {
+        if (nbr2Idx < (nbr1Idx + 1)) {
+          continue;
+        }
+        const Atom* atomK = mol[*nbr2Idx];
+        const auto  k     = atomK->getIdx();
+        if (!params[k]) {
+          continue;
+        }
+        if (atomJ->getHybridization() == Atom::SP3D && atomJ->getDegree() == 5) {
+          continue;
+        }
+
+        unsigned int order = 0;
+        switch (atomJ->getHybridization()) {
+          case Atom::SP:
+            order = 1;
+            break;
+          case Atom::SP2:
+            order = 3;
+            if (ringInfo->isAtomInRingOfSize(j, 3)) {
+              if (ringInfo->isAtomInRingOfSize(i, 3) != ringInfo->isAtomInRingOfSize(k, 3)) {
+                order = 30;
+              } else if (ringInfo->isAtomInRingOfSize(i, 3) && ringInfo->isAtomInRingOfSize(k, 3)) {
+                order = 35;
+              }
+            } else if (ringInfo->isAtomInRingOfSize(j, 4)) {
+              if (ringInfo->isAtomInRingOfSize(i, 4) != ringInfo->isAtomInRingOfSize(k, 4)) {
+                order = 40;
+              } else if (ringInfo->isAtomInRingOfSize(i, 4) && ringInfo->isAtomInRingOfSize(k, 4)) {
+                order = 45;
+              }
+            }
+            break;
+          case Atom::SP3D2:
+            order = 4;
+            break;
+          default:
+            break;
+        }
+
+        const Bond* b1 = mol.getBondBetweenAtoms(i, j);
+        const Bond* b2 = mol.getBondBetweenAtoms(k, j);
+        addAngleTerm(
+          contribs, i, j, k, b1->getBondTypeAsDouble(), b2->getBondTypeAsDouble(), params[i], params[j], params[k], order);
+      }
+    }
+  }
+}
+
+void addTrigonalBipyramidAngles(const Atom* atom,
+                                const ROMol& mol,
+                                const int confId,
+                                const AtomicParamVect& params,
+                                nvMolKit::UFF::EnergyForceContribsHost& contribs) {
+  PRECONDITION(atom, "bad atom");
+  PRECONDITION(atom->getHybridization() == Atom::SP3D, "bad hybridization");
+  PRECONDITION(atom->getDegree() == 5, "bad degree");
+
+  const Conformer& conf = mol.getConformer(confId);
+  const Bond *ax1 = nullptr, *ax2 = nullptr, *eq1 = nullptr, *eq2 = nullptr, *eq3 = nullptr;
+  double mostNeg = 100.0;
+  const unsigned int atomIdx = atom->getIdx();
+
+  ROMol::OEDGE_ITER beg1, end1;
+  boost::tie(beg1, end1) = mol.getAtomBonds(atom);
+  while (beg1 != end1) {
+    const Bond* bond1 = mol[*beg1];
+    const unsigned int other1 = bond1->getOtherAtomIdx(atomIdx);
+    const auto v1 = conf.getAtomPos(atomIdx).directionVector(conf.getAtomPos(other1));
+    ROMol::OEDGE_ITER beg2, end2;
+    boost::tie(beg2, end2) = mol.getAtomBonds(atom);
+    while (beg2 != end2) {
+      const Bond* bond2 = mol[*beg2];
+      if (bond2->getIdx() > bond1->getIdx()) {
+        const unsigned int other2 = bond2->getOtherAtomIdx(atomIdx);
+        const auto v2 = conf.getAtomPos(atomIdx).directionVector(conf.getAtomPos(other2));
+        const double dot = v1.dotProduct(v2);
+        if (dot < mostNeg) {
+          mostNeg = dot;
+          ax1     = bond1;
+          ax2     = bond2;
+        }
+      }
+      ++beg2;
+    }
+    ++beg1;
+  }
+  CHECK_INVARIANT(ax1, "axial bond not found");
+  CHECK_INVARIANT(ax2, "axial bond not found");
+
+  boost::tie(beg1, end1) = mol.getAtomBonds(atom);
+  while (beg1 != end1) {
+    const Bond* bond = mol[*beg1];
+    ++beg1;
+    if (bond == ax1 || bond == ax2) {
+      continue;
+    }
+    if (!eq1) {
+      eq1 = bond;
+    } else if (!eq2) {
+      eq2 = bond;
+    } else {
+      eq3 = bond;
+    }
+  }
+
+  CHECK_INVARIANT(eq1, "equatorial bond not found");
+  CHECK_INVARIANT(eq2, "equatorial bond not found");
+  CHECK_INVARIANT(eq3, "equatorial bond not found");
+
+  auto maybeAdd = [&](const Bond* lhs, const Bond* rhs, unsigned int order) {
+    const auto i = lhs->getOtherAtomIdx(atomIdx);
+    const auto j = rhs->getOtherAtomIdx(atomIdx);
+    if (!params[i] || !params[j]) {
+      return;
+    }
+    addAngleTerm(contribs,
+                 i,
+                 atomIdx,
+                 j,
+                 lhs->getBondTypeAsDouble(),
+                 rhs->getBondTypeAsDouble(),
+                 params[i],
+                 params[atomIdx],
+                 params[j],
+                 order);
+  };
+
+  maybeAdd(ax1, ax2, 2);
+  maybeAdd(eq1, eq2, 3);
+  maybeAdd(eq1, eq3, 3);
+  maybeAdd(eq2, eq3, 3);
+  maybeAdd(ax1, eq1, 0);
+  maybeAdd(ax1, eq2, 0);
+  maybeAdd(ax1, eq3, 0);
+  maybeAdd(ax2, eq1, 0);
+  maybeAdd(ax2, eq2, 0);
+  maybeAdd(ax2, eq3, 0);
+}
+
+void addAngleSpecialCases(const ROMol& mol,
+                          const int confId,
+                          const AtomicParamVect& params,
+                          nvMolKit::UFF::EnergyForceContribsHost& contribs) {
+  PRECONDITION(mol.getNumAtoms() == params.size(), "bad parameters");
+  for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
+    const Atom* atom = mol.getAtomWithIdx(i);
+    if (atom->getHybridization() == Atom::SP3D && atom->getDegree() == 5) {
+      addTrigonalBipyramidAngles(atom, mol, confId, params, contribs);
+    }
+  }
+}
+
+void addNonbonded(const ROMol& mol,
+                  const int confId,
+                  const AtomicParamVect& params,
+                  nvMolKit::UFF::EnergyForceContribsHost& contribs,
+                  boost::shared_array<std::uint8_t> neighborMatrix,
+                  const double vdwThresh,
+                  const bool ignoreInterfragInteractions) {
+  PRECONDITION(mol.getNumAtoms() == params.size(), "bad parameters");
+  INT_VECT fragMapping;
+  if (ignoreInterfragInteractions) {
+    std::vector<ROMOL_SPTR> molFrags = MolOps::getMolFrags(mol, true, &fragMapping);
+    (void)molFrags;
+  }
+
+  const Conformer& conf = mol.getConformer(confId);
+  for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
+    if (!params[i]) {
+      continue;
+    }
+    for (unsigned int j = i + 1; j < mol.getNumAtoms(); ++j) {
+      if (!params[j] || (ignoreInterfragInteractions && fragMapping[i] != fragMapping[j])) {
+        continue;
+      }
+      if (RDKit::UFF::Tools::getTwoBitCell(neighborMatrix, RDKit::UFF::Tools::twoBitCellPos(mol.getNumAtoms(), i, j)) >=
+          RDKit::UFF::Tools::RELATION_1_4) {
+        const double xij = ForceFields::UFF::Utils::calcNonbondedMinimum(params[i], params[j]);
+        const double threshold = vdwThresh * xij;
+        const double dist = (conf.getAtomPos(i) - conf.getAtomPos(j)).length();
+        if (dist < threshold) {
+          auto& terms = contribs.vdwTerms;
+          terms.idx1.push_back(static_cast<int>(i));
+          terms.idx2.push_back(static_cast<int>(j));
+          terms.x_ij.push_back(xij);
+          terms.wellDepth.push_back(ForceFields::UFF::Utils::calcNonbondedDepth(params[i], params[j]));
+          terms.threshold.push_back(threshold);
+        }
+      }
+    }
+  }
+}
+
+void addTorsions(const ROMol& mol, const AtomicParamVect& params, nvMolKit::UFF::EnergyForceContribsHost& contribs) {
+  PRECONDITION(mol.getNumAtoms() == params.size(), "bad parameters");
+
+  std::vector<MatchVectType> matchVect;
+  const ROMol* query = RDKit::UFF::Tools::DefaultTorsionBondSmarts::query();
+  PRECONDITION(query, "missing default torsion SMARTS");
+  const unsigned int nHits = SubstructMatch(mol, *query, matchVect);
+  for (unsigned int hitIdx = 0; hitIdx < nHits; ++hitIdx) {
+    const MatchVectType& match = matchVect[hitIdx];
+    PRECONDITION(match.size() == 2, "unexpected torsion match size");
+    const int idx1 = match[0].second;
+    const int idx2 = match[1].second;
+    if (!params[idx1] || !params[idx2]) {
+      continue;
+    }
+
+    const Bond* bond = mol.getBondBetweenAtoms(idx1, idx2);
+    PRECONDITION(bond, "missing torsion bond");
+    const Atom* atom1 = mol.getAtomWithIdx(idx1);
+    const Atom* atom2 = mol.getAtomWithIdx(idx2);
+    std::vector<size_t> contribIndices;
+
+    if (!((atom1->getHybridization() == Atom::SP2 || atom1->getHybridization() == Atom::SP3) &&
+          (atom2->getHybridization() == Atom::SP2 || atom2->getHybridization() == Atom::SP3))) {
+      continue;
+    }
+
+    ROMol::OEDGE_ITER beg1, end1;
+    boost::tie(beg1, end1) = mol.getAtomBonds(atom1);
+    while (beg1 != end1) {
+      const Bond* tBond1 = mol[*beg1];
+      ++beg1;
+      if (tBond1 == bond) {
+        continue;
+      }
+      const int bIdx = tBond1->getOtherAtomIdx(idx1);
+      ROMol::OEDGE_ITER beg2, end2;
+      boost::tie(beg2, end2) = mol.getAtomBonds(atom2);
+      while (beg2 != end2) {
+        const Bond* tBond2 = mol[*beg2];
+        ++beg2;
+        if (tBond2 == bond || tBond2 == tBond1) {
+          continue;
+        }
+        const int eIdx = tBond2->getOtherAtomIdx(idx2);
+        if (eIdx == bIdx) {
+          continue;
+        }
+
+        bool hasSP2 = false;
+        if (mol.getAtomWithIdx(bIdx)->getHybridization() == Atom::SP2 ||
+            mol.getAtomWithIdx(eIdx)->getHybridization() == Atom::SP2) {
+          hasSP2 = true;
+        }
+
+        const auto [forceConstant, order, cosTerm] =
+          calcTorsionParams(bond->getBondTypeAsDouble(),
+                            atom1->getAtomicNum(),
+                            atom2->getAtomicNum(),
+                            atom1->getHybridization(),
+                            atom2->getHybridization(),
+                            params[idx1],
+                            params[idx2],
+                            hasSP2);
+        auto& terms = contribs.torsionTerms;
+        terms.idx1.push_back(bIdx);
+        terms.idx2.push_back(idx1);
+        terms.idx3.push_back(idx2);
+        terms.idx4.push_back(eIdx);
+        terms.forceConstant.push_back(forceConstant);
+        terms.order.push_back(order);
+        terms.cosTerm.push_back(cosTerm);
+        contribIndices.push_back(terms.forceConstant.size() - 1);
+      }
+    }
+
+    if (!contribIndices.empty()) {
+      const double scale = static_cast<double>(contribIndices.size());
+      for (const auto contribIdx : contribIndices) {
+        contribs.torsionTerms.forceConstant[contribIdx] /= scale;
+      }
+    }
+  }
+}
+
+void addInversions(const ROMol& mol, const AtomicParamVect& params, nvMolKit::UFF::EnergyForceContribsHost& contribs) {
+  PRECONDITION(mol.getNumAtoms() == params.size(), "bad parameters");
+
+  unsigned int idx[4];
+  unsigned int perm[4];
+  const Atom*  atom[4];
+  ROMol::ADJ_ITER nbrIdx, endNbrs;
+  for (idx[1] = 0; idx[1] < mol.getNumAtoms(); ++idx[1]) {
+    atom[1] = mol.getAtomWithIdx(idx[1]);
+    const int at2AtomicNum = atom[1]->getAtomicNum();
+    if (((at2AtomicNum != 6) && (at2AtomicNum != 7) && (at2AtomicNum != 8) && (at2AtomicNum != 15) &&
+         (at2AtomicNum != 33) && (at2AtomicNum != 51) && (at2AtomicNum != 83)) ||
+        atom[1]->getDegree() != 3) {
+      continue;
+    }
+    if (((at2AtomicNum == 6) || (at2AtomicNum == 7) || (at2AtomicNum == 8)) &&
+        atom[1]->getHybridization() != Atom::SP2) {
+      continue;
+    }
+
+    boost::tie(nbrIdx, endNbrs) = mol.getAtomNeighbors(atom[1]);
+    unsigned int neighborSlot = 0;
+    bool         isBoundToSP2O = false;
+    for (; nbrIdx != endNbrs; ++nbrIdx) {
+      atom[neighborSlot] = mol[*nbrIdx];
+      idx[neighborSlot]  = atom[neighborSlot]->getIdx();
+      if (!isBoundToSP2O) {
+        isBoundToSP2O = (at2AtomicNum == 6) && (atom[neighborSlot]->getAtomicNum() == 8) &&
+                        (atom[neighborSlot]->getHybridization() == Atom::SP2);
+      }
+      if (!neighborSlot) {
+        ++neighborSlot;
+      }
+      ++neighborSlot;
+    }
+
+    const auto [forceConstant, C0, C1, C2] =
+      ForceFields::UFF::Utils::calcInversionCoefficientsAndForceConstant(at2AtomicNum, isBoundToSP2O);
+    for (unsigned int i = 0; i < 3; ++i) {
+      perm[1] = 1;
+      switch (i) {
+        case 0:
+          perm[0] = 0;
+          perm[2] = 2;
+          perm[3] = 3;
+          break;
+        case 1:
+          perm[0] = 0;
+          perm[2] = 3;
+          perm[3] = 2;
+          break;
+        default:
+          perm[0] = 2;
+          perm[2] = 3;
+          perm[3] = 0;
+          break;
+      }
+      auto& terms = contribs.inversionTerms;
+      terms.idx1.push_back(idx[perm[0]]);
+      terms.idx2.push_back(idx[perm[1]]);
+      terms.idx3.push_back(idx[perm[2]]);
+      terms.idx4.push_back(idx[perm[3]]);
+      terms.forceConstant.push_back(forceConstant);
+      terms.C0.push_back(C0);
+      terms.C1.push_back(C1);
+      terms.C2.push_back(C2);
+    }
+  }
+}
+
+}  // namespace Tools
+
+}  // namespace UFF
+}  // namespace RDKit
+
+namespace nvMolKit {
+namespace UFF {
+
+EnergyForceContribsHost constructForcefieldContribs(RDKit::ROMol& mol,
+                                                    const double   vdwThresh,
+                                                    const int      confId,
+                                                    const bool     ignoreInterfragInteractions) {
+  bool foundAll = false;
+  RDKit::UFF::AtomicParamVect params;
+  std::tie(params, foundAll) = RDKit::UFF::getAtomTypes(mol);
+  PRECONDITION(foundAll, "missing atom types - invalid force-field");
+
+  EnergyForceContribsHost contribs;
+  RDKit::UFF::Tools::addBonds(mol, params, contribs);
+  RDKit::UFF::Tools::addAngles(mol, params, contribs);
+  RDKit::UFF::Tools::addAngleSpecialCases(mol, confId, params, contribs);
+  auto neighborMat = RDKit::UFF::Tools::buildNeighborMatrix(mol);
+  RDKit::UFF::Tools::addNonbonded(mol, confId, params, contribs, neighborMat, vdwThresh, ignoreInterfragInteractions);
+  RDKit::UFF::Tools::addTorsions(mol, params, contribs);
+  RDKit::UFF::Tools::addInversions(mol, params, contribs);
+  return contribs;
+}
+
+}  // namespace UFF
+}  // namespace nvMolKit

--- a/rdkit_extensions/uff_flattened_builder.h
+++ b/rdkit_extensions/uff_flattened_builder.h
@@ -1,0 +1,20 @@
+#ifndef NVMOLKIT_UFF_FLATTENED_BUILDER_H
+#define NVMOLKIT_UFF_FLATTENED_BUILDER_H
+
+#include "uff.h"
+
+namespace RDKit {
+class ROMol;
+}
+
+namespace nvMolKit::UFF {
+
+//! Construct flattened UFF forcefield contribs for a molecule.
+EnergyForceContribsHost constructForcefieldContribs(RDKit::ROMol& mol,
+                                                    double        vdwThresh                  = 100.0,
+                                                    int           confId                     = -1,
+                                                    bool          ignoreInterfragInteractions = true);
+
+}  // namespace nvMolKit::UFF
+
+#endif  // NVMOLKIT_UFF_FLATTENED_BUILDER_H

--- a/src/forcefields/CMakeLists.txt
+++ b/src/forcefields/CMakeLists.txt
@@ -33,6 +33,10 @@ target_link_libraries(
   PRIVATE device_vector ff_kernel_utils)
 target_include_directories(mmff PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(uff uff.cu uff_kernels.cu)
+target_link_libraries(uff PRIVATE device_vector ff_kernel_utils)
+target_include_directories(uff PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(dist_geom dist_geom.cu dist_geom_kernels.cu coord_gen.cu)
 target_link_libraries(
   dist_geom
@@ -49,6 +53,15 @@ target_link_libraries(
 target_include_directories(
   mmff_batched_forcefield PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
                                  ${CMAKE_SOURCE_DIR}/src)
+
+add_library(uff_batched_forcefield uff_batched_forcefield.cu)
+target_link_libraries(
+  uff_batched_forcefield
+  PUBLIC batched_forcefield uff
+  PRIVATE device_vector)
+target_include_directories(
+  uff_batched_forcefield PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+                                ${CMAKE_SOURCE_DIR}/src)
 
 add_library(dg_batched_forcefield dg_batched_forcefield.cu)
 target_link_libraries(

--- a/src/forcefields/forcefield_constraints.h
+++ b/src/forcefields/forcefield_constraints.h
@@ -19,6 +19,9 @@
 #include <string>
 #include <vector>
 
+// TODO: Constraint term types, constraint kernels, and launchReduceEnergiesKernel currently live in
+// mmff.h / mmff_kernels.h but are forcefield-generic. They should be extracted into shared headers
+// so that UFF (and future forcefields) don't depend on MMFF.
 #include "mmff.h"
 
 namespace nvMolKit::ForceFieldConstraints {

--- a/src/forcefields/uff.cu
+++ b/src/forcefields/uff.cu
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/forcefields/uff.cu
+++ b/src/forcefields/uff.cu
@@ -1,0 +1,780 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <vector>
+
+#include "kernel_utils.cuh"
+#include "uff.h"
+
+namespace nvMolKit {
+namespace UFF {
+namespace {
+
+EnergyForceContribsDevicePtr toPointerStruct(const EnergyForceContribsDevice& src) {
+  EnergyForceContribsDevicePtr dst;
+  dst.bondTerms.idx1          = src.bondTerms.idx1.data();
+  dst.bondTerms.idx2          = src.bondTerms.idx2.data();
+  dst.bondTerms.restLen       = src.bondTerms.restLen.data();
+  dst.bondTerms.forceConstant = src.bondTerms.forceConstant.data();
+
+  dst.angleTerms.idx1          = src.angleTerms.idx1.data();
+  dst.angleTerms.idx2          = src.angleTerms.idx2.data();
+  dst.angleTerms.idx3          = src.angleTerms.idx3.data();
+  dst.angleTerms.theta0        = src.angleTerms.theta0.data();
+  dst.angleTerms.forceConstant = src.angleTerms.forceConstant.data();
+  dst.angleTerms.order         = src.angleTerms.order.data();
+  dst.angleTerms.C0            = src.angleTerms.C0.data();
+  dst.angleTerms.C1            = src.angleTerms.C1.data();
+  dst.angleTerms.C2            = src.angleTerms.C2.data();
+
+  dst.torsionTerms.idx1          = src.torsionTerms.idx1.data();
+  dst.torsionTerms.idx2          = src.torsionTerms.idx2.data();
+  dst.torsionTerms.idx3          = src.torsionTerms.idx3.data();
+  dst.torsionTerms.idx4          = src.torsionTerms.idx4.data();
+  dst.torsionTerms.forceConstant = src.torsionTerms.forceConstant.data();
+  dst.torsionTerms.order         = src.torsionTerms.order.data();
+  dst.torsionTerms.cosTerm       = src.torsionTerms.cosTerm.data();
+
+  dst.inversionTerms.idx1          = src.inversionTerms.idx1.data();
+  dst.inversionTerms.idx2          = src.inversionTerms.idx2.data();
+  dst.inversionTerms.idx3          = src.inversionTerms.idx3.data();
+  dst.inversionTerms.idx4          = src.inversionTerms.idx4.data();
+  dst.inversionTerms.forceConstant = src.inversionTerms.forceConstant.data();
+  dst.inversionTerms.C0            = src.inversionTerms.C0.data();
+  dst.inversionTerms.C1            = src.inversionTerms.C1.data();
+  dst.inversionTerms.C2            = src.inversionTerms.C2.data();
+
+  dst.vdwTerms.idx1      = src.vdwTerms.idx1.data();
+  dst.vdwTerms.idx2      = src.vdwTerms.idx2.data();
+  dst.vdwTerms.x_ij      = src.vdwTerms.x_ij.data();
+  dst.vdwTerms.wellDepth = src.vdwTerms.wellDepth.data();
+  dst.vdwTerms.threshold = src.vdwTerms.threshold.data();
+
+  dst.distanceConstraintTerms.idx1          = src.distanceConstraintTerms.idx1.data();
+  dst.distanceConstraintTerms.idx2          = src.distanceConstraintTerms.idx2.data();
+  dst.distanceConstraintTerms.minLen        = src.distanceConstraintTerms.minLen.data();
+  dst.distanceConstraintTerms.maxLen        = src.distanceConstraintTerms.maxLen.data();
+  dst.distanceConstraintTerms.forceConstant = src.distanceConstraintTerms.forceConstant.data();
+
+  dst.positionConstraintTerms.idx           = src.positionConstraintTerms.idx.data();
+  dst.positionConstraintTerms.refX          = src.positionConstraintTerms.refX.data();
+  dst.positionConstraintTerms.refY          = src.positionConstraintTerms.refY.data();
+  dst.positionConstraintTerms.refZ          = src.positionConstraintTerms.refZ.data();
+  dst.positionConstraintTerms.maxDispl      = src.positionConstraintTerms.maxDispl.data();
+  dst.positionConstraintTerms.forceConstant = src.positionConstraintTerms.forceConstant.data();
+
+  dst.angleConstraintTerms.idx1          = src.angleConstraintTerms.idx1.data();
+  dst.angleConstraintTerms.idx2          = src.angleConstraintTerms.idx2.data();
+  dst.angleConstraintTerms.idx3          = src.angleConstraintTerms.idx3.data();
+  dst.angleConstraintTerms.minAngleDeg   = src.angleConstraintTerms.minAngleDeg.data();
+  dst.angleConstraintTerms.maxAngleDeg   = src.angleConstraintTerms.maxAngleDeg.data();
+  dst.angleConstraintTerms.forceConstant = src.angleConstraintTerms.forceConstant.data();
+
+  dst.torsionConstraintTerms.idx1           = src.torsionConstraintTerms.idx1.data();
+  dst.torsionConstraintTerms.idx2           = src.torsionConstraintTerms.idx2.data();
+  dst.torsionConstraintTerms.idx3           = src.torsionConstraintTerms.idx3.data();
+  dst.torsionConstraintTerms.idx4           = src.torsionConstraintTerms.idx4.data();
+  dst.torsionConstraintTerms.minDihedralDeg = src.torsionConstraintTerms.minDihedralDeg.data();
+  dst.torsionConstraintTerms.maxDihedralDeg = src.torsionConstraintTerms.maxDihedralDeg.data();
+  dst.torsionConstraintTerms.forceConstant  = src.torsionConstraintTerms.forceConstant.data();
+  return dst;
+}
+
+BatchedIndicesDevicePtr toPointerStruct(const BatchedIndicesDevice& src) {
+  BatchedIndicesDevicePtr dst;
+  dst.atomStarts                   = src.atomStarts.data();
+  dst.bondTermStarts               = src.bondTermStarts.data();
+  dst.angleTermStarts              = src.angleTermStarts.data();
+  dst.torsionTermStarts            = src.torsionTermStarts.data();
+  dst.inversionTermStarts          = src.inversionTermStarts.data();
+  dst.vdwTermStarts                = src.vdwTermStarts.data();
+  dst.distanceConstraintTermStarts = src.distanceConstraintTermStarts.data();
+  dst.positionConstraintTermStarts = src.positionConstraintTermStarts.data();
+  dst.angleConstraintTermStarts    = src.angleConstraintTermStarts.data();
+  dst.torsionConstraintTermStarts  = src.torsionConstraintTermStarts.data();
+  return dst;
+}
+
+__global__ void zeroInactiveGradientEntries(const int*     atomIdxToBatchIdx,
+                                            const uint8_t* activeSystemMask,
+                                            const int      numAtoms,
+                                            const int      dataDim,
+                                            double*        grad) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= numAtoms * dataDim) {
+    return;
+  }
+  const int atomIdx  = idx / dataDim;
+  const int batchIdx = atomIdxToBatchIdx[atomIdx];
+  if (activeSystemMask[batchIdx] == 0) {
+    grad[idx] = 0.0;
+  }
+}
+
+template <typename T>
+void appendOffsetIndices(std::vector<T>& dst, const std::vector<T>& src, const int offset) {
+  dst.reserve(dst.size() + src.size());
+  for (const auto value : src) {
+    dst.push_back(value + offset);
+  }
+}
+
+template <typename T>
+void appendValues(std::vector<T>& dst, const std::vector<T>& src) {
+  dst.insert(dst.end(), src.begin(), src.end());
+}
+
+}  // namespace
+
+void setStreams(BatchedMolecularDeviceBuffers& molSystemDevice, cudaStream_t stream) {
+  molSystemDevice.positions.setStream(stream);
+  molSystemDevice.grad.setStream(stream);
+  molSystemDevice.energyOuts.setStream(stream);
+  molSystemDevice.energyBuffer.setStream(stream);
+
+  auto& contribs = molSystemDevice.contribs;
+  contribs.bondTerms.idx1.setStream(stream);
+  contribs.bondTerms.idx2.setStream(stream);
+  contribs.bondTerms.restLen.setStream(stream);
+  contribs.bondTerms.forceConstant.setStream(stream);
+
+  contribs.angleTerms.idx1.setStream(stream);
+  contribs.angleTerms.idx2.setStream(stream);
+  contribs.angleTerms.idx3.setStream(stream);
+  contribs.angleTerms.theta0.setStream(stream);
+  contribs.angleTerms.forceConstant.setStream(stream);
+  contribs.angleTerms.order.setStream(stream);
+  contribs.angleTerms.C0.setStream(stream);
+  contribs.angleTerms.C1.setStream(stream);
+  contribs.angleTerms.C2.setStream(stream);
+
+  contribs.torsionTerms.idx1.setStream(stream);
+  contribs.torsionTerms.idx2.setStream(stream);
+  contribs.torsionTerms.idx3.setStream(stream);
+  contribs.torsionTerms.idx4.setStream(stream);
+  contribs.torsionTerms.forceConstant.setStream(stream);
+  contribs.torsionTerms.order.setStream(stream);
+  contribs.torsionTerms.cosTerm.setStream(stream);
+
+  contribs.inversionTerms.idx1.setStream(stream);
+  contribs.inversionTerms.idx2.setStream(stream);
+  contribs.inversionTerms.idx3.setStream(stream);
+  contribs.inversionTerms.idx4.setStream(stream);
+  contribs.inversionTerms.forceConstant.setStream(stream);
+  contribs.inversionTerms.C0.setStream(stream);
+  contribs.inversionTerms.C1.setStream(stream);
+  contribs.inversionTerms.C2.setStream(stream);
+
+  contribs.vdwTerms.idx1.setStream(stream);
+  contribs.vdwTerms.idx2.setStream(stream);
+  contribs.vdwTerms.x_ij.setStream(stream);
+  contribs.vdwTerms.wellDepth.setStream(stream);
+  contribs.vdwTerms.threshold.setStream(stream);
+
+  contribs.distanceConstraintTerms.idx1.setStream(stream);
+  contribs.distanceConstraintTerms.idx2.setStream(stream);
+  contribs.distanceConstraintTerms.minLen.setStream(stream);
+  contribs.distanceConstraintTerms.maxLen.setStream(stream);
+  contribs.distanceConstraintTerms.forceConstant.setStream(stream);
+
+  contribs.positionConstraintTerms.idx.setStream(stream);
+  contribs.positionConstraintTerms.refX.setStream(stream);
+  contribs.positionConstraintTerms.refY.setStream(stream);
+  contribs.positionConstraintTerms.refZ.setStream(stream);
+  contribs.positionConstraintTerms.maxDispl.setStream(stream);
+  contribs.positionConstraintTerms.forceConstant.setStream(stream);
+
+  contribs.angleConstraintTerms.idx1.setStream(stream);
+  contribs.angleConstraintTerms.idx2.setStream(stream);
+  contribs.angleConstraintTerms.idx3.setStream(stream);
+  contribs.angleConstraintTerms.minAngleDeg.setStream(stream);
+  contribs.angleConstraintTerms.maxAngleDeg.setStream(stream);
+  contribs.angleConstraintTerms.forceConstant.setStream(stream);
+
+  contribs.torsionConstraintTerms.idx1.setStream(stream);
+  contribs.torsionConstraintTerms.idx2.setStream(stream);
+  contribs.torsionConstraintTerms.idx3.setStream(stream);
+  contribs.torsionConstraintTerms.idx4.setStream(stream);
+  contribs.torsionConstraintTerms.minDihedralDeg.setStream(stream);
+  contribs.torsionConstraintTerms.maxDihedralDeg.setStream(stream);
+  contribs.torsionConstraintTerms.forceConstant.setStream(stream);
+
+  molSystemDevice.indices.atomStarts.setStream(stream);
+  molSystemDevice.indices.atomIdxToBatchIdx.setStream(stream);
+  molSystemDevice.indices.energyBufferStarts.setStream(stream);
+  molSystemDevice.indices.energyBufferBlockIdxToBatchIdx.setStream(stream);
+  molSystemDevice.indices.bondTermStarts.setStream(stream);
+  molSystemDevice.indices.angleTermStarts.setStream(stream);
+  molSystemDevice.indices.torsionTermStarts.setStream(stream);
+  molSystemDevice.indices.inversionTermStarts.setStream(stream);
+  molSystemDevice.indices.vdwTermStarts.setStream(stream);
+  molSystemDevice.indices.distanceConstraintTermStarts.setStream(stream);
+  molSystemDevice.indices.positionConstraintTermStarts.setStream(stream);
+  molSystemDevice.indices.angleConstraintTermStarts.setStream(stream);
+  molSystemDevice.indices.torsionConstraintTermStarts.setStream(stream);
+}
+
+void sendContribsAndIndicesToDevice(const BatchedMolecularSystemHost& molSystemHost,
+                                    BatchedMolecularDeviceBuffers&    molSystemDevice) {
+  const auto& hostContribs = molSystemHost.contribs;
+  auto&       contribs     = molSystemDevice.contribs;
+
+  contribs.bondTerms.idx1.setFromVector(hostContribs.bondTerms.idx1);
+  contribs.bondTerms.idx2.setFromVector(hostContribs.bondTerms.idx2);
+  contribs.bondTerms.restLen.setFromVector(hostContribs.bondTerms.restLen);
+  contribs.bondTerms.forceConstant.setFromVector(hostContribs.bondTerms.forceConstant);
+
+  contribs.angleTerms.idx1.setFromVector(hostContribs.angleTerms.idx1);
+  contribs.angleTerms.idx2.setFromVector(hostContribs.angleTerms.idx2);
+  contribs.angleTerms.idx3.setFromVector(hostContribs.angleTerms.idx3);
+  contribs.angleTerms.theta0.setFromVector(hostContribs.angleTerms.theta0);
+  contribs.angleTerms.forceConstant.setFromVector(hostContribs.angleTerms.forceConstant);
+  contribs.angleTerms.order.setFromVector(hostContribs.angleTerms.order);
+  contribs.angleTerms.C0.setFromVector(hostContribs.angleTerms.C0);
+  contribs.angleTerms.C1.setFromVector(hostContribs.angleTerms.C1);
+  contribs.angleTerms.C2.setFromVector(hostContribs.angleTerms.C2);
+
+  contribs.torsionTerms.idx1.setFromVector(hostContribs.torsionTerms.idx1);
+  contribs.torsionTerms.idx2.setFromVector(hostContribs.torsionTerms.idx2);
+  contribs.torsionTerms.idx3.setFromVector(hostContribs.torsionTerms.idx3);
+  contribs.torsionTerms.idx4.setFromVector(hostContribs.torsionTerms.idx4);
+  contribs.torsionTerms.forceConstant.setFromVector(hostContribs.torsionTerms.forceConstant);
+  contribs.torsionTerms.order.setFromVector(hostContribs.torsionTerms.order);
+  contribs.torsionTerms.cosTerm.setFromVector(hostContribs.torsionTerms.cosTerm);
+
+  contribs.inversionTerms.idx1.setFromVector(hostContribs.inversionTerms.idx1);
+  contribs.inversionTerms.idx2.setFromVector(hostContribs.inversionTerms.idx2);
+  contribs.inversionTerms.idx3.setFromVector(hostContribs.inversionTerms.idx3);
+  contribs.inversionTerms.idx4.setFromVector(hostContribs.inversionTerms.idx4);
+  contribs.inversionTerms.forceConstant.setFromVector(hostContribs.inversionTerms.forceConstant);
+  contribs.inversionTerms.C0.setFromVector(hostContribs.inversionTerms.C0);
+  contribs.inversionTerms.C1.setFromVector(hostContribs.inversionTerms.C1);
+  contribs.inversionTerms.C2.setFromVector(hostContribs.inversionTerms.C2);
+
+  contribs.vdwTerms.idx1.setFromVector(hostContribs.vdwTerms.idx1);
+  contribs.vdwTerms.idx2.setFromVector(hostContribs.vdwTerms.idx2);
+  contribs.vdwTerms.x_ij.setFromVector(hostContribs.vdwTerms.x_ij);
+  contribs.vdwTerms.wellDepth.setFromVector(hostContribs.vdwTerms.wellDepth);
+  contribs.vdwTerms.threshold.setFromVector(hostContribs.vdwTerms.threshold);
+
+  contribs.distanceConstraintTerms.idx1.setFromVector(hostContribs.distanceConstraintTerms.idx1);
+  contribs.distanceConstraintTerms.idx2.setFromVector(hostContribs.distanceConstraintTerms.idx2);
+  contribs.distanceConstraintTerms.minLen.setFromVector(hostContribs.distanceConstraintTerms.minLen);
+  contribs.distanceConstraintTerms.maxLen.setFromVector(hostContribs.distanceConstraintTerms.maxLen);
+  contribs.distanceConstraintTerms.forceConstant.setFromVector(hostContribs.distanceConstraintTerms.forceConstant);
+
+  contribs.positionConstraintTerms.idx.setFromVector(hostContribs.positionConstraintTerms.idx);
+  contribs.positionConstraintTerms.refX.setFromVector(hostContribs.positionConstraintTerms.refX);
+  contribs.positionConstraintTerms.refY.setFromVector(hostContribs.positionConstraintTerms.refY);
+  contribs.positionConstraintTerms.refZ.setFromVector(hostContribs.positionConstraintTerms.refZ);
+  contribs.positionConstraintTerms.maxDispl.setFromVector(hostContribs.positionConstraintTerms.maxDispl);
+  contribs.positionConstraintTerms.forceConstant.setFromVector(hostContribs.positionConstraintTerms.forceConstant);
+
+  contribs.angleConstraintTerms.idx1.setFromVector(hostContribs.angleConstraintTerms.idx1);
+  contribs.angleConstraintTerms.idx2.setFromVector(hostContribs.angleConstraintTerms.idx2);
+  contribs.angleConstraintTerms.idx3.setFromVector(hostContribs.angleConstraintTerms.idx3);
+  contribs.angleConstraintTerms.minAngleDeg.setFromVector(hostContribs.angleConstraintTerms.minAngleDeg);
+  contribs.angleConstraintTerms.maxAngleDeg.setFromVector(hostContribs.angleConstraintTerms.maxAngleDeg);
+  contribs.angleConstraintTerms.forceConstant.setFromVector(hostContribs.angleConstraintTerms.forceConstant);
+
+  contribs.torsionConstraintTerms.idx1.setFromVector(hostContribs.torsionConstraintTerms.idx1);
+  contribs.torsionConstraintTerms.idx2.setFromVector(hostContribs.torsionConstraintTerms.idx2);
+  contribs.torsionConstraintTerms.idx3.setFromVector(hostContribs.torsionConstraintTerms.idx3);
+  contribs.torsionConstraintTerms.idx4.setFromVector(hostContribs.torsionConstraintTerms.idx4);
+  contribs.torsionConstraintTerms.minDihedralDeg.setFromVector(hostContribs.torsionConstraintTerms.minDihedralDeg);
+  contribs.torsionConstraintTerms.maxDihedralDeg.setFromVector(hostContribs.torsionConstraintTerms.maxDihedralDeg);
+  contribs.torsionConstraintTerms.forceConstant.setFromVector(hostContribs.torsionConstraintTerms.forceConstant);
+
+  molSystemDevice.indices.atomStarts.setFromVector(molSystemHost.indices.atomStarts);
+  molSystemDevice.indices.atomIdxToBatchIdx.setFromVector(molSystemHost.indices.atomIdxToBatchIdx);
+  molSystemDevice.indices.energyBufferStarts.setFromVector(molSystemHost.indices.energyBufferStarts);
+  molSystemDevice.indices.energyBufferBlockIdxToBatchIdx.setFromVector(molSystemHost.indices.energyBufferBlockIdxToBatchIdx);
+  molSystemDevice.indices.bondTermStarts.setFromVector(molSystemHost.indices.bondTermStarts);
+  molSystemDevice.indices.angleTermStarts.setFromVector(molSystemHost.indices.angleTermStarts);
+  molSystemDevice.indices.torsionTermStarts.setFromVector(molSystemHost.indices.torsionTermStarts);
+  molSystemDevice.indices.inversionTermStarts.setFromVector(molSystemHost.indices.inversionTermStarts);
+  molSystemDevice.indices.vdwTermStarts.setFromVector(molSystemHost.indices.vdwTermStarts);
+  molSystemDevice.indices.distanceConstraintTermStarts.setFromVector(molSystemHost.indices.distanceConstraintTermStarts);
+  molSystemDevice.indices.positionConstraintTermStarts.setFromVector(molSystemHost.indices.positionConstraintTermStarts);
+  molSystemDevice.indices.angleConstraintTermStarts.setFromVector(molSystemHost.indices.angleConstraintTermStarts);
+  molSystemDevice.indices.torsionConstraintTermStarts.setFromVector(molSystemHost.indices.torsionConstraintTermStarts);
+}
+
+void addMoleculeToBatch(const EnergyForceContribsHost& contribs,
+                        const std::vector<double>&     positions,
+                        BatchedMolecularSystemHost&    molSystem) {
+  const int atomOffset   = molSystem.indices.atomStarts.back();
+  const int batchIdx     = static_cast<int>(molSystem.indices.atomStarts.size()) - 1;
+  const int newNumAtoms  = static_cast<int>(positions.size()) / 3;
+  auto&     indices      = molSystem.indices;
+  auto&     dstContribs  = molSystem.contribs;
+
+  indices.atomStarts.push_back(atomOffset + newNumAtoms);
+  molSystem.maxNumAtoms = std::max(molSystem.maxNumAtoms, newNumAtoms);
+  molSystem.positions.insert(molSystem.positions.end(), positions.begin(), positions.end());
+  indices.atomIdxToBatchIdx.resize(molSystem.positions.size() / 3, batchIdx);
+
+  indices.bondTermStarts.push_back(indices.bondTermStarts.back() + contribs.bondTerms.idx1.size());
+  indices.angleTermStarts.push_back(indices.angleTermStarts.back() + contribs.angleTerms.idx1.size());
+  indices.torsionTermStarts.push_back(indices.torsionTermStarts.back() + contribs.torsionTerms.idx1.size());
+  indices.inversionTermStarts.push_back(indices.inversionTermStarts.back() + contribs.inversionTerms.idx1.size());
+  indices.vdwTermStarts.push_back(indices.vdwTermStarts.back() + contribs.vdwTerms.idx1.size());
+  indices.distanceConstraintTermStarts.push_back(indices.distanceConstraintTermStarts.back() +
+                                                 contribs.distanceConstraintTerms.idx1.size());
+  indices.positionConstraintTermStarts.push_back(indices.positionConstraintTermStarts.back() +
+                                                 contribs.positionConstraintTerms.idx.size());
+  indices.angleConstraintTermStarts.push_back(indices.angleConstraintTermStarts.back() +
+                                              contribs.angleConstraintTerms.idx1.size());
+  indices.torsionConstraintTermStarts.push_back(indices.torsionConstraintTermStarts.back() +
+                                                contribs.torsionConstraintTerms.idx1.size());
+
+  int maxNumContribs = 0;
+  maxNumContribs = std::max<int>(maxNumContribs, contribs.bondTerms.idx1.size());
+  maxNumContribs = std::max<int>(maxNumContribs, contribs.angleTerms.idx1.size());
+  maxNumContribs = std::max<int>(maxNumContribs, contribs.torsionTerms.idx1.size());
+  maxNumContribs = std::max<int>(maxNumContribs, contribs.inversionTerms.idx1.size());
+  maxNumContribs = std::max<int>(maxNumContribs, contribs.vdwTerms.idx1.size());
+  maxNumContribs = std::max<int>(maxNumContribs, contribs.distanceConstraintTerms.idx1.size());
+  maxNumContribs = std::max<int>(maxNumContribs, contribs.positionConstraintTerms.idx.size());
+  maxNumContribs = std::max<int>(maxNumContribs, contribs.angleConstraintTerms.idx1.size());
+  maxNumContribs = std::max<int>(maxNumContribs, contribs.torsionConstraintTerms.idx1.size());
+
+  const int numBlocksNeeded  =
+    (maxNumContribs + FFKernelUtils::blockSizeEnergyReduction - 1) / FFKernelUtils::blockSizeEnergyReduction;
+  const int numThreadsNeeded = numBlocksNeeded * FFKernelUtils::blockSizeEnergyReduction;
+  indices.energyBufferStarts.push_back(indices.energyBufferStarts.back() + numThreadsNeeded);
+  for (int i = 0; i < numBlocksNeeded; ++i) {
+    indices.energyBufferBlockIdxToBatchIdx.push_back(batchIdx);
+  }
+
+  appendOffsetIndices(dstContribs.bondTerms.idx1, contribs.bondTerms.idx1, atomOffset);
+  appendOffsetIndices(dstContribs.bondTerms.idx2, contribs.bondTerms.idx2, atomOffset);
+  appendValues(dstContribs.bondTerms.restLen, contribs.bondTerms.restLen);
+  appendValues(dstContribs.bondTerms.forceConstant, contribs.bondTerms.forceConstant);
+
+  appendOffsetIndices(dstContribs.angleTerms.idx1, contribs.angleTerms.idx1, atomOffset);
+  appendOffsetIndices(dstContribs.angleTerms.idx2, contribs.angleTerms.idx2, atomOffset);
+  appendOffsetIndices(dstContribs.angleTerms.idx3, contribs.angleTerms.idx3, atomOffset);
+  appendValues(dstContribs.angleTerms.theta0, contribs.angleTerms.theta0);
+  appendValues(dstContribs.angleTerms.forceConstant, contribs.angleTerms.forceConstant);
+  appendValues(dstContribs.angleTerms.order, contribs.angleTerms.order);
+  appendValues(dstContribs.angleTerms.C0, contribs.angleTerms.C0);
+  appendValues(dstContribs.angleTerms.C1, contribs.angleTerms.C1);
+  appendValues(dstContribs.angleTerms.C2, contribs.angleTerms.C2);
+
+  appendOffsetIndices(dstContribs.torsionTerms.idx1, contribs.torsionTerms.idx1, atomOffset);
+  appendOffsetIndices(dstContribs.torsionTerms.idx2, contribs.torsionTerms.idx2, atomOffset);
+  appendOffsetIndices(dstContribs.torsionTerms.idx3, contribs.torsionTerms.idx3, atomOffset);
+  appendOffsetIndices(dstContribs.torsionTerms.idx4, contribs.torsionTerms.idx4, atomOffset);
+  appendValues(dstContribs.torsionTerms.forceConstant, contribs.torsionTerms.forceConstant);
+  appendValues(dstContribs.torsionTerms.order, contribs.torsionTerms.order);
+  appendValues(dstContribs.torsionTerms.cosTerm, contribs.torsionTerms.cosTerm);
+
+  appendOffsetIndices(dstContribs.inversionTerms.idx1, contribs.inversionTerms.idx1, atomOffset);
+  appendOffsetIndices(dstContribs.inversionTerms.idx2, contribs.inversionTerms.idx2, atomOffset);
+  appendOffsetIndices(dstContribs.inversionTerms.idx3, contribs.inversionTerms.idx3, atomOffset);
+  appendOffsetIndices(dstContribs.inversionTerms.idx4, contribs.inversionTerms.idx4, atomOffset);
+  appendValues(dstContribs.inversionTerms.forceConstant, contribs.inversionTerms.forceConstant);
+  appendValues(dstContribs.inversionTerms.C0, contribs.inversionTerms.C0);
+  appendValues(dstContribs.inversionTerms.C1, contribs.inversionTerms.C1);
+  appendValues(dstContribs.inversionTerms.C2, contribs.inversionTerms.C2);
+
+  appendOffsetIndices(dstContribs.vdwTerms.idx1, contribs.vdwTerms.idx1, atomOffset);
+  appendOffsetIndices(dstContribs.vdwTerms.idx2, contribs.vdwTerms.idx2, atomOffset);
+  appendValues(dstContribs.vdwTerms.x_ij, contribs.vdwTerms.x_ij);
+  appendValues(dstContribs.vdwTerms.wellDepth, contribs.vdwTerms.wellDepth);
+  appendValues(dstContribs.vdwTerms.threshold, contribs.vdwTerms.threshold);
+
+  appendOffsetIndices(dstContribs.distanceConstraintTerms.idx1, contribs.distanceConstraintTerms.idx1, atomOffset);
+  appendOffsetIndices(dstContribs.distanceConstraintTerms.idx2, contribs.distanceConstraintTerms.idx2, atomOffset);
+  appendValues(dstContribs.distanceConstraintTerms.minLen, contribs.distanceConstraintTerms.minLen);
+  appendValues(dstContribs.distanceConstraintTerms.maxLen, contribs.distanceConstraintTerms.maxLen);
+  appendValues(dstContribs.distanceConstraintTerms.forceConstant, contribs.distanceConstraintTerms.forceConstant);
+
+  appendOffsetIndices(dstContribs.positionConstraintTerms.idx, contribs.positionConstraintTerms.idx, atomOffset);
+  appendValues(dstContribs.positionConstraintTerms.refX, contribs.positionConstraintTerms.refX);
+  appendValues(dstContribs.positionConstraintTerms.refY, contribs.positionConstraintTerms.refY);
+  appendValues(dstContribs.positionConstraintTerms.refZ, contribs.positionConstraintTerms.refZ);
+  appendValues(dstContribs.positionConstraintTerms.maxDispl, contribs.positionConstraintTerms.maxDispl);
+  appendValues(dstContribs.positionConstraintTerms.forceConstant, contribs.positionConstraintTerms.forceConstant);
+
+  appendOffsetIndices(dstContribs.angleConstraintTerms.idx1, contribs.angleConstraintTerms.idx1, atomOffset);
+  appendOffsetIndices(dstContribs.angleConstraintTerms.idx2, contribs.angleConstraintTerms.idx2, atomOffset);
+  appendOffsetIndices(dstContribs.angleConstraintTerms.idx3, contribs.angleConstraintTerms.idx3, atomOffset);
+  appendValues(dstContribs.angleConstraintTerms.minAngleDeg, contribs.angleConstraintTerms.minAngleDeg);
+  appendValues(dstContribs.angleConstraintTerms.maxAngleDeg, contribs.angleConstraintTerms.maxAngleDeg);
+  appendValues(dstContribs.angleConstraintTerms.forceConstant, contribs.angleConstraintTerms.forceConstant);
+
+  appendOffsetIndices(dstContribs.torsionConstraintTerms.idx1, contribs.torsionConstraintTerms.idx1, atomOffset);
+  appendOffsetIndices(dstContribs.torsionConstraintTerms.idx2, contribs.torsionConstraintTerms.idx2, atomOffset);
+  appendOffsetIndices(dstContribs.torsionConstraintTerms.idx3, contribs.torsionConstraintTerms.idx3, atomOffset);
+  appendOffsetIndices(dstContribs.torsionConstraintTerms.idx4, contribs.torsionConstraintTerms.idx4, atomOffset);
+  appendValues(dstContribs.torsionConstraintTerms.minDihedralDeg, contribs.torsionConstraintTerms.minDihedralDeg);
+  appendValues(dstContribs.torsionConstraintTerms.maxDihedralDeg, contribs.torsionConstraintTerms.maxDihedralDeg);
+  appendValues(dstContribs.torsionConstraintTerms.forceConstant, contribs.torsionConstraintTerms.forceConstant);
+}
+
+void addMoleculeToBatch(const EnergyForceContribsHost& contribs,
+                        const std::vector<double>&     positions,
+                        BatchedMolecularSystemHost&    molSystem,
+                        BatchedForcefieldMetadata&     metadata,
+                        const int                      moleculeIdx,
+                        const int                      conformerIdx,
+                        const HostCustomization&       customization) {
+  EnergyForceContribsHost contribsCopy = contribs;
+  const BatchedSystemInfo systemInfo   = metadata.recordSystem(moleculeIdx, conformerIdx);
+  if (customization) {
+    customization(systemInfo, positions, contribsCopy);
+  }
+  addMoleculeToBatch(contribsCopy, positions, molSystem);
+}
+
+void allocateIntermediateBuffers(const BatchedMolecularSystemHost& molSystemHost,
+                                 BatchedMolecularDeviceBuffers&    molSystemDevice) {
+  FFKernelUtils::allocateIntermediateBuffers(molSystemHost, molSystemDevice, molSystemHost.indices.atomStarts.size() - 1);
+}
+
+cudaError_t computeEnergy(BatchedMolecularDeviceBuffers& molSystemDevice,
+                          double*                        energyOuts,
+                          const double*                  positions,
+                          const uint8_t*                 activeSystemMask,
+                          cudaStream_t                   stream) {
+  assert(molSystemDevice.energyBuffer.size() > 0);
+  assert(energyOuts != nullptr);
+  molSystemDevice.energyBuffer.zero();
+
+  const auto& contribs = molSystemDevice.contribs;
+  cudaError_t err      = cudaSuccess;
+  if (contribs.bondTerms.idx1.size() > 0) {
+    err = launchBondStretchEnergyKernel(contribs.bondTerms.idx1.size(),
+                                        contribs.bondTerms.idx1.data(),
+                                        contribs.bondTerms.idx2.data(),
+                                        contribs.bondTerms.restLen.data(),
+                                        contribs.bondTerms.forceConstant.data(),
+                                        positions,
+                                        molSystemDevice.energyBuffer.data(),
+                                        molSystemDevice.indices.energyBufferStarts.data(),
+                                        molSystemDevice.indices.atomIdxToBatchIdx.data(),
+                                        molSystemDevice.indices.bondTermStarts.data(),
+                                        stream);
+  }
+  if (err == cudaSuccess && contribs.angleTerms.idx1.size() > 0) {
+    err = launchAngleBendEnergyKernel(contribs.angleTerms.idx1.size(),
+                                      contribs.angleTerms.idx1.data(),
+                                      contribs.angleTerms.idx2.data(),
+                                      contribs.angleTerms.idx3.data(),
+                                      contribs.angleTerms.theta0.data(),
+                                      contribs.angleTerms.forceConstant.data(),
+                                      contribs.angleTerms.order.data(),
+                                      contribs.angleTerms.C0.data(),
+                                      contribs.angleTerms.C1.data(),
+                                      contribs.angleTerms.C2.data(),
+                                      positions,
+                                      molSystemDevice.energyBuffer.data(),
+                                      molSystemDevice.indices.energyBufferStarts.data(),
+                                      molSystemDevice.indices.atomIdxToBatchIdx.data(),
+                                      molSystemDevice.indices.angleTermStarts.data(),
+                                      stream);
+  }
+  if (err == cudaSuccess && contribs.torsionTerms.idx1.size() > 0) {
+    err = launchTorsionEnergyKernel(contribs.torsionTerms.idx1.size(),
+                                    contribs.torsionTerms.idx1.data(),
+                                    contribs.torsionTerms.idx2.data(),
+                                    contribs.torsionTerms.idx3.data(),
+                                    contribs.torsionTerms.idx4.data(),
+                                    contribs.torsionTerms.forceConstant.data(),
+                                    contribs.torsionTerms.order.data(),
+                                    contribs.torsionTerms.cosTerm.data(),
+                                    positions,
+                                    molSystemDevice.energyBuffer.data(),
+                                    molSystemDevice.indices.energyBufferStarts.data(),
+                                    molSystemDevice.indices.atomIdxToBatchIdx.data(),
+                                    molSystemDevice.indices.torsionTermStarts.data(),
+                                    stream);
+  }
+  if (err == cudaSuccess && contribs.inversionTerms.idx1.size() > 0) {
+    err = launchInversionEnergyKernel(contribs.inversionTerms.idx1.size(),
+                                      contribs.inversionTerms.idx1.data(),
+                                      contribs.inversionTerms.idx2.data(),
+                                      contribs.inversionTerms.idx3.data(),
+                                      contribs.inversionTerms.idx4.data(),
+                                      contribs.inversionTerms.forceConstant.data(),
+                                      contribs.inversionTerms.C0.data(),
+                                      contribs.inversionTerms.C1.data(),
+                                      contribs.inversionTerms.C2.data(),
+                                      positions,
+                                      molSystemDevice.energyBuffer.data(),
+                                      molSystemDevice.indices.energyBufferStarts.data(),
+                                      molSystemDevice.indices.atomIdxToBatchIdx.data(),
+                                      molSystemDevice.indices.inversionTermStarts.data(),
+                                      stream);
+  }
+  if (err == cudaSuccess && contribs.vdwTerms.idx1.size() > 0) {
+    err = launchVdwEnergyKernel(contribs.vdwTerms.idx1.size(),
+                                contribs.vdwTerms.idx1.data(),
+                                contribs.vdwTerms.idx2.data(),
+                                contribs.vdwTerms.x_ij.data(),
+                                contribs.vdwTerms.wellDepth.data(),
+                                contribs.vdwTerms.threshold.data(),
+                                positions,
+                                molSystemDevice.energyBuffer.data(),
+                                molSystemDevice.indices.energyBufferStarts.data(),
+                                molSystemDevice.indices.atomIdxToBatchIdx.data(),
+                                molSystemDevice.indices.vdwTermStarts.data(),
+                                stream);
+  }
+  if (err == cudaSuccess && contribs.distanceConstraintTerms.idx1.size() > 0) {
+    err = MMFF::launchDistanceConstraintEnergyKernel(contribs.distanceConstraintTerms.idx1.size(),
+                                                     contribs.distanceConstraintTerms.idx1.data(),
+                                                     contribs.distanceConstraintTerms.idx2.data(),
+                                                     contribs.distanceConstraintTerms.minLen.data(),
+                                                     contribs.distanceConstraintTerms.maxLen.data(),
+                                                     contribs.distanceConstraintTerms.forceConstant.data(),
+                                                     positions,
+                                                     molSystemDevice.energyBuffer.data(),
+                                                     molSystemDevice.indices.energyBufferStarts.data(),
+                                                     molSystemDevice.indices.atomIdxToBatchIdx.data(),
+                                                     molSystemDevice.indices.distanceConstraintTermStarts.data(),
+                                                     stream);
+  }
+  if (err == cudaSuccess && contribs.positionConstraintTerms.idx.size() > 0) {
+    err = MMFF::launchPositionConstraintEnergyKernel(contribs.positionConstraintTerms.idx.size(),
+                                                     contribs.positionConstraintTerms.idx.data(),
+                                                     contribs.positionConstraintTerms.refX.data(),
+                                                     contribs.positionConstraintTerms.refY.data(),
+                                                     contribs.positionConstraintTerms.refZ.data(),
+                                                     contribs.positionConstraintTerms.maxDispl.data(),
+                                                     contribs.positionConstraintTerms.forceConstant.data(),
+                                                     positions,
+                                                     molSystemDevice.energyBuffer.data(),
+                                                     molSystemDevice.indices.energyBufferStarts.data(),
+                                                     molSystemDevice.indices.atomIdxToBatchIdx.data(),
+                                                     molSystemDevice.indices.positionConstraintTermStarts.data(),
+                                                     stream);
+  }
+  if (err == cudaSuccess && contribs.angleConstraintTerms.idx1.size() > 0) {
+    err = MMFF::launchAngleConstraintEnergyKernel(contribs.angleConstraintTerms.idx1.size(),
+                                                  contribs.angleConstraintTerms.idx1.data(),
+                                                  contribs.angleConstraintTerms.idx2.data(),
+                                                  contribs.angleConstraintTerms.idx3.data(),
+                                                  contribs.angleConstraintTerms.minAngleDeg.data(),
+                                                  contribs.angleConstraintTerms.maxAngleDeg.data(),
+                                                  contribs.angleConstraintTerms.forceConstant.data(),
+                                                  positions,
+                                                  molSystemDevice.energyBuffer.data(),
+                                                  molSystemDevice.indices.energyBufferStarts.data(),
+                                                  molSystemDevice.indices.atomIdxToBatchIdx.data(),
+                                                  molSystemDevice.indices.angleConstraintTermStarts.data(),
+                                                  stream);
+  }
+  if (err == cudaSuccess && contribs.torsionConstraintTerms.idx1.size() > 0) {
+    err = MMFF::launchTorsionConstraintEnergyKernel(contribs.torsionConstraintTerms.idx1.size(),
+                                                    contribs.torsionConstraintTerms.idx1.data(),
+                                                    contribs.torsionConstraintTerms.idx2.data(),
+                                                    contribs.torsionConstraintTerms.idx3.data(),
+                                                    contribs.torsionConstraintTerms.idx4.data(),
+                                                    contribs.torsionConstraintTerms.minDihedralDeg.data(),
+                                                    contribs.torsionConstraintTerms.maxDihedralDeg.data(),
+                                                    contribs.torsionConstraintTerms.forceConstant.data(),
+                                                    positions,
+                                                    molSystemDevice.energyBuffer.data(),
+                                                    molSystemDevice.indices.energyBufferStarts.data(),
+                                                    molSystemDevice.indices.atomIdxToBatchIdx.data(),
+                                                    molSystemDevice.indices.torsionConstraintTermStarts.data(),
+                                                    stream);
+  }
+  if (err == cudaSuccess) {
+    err = MMFF::launchReduceEnergiesKernel(molSystemDevice.indices.energyBufferBlockIdxToBatchIdx.size(),
+                                           molSystemDevice.energyBuffer.data(),
+                                           molSystemDevice.indices.energyBufferBlockIdxToBatchIdx.data(),
+                                           energyOuts,
+                                           activeSystemMask,
+                                           stream);
+  }
+  return err;
+}
+
+cudaError_t computeEnergy(BatchedMolecularDeviceBuffers& molSystemDevice, const double* coords, cudaStream_t stream) {
+  return computeEnergy(molSystemDevice, molSystemDevice.energyOuts.data(), coords != nullptr ? coords : molSystemDevice.positions.data(), nullptr, stream);
+}
+
+cudaError_t computeGradients(BatchedMolecularDeviceBuffers& molSystemDevice,
+                             const double*                  positions,
+                             double*                        grad,
+                             const uint8_t*                 activeSystemMask,
+                             cudaStream_t                   stream) {
+  const auto& contribs = molSystemDevice.contribs;
+  cudaError_t err      = cudaSuccess;
+  if (contribs.bondTerms.idx1.size() > 0) {
+    err = launchBondStretchGradientKernel(contribs.bondTerms.idx1.size(),
+                                          contribs.bondTerms.idx1.data(),
+                                          contribs.bondTerms.idx2.data(),
+                                          contribs.bondTerms.restLen.data(),
+                                          contribs.bondTerms.forceConstant.data(),
+                                          positions,
+                                          grad,
+                                          stream);
+  }
+  if (err == cudaSuccess && contribs.angleTerms.idx1.size() > 0) {
+    err = launchAngleBendGradientKernel(contribs.angleTerms.idx1.size(),
+                                        contribs.angleTerms.idx1.data(),
+                                        contribs.angleTerms.idx2.data(),
+                                        contribs.angleTerms.idx3.data(),
+                                        contribs.angleTerms.theta0.data(),
+                                        contribs.angleTerms.forceConstant.data(),
+                                        contribs.angleTerms.order.data(),
+                                        contribs.angleTerms.C0.data(),
+                                        contribs.angleTerms.C1.data(),
+                                        contribs.angleTerms.C2.data(),
+                                        positions,
+                                        grad,
+                                        stream);
+  }
+  if (err == cudaSuccess && contribs.torsionTerms.idx1.size() > 0) {
+    err = launchTorsionGradientKernel(contribs.torsionTerms.idx1.size(),
+                                      contribs.torsionTerms.idx1.data(),
+                                      contribs.torsionTerms.idx2.data(),
+                                      contribs.torsionTerms.idx3.data(),
+                                      contribs.torsionTerms.idx4.data(),
+                                      contribs.torsionTerms.forceConstant.data(),
+                                      contribs.torsionTerms.order.data(),
+                                      contribs.torsionTerms.cosTerm.data(),
+                                      positions,
+                                      grad,
+                                      stream);
+  }
+  if (err == cudaSuccess && contribs.inversionTerms.idx1.size() > 0) {
+    err = launchInversionGradientKernel(contribs.inversionTerms.idx1.size(),
+                                        contribs.inversionTerms.idx1.data(),
+                                        contribs.inversionTerms.idx2.data(),
+                                        contribs.inversionTerms.idx3.data(),
+                                        contribs.inversionTerms.idx4.data(),
+                                        contribs.inversionTerms.forceConstant.data(),
+                                        contribs.inversionTerms.C0.data(),
+                                        contribs.inversionTerms.C1.data(),
+                                        contribs.inversionTerms.C2.data(),
+                                        positions,
+                                        grad,
+                                        stream);
+  }
+  if (err == cudaSuccess && contribs.vdwTerms.idx1.size() > 0) {
+    err = launchVdwGradientKernel(contribs.vdwTerms.idx1.size(),
+                                  contribs.vdwTerms.idx1.data(),
+                                  contribs.vdwTerms.idx2.data(),
+                                  contribs.vdwTerms.x_ij.data(),
+                                  contribs.vdwTerms.wellDepth.data(),
+                                  contribs.vdwTerms.threshold.data(),
+                                  positions,
+                                  grad,
+                                  stream);
+  }
+  if (err == cudaSuccess && contribs.distanceConstraintTerms.idx1.size() > 0) {
+    err = MMFF::launchDistanceConstraintGradientKernel(contribs.distanceConstraintTerms.idx1.size(),
+                                                       contribs.distanceConstraintTerms.idx1.data(),
+                                                       contribs.distanceConstraintTerms.idx2.data(),
+                                                       contribs.distanceConstraintTerms.minLen.data(),
+                                                       contribs.distanceConstraintTerms.maxLen.data(),
+                                                       contribs.distanceConstraintTerms.forceConstant.data(),
+                                                       positions,
+                                                       grad,
+                                                       stream);
+  }
+  if (err == cudaSuccess && contribs.positionConstraintTerms.idx.size() > 0) {
+    err = MMFF::launchPositionConstraintGradientKernel(contribs.positionConstraintTerms.idx.size(),
+                                                       contribs.positionConstraintTerms.idx.data(),
+                                                       contribs.positionConstraintTerms.refX.data(),
+                                                       contribs.positionConstraintTerms.refY.data(),
+                                                       contribs.positionConstraintTerms.refZ.data(),
+                                                       contribs.positionConstraintTerms.maxDispl.data(),
+                                                       contribs.positionConstraintTerms.forceConstant.data(),
+                                                       positions,
+                                                       grad,
+                                                       stream);
+  }
+  if (err == cudaSuccess && contribs.angleConstraintTerms.idx1.size() > 0) {
+    err = MMFF::launchAngleConstraintGradientKernel(contribs.angleConstraintTerms.idx1.size(),
+                                                    contribs.angleConstraintTerms.idx1.data(),
+                                                    contribs.angleConstraintTerms.idx2.data(),
+                                                    contribs.angleConstraintTerms.idx3.data(),
+                                                    contribs.angleConstraintTerms.minAngleDeg.data(),
+                                                    contribs.angleConstraintTerms.maxAngleDeg.data(),
+                                                    contribs.angleConstraintTerms.forceConstant.data(),
+                                                    positions,
+                                                    grad,
+                                                    stream);
+  }
+  if (err == cudaSuccess && contribs.torsionConstraintTerms.idx1.size() > 0) {
+    err = MMFF::launchTorsionConstraintGradientKernel(contribs.torsionConstraintTerms.idx1.size(),
+                                                      contribs.torsionConstraintTerms.idx1.data(),
+                                                      contribs.torsionConstraintTerms.idx2.data(),
+                                                      contribs.torsionConstraintTerms.idx3.data(),
+                                                      contribs.torsionConstraintTerms.idx4.data(),
+                                                      contribs.torsionConstraintTerms.minDihedralDeg.data(),
+                                                      contribs.torsionConstraintTerms.maxDihedralDeg.data(),
+                                                      contribs.torsionConstraintTerms.forceConstant.data(),
+                                                      positions,
+                                                      grad,
+                                                      stream);
+  }
+  if (err == cudaSuccess && activeSystemMask != nullptr && molSystemDevice.indices.atomIdxToBatchIdx.size() > 0) {
+    constexpr int blockSize = 256;
+    const int     numTerms  = molSystemDevice.indices.atomIdxToBatchIdx.size() * 3;
+    const int     numBlocks = (numTerms + blockSize - 1) / blockSize;
+    zeroInactiveGradientEntries<<<numBlocks, blockSize, 0, stream>>>(molSystemDevice.indices.atomIdxToBatchIdx.data(),
+                                                                     activeSystemMask,
+                                                                     molSystemDevice.indices.atomIdxToBatchIdx.size(),
+                                                                     3,
+                                                                     grad);
+    err = cudaGetLastError();
+  }
+  return err;
+}
+
+cudaError_t computeGradients(BatchedMolecularDeviceBuffers& molSystemDevice, cudaStream_t stream) {
+  return computeGradients(
+    molSystemDevice, molSystemDevice.positions.data(), molSystemDevice.grad.data(), nullptr, stream);
+}
+
+cudaError_t computeEnergyBlockPerMol(BatchedMolecularDeviceBuffers& molSystemDevice,
+                                     const double*                  coords,
+                                     cudaStream_t                   stream) {
+  return launchBlockPerMolEnergyKernel(molSystemDevice.indices.atomStarts.size() - 1,
+                                       toPointerStruct(molSystemDevice.contribs),
+                                       toPointerStruct(molSystemDevice.indices),
+                                       coords != nullptr ? coords : molSystemDevice.positions.data(),
+                                       molSystemDevice.energyOuts.data(),
+                                       stream);
+}
+
+cudaError_t computeGradBlockPerMol(BatchedMolecularDeviceBuffers& molSystemDevice, cudaStream_t stream) {
+  return launchBlockPerMolGradKernel(molSystemDevice.indices.atomStarts.size() - 1,
+                                     toPointerStruct(molSystemDevice.contribs),
+                                     toPointerStruct(molSystemDevice.indices),
+                                     molSystemDevice.positions.data(),
+                                     molSystemDevice.grad.data(),
+                                     stream);
+}
+
+EnergyForceContribsDevicePtr toEnergyForceContribsDevicePtr(const BatchedMolecularDeviceBuffers& molSystemDevice) {
+  return toPointerStruct(molSystemDevice.contribs);
+}
+
+BatchedIndicesDevicePtr toBatchedIndicesDevicePtr(const BatchedMolecularDeviceBuffers& molSystemDevice) {
+  return toPointerStruct(molSystemDevice.indices);
+}
+
+}  // namespace UFF
+}  // namespace nvMolKit

--- a/src/forcefields/uff.cu
+++ b/src/forcefields/uff.cu
@@ -124,16 +124,14 @@ __global__ void zeroInactiveGradientEntries(const int*     atomIdxToBatchIdx,
   }
 }
 
-template <typename T>
-void appendOffsetIndices(std::vector<T>& dst, const std::vector<T>& src, const int offset) {
+template <typename T> void appendOffsetIndices(std::vector<T>& dst, const std::vector<T>& src, const int offset) {
   dst.reserve(dst.size() + src.size());
   for (const auto value : src) {
     dst.push_back(value + offset);
   }
 }
 
-template <typename T>
-void appendValues(std::vector<T>& dst, const std::vector<T>& src) {
+template <typename T> void appendValues(std::vector<T>& dst, const std::vector<T>& src) {
   dst.insert(dst.end(), src.begin(), src.end());
 }
 
@@ -301,14 +299,17 @@ void sendContribsAndIndicesToDevice(const BatchedMolecularSystemHost& molSystemH
   molSystemDevice.indices.atomStarts.setFromVector(molSystemHost.indices.atomStarts);
   molSystemDevice.indices.atomIdxToBatchIdx.setFromVector(molSystemHost.indices.atomIdxToBatchIdx);
   molSystemDevice.indices.energyBufferStarts.setFromVector(molSystemHost.indices.energyBufferStarts);
-  molSystemDevice.indices.energyBufferBlockIdxToBatchIdx.setFromVector(molSystemHost.indices.energyBufferBlockIdxToBatchIdx);
+  molSystemDevice.indices.energyBufferBlockIdxToBatchIdx.setFromVector(
+    molSystemHost.indices.energyBufferBlockIdxToBatchIdx);
   molSystemDevice.indices.bondTermStarts.setFromVector(molSystemHost.indices.bondTermStarts);
   molSystemDevice.indices.angleTermStarts.setFromVector(molSystemHost.indices.angleTermStarts);
   molSystemDevice.indices.torsionTermStarts.setFromVector(molSystemHost.indices.torsionTermStarts);
   molSystemDevice.indices.inversionTermStarts.setFromVector(molSystemHost.indices.inversionTermStarts);
   molSystemDevice.indices.vdwTermStarts.setFromVector(molSystemHost.indices.vdwTermStarts);
-  molSystemDevice.indices.distanceConstraintTermStarts.setFromVector(molSystemHost.indices.distanceConstraintTermStarts);
-  molSystemDevice.indices.positionConstraintTermStarts.setFromVector(molSystemHost.indices.positionConstraintTermStarts);
+  molSystemDevice.indices.distanceConstraintTermStarts.setFromVector(
+    molSystemHost.indices.distanceConstraintTermStarts);
+  molSystemDevice.indices.positionConstraintTermStarts.setFromVector(
+    molSystemHost.indices.positionConstraintTermStarts);
   molSystemDevice.indices.angleConstraintTermStarts.setFromVector(molSystemHost.indices.angleConstraintTermStarts);
   molSystemDevice.indices.torsionConstraintTermStarts.setFromVector(molSystemHost.indices.torsionConstraintTermStarts);
 }
@@ -316,11 +317,11 @@ void sendContribsAndIndicesToDevice(const BatchedMolecularSystemHost& molSystemH
 void addMoleculeToBatch(const EnergyForceContribsHost& contribs,
                         const std::vector<double>&     positions,
                         BatchedMolecularSystemHost&    molSystem) {
-  const int atomOffset   = molSystem.indices.atomStarts.back();
-  const int batchIdx     = static_cast<int>(molSystem.indices.atomStarts.size()) - 1;
-  const int newNumAtoms  = static_cast<int>(positions.size()) / 3;
-  auto&     indices      = molSystem.indices;
-  auto&     dstContribs  = molSystem.contribs;
+  const int atomOffset  = molSystem.indices.atomStarts.back();
+  const int batchIdx    = static_cast<int>(molSystem.indices.atomStarts.size()) - 1;
+  const int newNumAtoms = static_cast<int>(positions.size()) / 3;
+  auto&     indices     = molSystem.indices;
+  auto&     dstContribs = molSystem.contribs;
 
   indices.atomStarts.push_back(atomOffset + newNumAtoms);
   molSystem.maxNumAtoms = std::max(molSystem.maxNumAtoms, newNumAtoms);
@@ -342,17 +343,17 @@ void addMoleculeToBatch(const EnergyForceContribsHost& contribs,
                                                 contribs.torsionConstraintTerms.idx1.size());
 
   int maxNumContribs = 0;
-  maxNumContribs = std::max<int>(maxNumContribs, contribs.bondTerms.idx1.size());
-  maxNumContribs = std::max<int>(maxNumContribs, contribs.angleTerms.idx1.size());
-  maxNumContribs = std::max<int>(maxNumContribs, contribs.torsionTerms.idx1.size());
-  maxNumContribs = std::max<int>(maxNumContribs, contribs.inversionTerms.idx1.size());
-  maxNumContribs = std::max<int>(maxNumContribs, contribs.vdwTerms.idx1.size());
-  maxNumContribs = std::max<int>(maxNumContribs, contribs.distanceConstraintTerms.idx1.size());
-  maxNumContribs = std::max<int>(maxNumContribs, contribs.positionConstraintTerms.idx.size());
-  maxNumContribs = std::max<int>(maxNumContribs, contribs.angleConstraintTerms.idx1.size());
-  maxNumContribs = std::max<int>(maxNumContribs, contribs.torsionConstraintTerms.idx1.size());
+  maxNumContribs     = std::max<int>(maxNumContribs, contribs.bondTerms.idx1.size());
+  maxNumContribs     = std::max<int>(maxNumContribs, contribs.angleTerms.idx1.size());
+  maxNumContribs     = std::max<int>(maxNumContribs, contribs.torsionTerms.idx1.size());
+  maxNumContribs     = std::max<int>(maxNumContribs, contribs.inversionTerms.idx1.size());
+  maxNumContribs     = std::max<int>(maxNumContribs, contribs.vdwTerms.idx1.size());
+  maxNumContribs     = std::max<int>(maxNumContribs, contribs.distanceConstraintTerms.idx1.size());
+  maxNumContribs     = std::max<int>(maxNumContribs, contribs.positionConstraintTerms.idx.size());
+  maxNumContribs     = std::max<int>(maxNumContribs, contribs.angleConstraintTerms.idx1.size());
+  maxNumContribs     = std::max<int>(maxNumContribs, contribs.torsionConstraintTerms.idx1.size());
 
-  const int numBlocksNeeded  =
+  const int numBlocksNeeded =
     (maxNumContribs + FFKernelUtils::blockSizeEnergyReduction - 1) / FFKernelUtils::blockSizeEnergyReduction;
   const int numThreadsNeeded = numBlocksNeeded * FFKernelUtils::blockSizeEnergyReduction;
   indices.energyBufferStarts.push_back(indices.energyBufferStarts.back() + numThreadsNeeded);
@@ -444,7 +445,9 @@ void addMoleculeToBatch(const EnergyForceContribsHost& contribs,
 
 void allocateIntermediateBuffers(const BatchedMolecularSystemHost& molSystemHost,
                                  BatchedMolecularDeviceBuffers&    molSystemDevice) {
-  FFKernelUtils::allocateIntermediateBuffers(molSystemHost, molSystemDevice, molSystemHost.indices.atomStarts.size() - 1);
+  FFKernelUtils::allocateIntermediateBuffers(molSystemHost,
+                                             molSystemDevice,
+                                             molSystemHost.indices.atomStarts.size() - 1);
 }
 
 cudaError_t computeEnergy(BatchedMolecularDeviceBuffers& molSystemDevice,
@@ -608,7 +611,11 @@ cudaError_t computeEnergy(BatchedMolecularDeviceBuffers& molSystemDevice,
 }
 
 cudaError_t computeEnergy(BatchedMolecularDeviceBuffers& molSystemDevice, const double* coords, cudaStream_t stream) {
-  return computeEnergy(molSystemDevice, molSystemDevice.energyOuts.data(), coords != nullptr ? coords : molSystemDevice.positions.data(), nullptr, stream);
+  return computeEnergy(molSystemDevice,
+                       molSystemDevice.energyOuts.data(),
+                       coords != nullptr ? coords : molSystemDevice.positions.data(),
+                       nullptr,
+                       stream);
 }
 
 cudaError_t computeGradients(BatchedMolecularDeviceBuffers& molSystemDevice,
@@ -744,8 +751,11 @@ cudaError_t computeGradients(BatchedMolecularDeviceBuffers& molSystemDevice,
 }
 
 cudaError_t computeGradients(BatchedMolecularDeviceBuffers& molSystemDevice, cudaStream_t stream) {
-  return computeGradients(
-    molSystemDevice, molSystemDevice.positions.data(), molSystemDevice.grad.data(), nullptr, stream);
+  return computeGradients(molSystemDevice,
+                          molSystemDevice.positions.data(),
+                          molSystemDevice.grad.data(),
+                          nullptr,
+                          stream);
 }
 
 cudaError_t computeEnergyBlockPerMol(BatchedMolecularDeviceBuffers& molSystemDevice,

--- a/src/forcefields/uff.h
+++ b/src/forcefields/uff.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/forcefields/uff.h
+++ b/src/forcefields/uff.h
@@ -22,6 +22,8 @@
 
 #include "batched_forcefield.h"
 #include "device_vector.h"
+// TODO: Constraint types and kernels (DistanceConstraintTerms, launchReduceEnergiesKernel, etc.)
+// should be extracted from MMFF into shared forcefield-generic headers so UFF doesn't depend on MMFF.
 #include "mmff.h"
 #include "uff_kernels.h"
 
@@ -82,20 +84,19 @@ using AngleConstraintTerms    = MMFF::AngleConstraintTerms;
 using TorsionConstraintTerms  = MMFF::TorsionConstraintTerms;
 
 struct EnergyForceContribsHost {
-  BondStretchTerms       bondTerms;
-  AngleBendTerms         angleTerms;
-  TorsionTerms           torsionTerms;
-  InversionTerms         inversionTerms;
-  VdwTerms               vdwTerms;
+  BondStretchTerms        bondTerms;
+  AngleBendTerms          angleTerms;
+  TorsionTerms            torsionTerms;
+  InversionTerms          inversionTerms;
+  VdwTerms                vdwTerms;
   DistanceConstraintTerms distanceConstraintTerms;
   PositionConstraintTerms positionConstraintTerms;
   AngleConstraintTerms    angleConstraintTerms;
   TorsionConstraintTerms  torsionConstraintTerms;
 };
 
-using HostCustomization = std::function<void(const BatchedSystemInfo&,
-                                             const std::vector<double>&,
-                                             EnergyForceContribsHost&)>;
+using HostCustomization =
+  std::function<void(const BatchedSystemInfo&, const std::vector<double>&, EnergyForceContribsHost&)>;
 
 struct BatchedIndicesHost {
   std::vector<int> atomStarts         = {0};
@@ -175,11 +176,11 @@ using AngleConstraintTermsDevice    = MMFF::AngleConstraintTermsDevice;
 using TorsionConstraintTermsDevice  = MMFF::TorsionConstraintTermsDevice;
 
 struct EnergyForceContribsDevice {
-  BondStretchTermsDevice       bondTerms;
-  AngleBendTermsDevice         angleTerms;
-  TorsionTermsDevice           torsionTerms;
-  InversionTermsDevice         inversionTerms;
-  VdwTermsDevice               vdwTerms;
+  BondStretchTermsDevice        bondTerms;
+  AngleBendTermsDevice          angleTerms;
+  TorsionTermsDevice            torsionTerms;
+  InversionTermsDevice          inversionTerms;
+  VdwTermsDevice                vdwTerms;
   DistanceConstraintTermsDevice distanceConstraintTerms;
   PositionConstraintTermsDevice positionConstraintTerms;
   AngleConstraintTermsDevice    angleConstraintTerms;
@@ -204,12 +205,12 @@ struct BatchedIndicesDevice {
 };
 
 struct BatchedMolecularDeviceBuffers {
-  EnergyForceContribsDevice   contribs;
-  BatchedIndicesDevice        indices;
-  AsyncDeviceVector<double>   positions;
-  AsyncDeviceVector<double>   grad;
-  AsyncDeviceVector<double>   energyBuffer;
-  AsyncDeviceVector<double>   energyOuts;
+  EnergyForceContribsDevice contribs;
+  BatchedIndicesDevice      indices;
+  AsyncDeviceVector<double> positions;
+  AsyncDeviceVector<double> grad;
+  AsyncDeviceVector<double> energyBuffer;
+  AsyncDeviceVector<double> energyOuts;
 };
 
 void addMoleculeToBatch(const EnergyForceContribsHost& contribs,

--- a/src/forcefields/uff.h
+++ b/src/forcefields/uff.h
@@ -1,0 +1,266 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NVMOLKIT_UFF_H
+#define NVMOLKIT_UFF_H
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include "batched_forcefield.h"
+#include "device_vector.h"
+#include "mmff.h"
+#include "uff_kernels.h"
+
+namespace nvMolKit {
+namespace UFF {
+
+struct BondStretchTerms {
+  std::vector<int>    idx1;
+  std::vector<int>    idx2;
+  std::vector<double> restLen;
+  std::vector<double> forceConstant;
+};
+
+struct AngleBendTerms {
+  std::vector<int>          idx1;
+  std::vector<int>          idx2;
+  std::vector<int>          idx3;
+  std::vector<double>       theta0;
+  std::vector<double>       forceConstant;
+  std::vector<std::uint8_t> order;
+  std::vector<double>       C0;
+  std::vector<double>       C1;
+  std::vector<double>       C2;
+};
+
+struct TorsionTerms {
+  std::vector<int>          idx1;
+  std::vector<int>          idx2;
+  std::vector<int>          idx3;
+  std::vector<int>          idx4;
+  std::vector<double>       forceConstant;
+  std::vector<std::uint8_t> order;
+  std::vector<double>       cosTerm;
+};
+
+struct InversionTerms {
+  std::vector<int>    idx1;
+  std::vector<int>    idx2;
+  std::vector<int>    idx3;
+  std::vector<int>    idx4;
+  std::vector<double> forceConstant;
+  std::vector<double> C0;
+  std::vector<double> C1;
+  std::vector<double> C2;
+};
+
+struct VdwTerms {
+  std::vector<int>    idx1;
+  std::vector<int>    idx2;
+  std::vector<double> x_ij;
+  std::vector<double> wellDepth;
+  std::vector<double> threshold;
+};
+
+using DistanceConstraintTerms = MMFF::DistanceConstraintTerms;
+using PositionConstraintTerms = MMFF::PositionConstraintTerms;
+using AngleConstraintTerms    = MMFF::AngleConstraintTerms;
+using TorsionConstraintTerms  = MMFF::TorsionConstraintTerms;
+
+struct EnergyForceContribsHost {
+  BondStretchTerms       bondTerms;
+  AngleBendTerms         angleTerms;
+  TorsionTerms           torsionTerms;
+  InversionTerms         inversionTerms;
+  VdwTerms               vdwTerms;
+  DistanceConstraintTerms distanceConstraintTerms;
+  PositionConstraintTerms positionConstraintTerms;
+  AngleConstraintTerms    angleConstraintTerms;
+  TorsionConstraintTerms  torsionConstraintTerms;
+};
+
+using HostCustomization = std::function<void(const BatchedSystemInfo&,
+                                             const std::vector<double>&,
+                                             EnergyForceContribsHost&)>;
+
+struct BatchedIndicesHost {
+  std::vector<int> atomStarts         = {0};
+  std::vector<int> energyBufferStarts = {0};
+  std::vector<int> atomIdxToBatchIdx;
+  std::vector<int> energyBufferBlockIdxToBatchIdx;
+
+  std::vector<int> bondTermStarts               = {0};
+  std::vector<int> angleTermStarts              = {0};
+  std::vector<int> torsionTermStarts            = {0};
+  std::vector<int> inversionTermStarts          = {0};
+  std::vector<int> vdwTermStarts                = {0};
+  std::vector<int> distanceConstraintTermStarts = {0};
+  std::vector<int> positionConstraintTermStarts = {0};
+  std::vector<int> angleConstraintTermStarts    = {0};
+  std::vector<int> torsionConstraintTermStarts  = {0};
+};
+
+struct BatchedMolecularSystemHost {
+  EnergyForceContribsHost contribs;
+  BatchedIndicesHost      indices;
+  std::vector<double>     positions;
+  int                     maxNumAtoms = 0;
+};
+
+struct BondStretchTermsDevice {
+  AsyncDeviceVector<int>    idx1;
+  AsyncDeviceVector<int>    idx2;
+  AsyncDeviceVector<double> restLen;
+  AsyncDeviceVector<double> forceConstant;
+};
+
+struct AngleBendTermsDevice {
+  AsyncDeviceVector<int>          idx1;
+  AsyncDeviceVector<int>          idx2;
+  AsyncDeviceVector<int>          idx3;
+  AsyncDeviceVector<double>       theta0;
+  AsyncDeviceVector<double>       forceConstant;
+  AsyncDeviceVector<std::uint8_t> order;
+  AsyncDeviceVector<double>       C0;
+  AsyncDeviceVector<double>       C1;
+  AsyncDeviceVector<double>       C2;
+};
+
+struct TorsionTermsDevice {
+  AsyncDeviceVector<int>          idx1;
+  AsyncDeviceVector<int>          idx2;
+  AsyncDeviceVector<int>          idx3;
+  AsyncDeviceVector<int>          idx4;
+  AsyncDeviceVector<double>       forceConstant;
+  AsyncDeviceVector<std::uint8_t> order;
+  AsyncDeviceVector<double>       cosTerm;
+};
+
+struct InversionTermsDevice {
+  AsyncDeviceVector<int>    idx1;
+  AsyncDeviceVector<int>    idx2;
+  AsyncDeviceVector<int>    idx3;
+  AsyncDeviceVector<int>    idx4;
+  AsyncDeviceVector<double> forceConstant;
+  AsyncDeviceVector<double> C0;
+  AsyncDeviceVector<double> C1;
+  AsyncDeviceVector<double> C2;
+};
+
+struct VdwTermsDevice {
+  AsyncDeviceVector<int>    idx1;
+  AsyncDeviceVector<int>    idx2;
+  AsyncDeviceVector<double> x_ij;
+  AsyncDeviceVector<double> wellDepth;
+  AsyncDeviceVector<double> threshold;
+};
+
+using DistanceConstraintTermsDevice = MMFF::DistanceConstraintTermsDevice;
+using PositionConstraintTermsDevice = MMFF::PositionConstraintTermsDevice;
+using AngleConstraintTermsDevice    = MMFF::AngleConstraintTermsDevice;
+using TorsionConstraintTermsDevice  = MMFF::TorsionConstraintTermsDevice;
+
+struct EnergyForceContribsDevice {
+  BondStretchTermsDevice       bondTerms;
+  AngleBendTermsDevice         angleTerms;
+  TorsionTermsDevice           torsionTerms;
+  InversionTermsDevice         inversionTerms;
+  VdwTermsDevice               vdwTerms;
+  DistanceConstraintTermsDevice distanceConstraintTerms;
+  PositionConstraintTermsDevice positionConstraintTerms;
+  AngleConstraintTermsDevice    angleConstraintTerms;
+  TorsionConstraintTermsDevice  torsionConstraintTerms;
+};
+
+struct BatchedIndicesDevice {
+  AsyncDeviceVector<int> atomStarts;
+  AsyncDeviceVector<int> atomIdxToBatchIdx;
+  AsyncDeviceVector<int> energyBufferStarts;
+  AsyncDeviceVector<int> energyBufferBlockIdxToBatchIdx;
+
+  AsyncDeviceVector<int> bondTermStarts;
+  AsyncDeviceVector<int> angleTermStarts;
+  AsyncDeviceVector<int> torsionTermStarts;
+  AsyncDeviceVector<int> inversionTermStarts;
+  AsyncDeviceVector<int> vdwTermStarts;
+  AsyncDeviceVector<int> distanceConstraintTermStarts;
+  AsyncDeviceVector<int> positionConstraintTermStarts;
+  AsyncDeviceVector<int> angleConstraintTermStarts;
+  AsyncDeviceVector<int> torsionConstraintTermStarts;
+};
+
+struct BatchedMolecularDeviceBuffers {
+  EnergyForceContribsDevice   contribs;
+  BatchedIndicesDevice        indices;
+  AsyncDeviceVector<double>   positions;
+  AsyncDeviceVector<double>   grad;
+  AsyncDeviceVector<double>   energyBuffer;
+  AsyncDeviceVector<double>   energyOuts;
+};
+
+void addMoleculeToBatch(const EnergyForceContribsHost& contribs,
+                        const std::vector<double>&     positions,
+                        BatchedMolecularSystemHost&    molSystem);
+
+void addMoleculeToBatch(const EnergyForceContribsHost& contribs,
+                        const std::vector<double>&     positions,
+                        BatchedMolecularSystemHost&    molSystem,
+                        BatchedForcefieldMetadata&     metadata,
+                        int                            moleculeIdx,
+                        int                            conformerIdx,
+                        const HostCustomization&       customization = {});
+
+void setStreams(BatchedMolecularDeviceBuffers& molSystemDevice, cudaStream_t stream);
+
+void sendContribsAndIndicesToDevice(const BatchedMolecularSystemHost& molSystemHost,
+                                    BatchedMolecularDeviceBuffers&    molSystemDevice);
+
+void allocateIntermediateBuffers(const BatchedMolecularSystemHost& molSystemHost,
+                                 BatchedMolecularDeviceBuffers&    molSystemDevice);
+
+cudaError_t computeEnergy(BatchedMolecularDeviceBuffers& molSystemDevice,
+                          double*                        energyOuts,
+                          const double*                  positions,
+                          const uint8_t*                 activeSystemMask = nullptr,
+                          cudaStream_t                   stream           = nullptr);
+
+cudaError_t computeEnergy(BatchedMolecularDeviceBuffers& molSystemDevice,
+                          const double*                  coords = nullptr,
+                          cudaStream_t                   stream = nullptr);
+
+cudaError_t computeEnergyBlockPerMol(BatchedMolecularDeviceBuffers& molSystemDevice,
+                                     const double*                  coords = nullptr,
+                                     cudaStream_t                   stream = nullptr);
+
+cudaError_t computeGradients(BatchedMolecularDeviceBuffers& molSystemDevice,
+                             const double*                  positions,
+                             double*                        grad,
+                             const uint8_t*                 activeSystemMask = nullptr,
+                             cudaStream_t                   stream           = nullptr);
+
+cudaError_t computeGradients(BatchedMolecularDeviceBuffers& molSystemDevice, cudaStream_t stream = nullptr);
+
+cudaError_t computeGradBlockPerMol(BatchedMolecularDeviceBuffers& molSystemDevice, cudaStream_t stream = nullptr);
+
+EnergyForceContribsDevicePtr toEnergyForceContribsDevicePtr(const BatchedMolecularDeviceBuffers& molSystemDevice);
+
+BatchedIndicesDevicePtr toBatchedIndicesDevicePtr(const BatchedMolecularDeviceBuffers& molSystemDevice);
+
+}  // namespace UFF
+}  // namespace nvMolKit
+
+#endif  // NVMOLKIT_UFF_H

--- a/src/forcefields/uff_batched_forcefield.cu
+++ b/src/forcefields/uff_batched_forcefield.cu
@@ -1,0 +1,36 @@
+#include "uff_batched_forcefield.h"
+
+namespace nvMolKit {
+namespace {
+void allocateEnergyScratch(const UFF::BatchedMolecularSystemHost& molSystemHost,
+                           UFF::BatchedMolecularDeviceBuffers&    systemDevice) {
+  systemDevice.energyBuffer.resize(molSystemHost.indices.energyBufferStarts.back());
+  systemDevice.energyBuffer.zero();
+}
+}  // namespace
+
+UFFBatchedForcefield::UFFBatchedForcefield(const UFF::BatchedMolecularSystemHost& molSystemHost,
+                                           BatchedForcefieldMetadata               metadata,
+                                           const cudaStream_t                      stream)
+    : BatchedForcefield(ForceFieldType::UFF, 3, molSystemHost.indices.atomStarts, nullptr, std::move(metadata)) {
+  UFF::setStreams(systemDevice_, stream);
+  UFF::sendContribsAndIndicesToDevice(molSystemHost, systemDevice_);
+  allocateEnergyScratch(molSystemHost, systemDevice_);
+  setAtomStartsDevice(systemDevice_.indices.atomStarts.data());
+}
+
+cudaError_t UFFBatchedForcefield::computeEnergy(double*        energyOuts,
+                                                const double*  positions,
+                                                const uint8_t* activeSystemMask,
+                                                cudaStream_t   stream) {
+  return UFF::computeEnergy(systemDevice_, energyOuts, positions, activeSystemMask, stream);
+}
+
+cudaError_t UFFBatchedForcefield::computeGradients(double*        grad,
+                                                   const double*  positions,
+                                                   const uint8_t* activeSystemMask,
+                                                   cudaStream_t   stream) {
+  return UFF::computeGradients(systemDevice_, positions, grad, activeSystemMask, stream);
+}
+
+}  // namespace nvMolKit

--- a/src/forcefields/uff_batched_forcefield.cu
+++ b/src/forcefields/uff_batched_forcefield.cu
@@ -10,8 +10,8 @@ void allocateEnergyScratch(const UFF::BatchedMolecularSystemHost& molSystemHost,
 }  // namespace
 
 UFFBatchedForcefield::UFFBatchedForcefield(const UFF::BatchedMolecularSystemHost& molSystemHost,
-                                           BatchedForcefieldMetadata               metadata,
-                                           const cudaStream_t                      stream)
+                                           BatchedForcefieldMetadata              metadata,
+                                           const cudaStream_t                     stream)
     : BatchedForcefield(ForceFieldType::UFF, 3, molSystemHost.indices.atomStarts, nullptr, std::move(metadata)) {
   UFF::setStreams(systemDevice_, stream);
   UFF::sendContribsAndIndicesToDevice(molSystemHost, systemDevice_);

--- a/src/forcefields/uff_batched_forcefield.cu
+++ b/src/forcefields/uff_batched_forcefield.cu
@@ -1,3 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "uff_batched_forcefield.h"
 
 namespace nvMolKit {

--- a/src/forcefields/uff_batched_forcefield.h
+++ b/src/forcefields/uff_batched_forcefield.h
@@ -1,0 +1,31 @@
+#ifndef NVMOLKIT_UFF_BATCHED_FORCEFIELD_H
+#define NVMOLKIT_UFF_BATCHED_FORCEFIELD_H
+
+#include "batched_forcefield.h"
+#include "uff.h"
+
+namespace nvMolKit {
+
+class UFFBatchedForcefield final : public BatchedForcefield {
+ public:
+  explicit UFFBatchedForcefield(const UFF::BatchedMolecularSystemHost& molSystemHost,
+                                BatchedForcefieldMetadata              metadata = {},
+                                cudaStream_t                           stream   = nullptr);
+
+  cudaError_t computeEnergy(double*        energyOuts,
+                            const double*  positions,
+                            const uint8_t* activeSystemMask = nullptr,
+                            cudaStream_t   stream           = nullptr) override;
+
+  cudaError_t computeGradients(double*        grad,
+                               const double*  positions,
+                               const uint8_t* activeSystemMask = nullptr,
+                               cudaStream_t   stream           = nullptr) override;
+
+ private:
+  UFF::BatchedMolecularDeviceBuffers systemDevice_;
+};
+
+}  // namespace nvMolKit
+
+#endif  // NVMOLKIT_UFF_BATCHED_FORCEFIELD_H

--- a/src/forcefields/uff_batched_forcefield.h
+++ b/src/forcefields/uff_batched_forcefield.h
@@ -1,3 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef NVMOLKIT_UFF_BATCHED_FORCEFIELD_H
 #define NVMOLKIT_UFF_BATCHED_FORCEFIELD_H
 

--- a/src/forcefields/uff_kernels.cu
+++ b/src/forcefields/uff_kernels.cu
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/forcefields/uff_kernels.cu
+++ b/src/forcefields/uff_kernels.cu
@@ -35,8 +35,8 @@ __global__ void bondStretchEnergyKernel(const int     numBonds,
                                         const int*    termBatchStarts) {
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < numBonds) {
-    const double energy = uffBondStretchEnergy(pos, idx1[idx], idx2[idx], restLen[idx], forceConstant[idx]);
-    const int    batchIdx = atomBatchMap[idx1[idx]];
+    const double energy    = uffBondStretchEnergy(pos, idx1[idx], idx2[idx], restLen[idx], forceConstant[idx]);
+    const int    batchIdx  = atomBatchMap[idx1[idx]];
     const int    outputIdx = getEnergyAccumulatorIndex(idx, batchIdx, energyBufferStarts, termBatchStarts);
     energyBuffer[outputIdx] += energy;
   }
@@ -72,10 +72,18 @@ __global__ void angleBendEnergyKernel(const int      numAngles,
                                       const int*     termBatchStarts) {
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < numAngles) {
-    const double energy = uffAngleBendEnergy(
-      pos, idx1[idx], idx2[idx], idx3[idx], theta0[idx], forceConstant[idx], order[idx], C0[idx], C1[idx], C2[idx]);
-    const int batchIdx  = atomBatchMap[idx1[idx]];
-    const int outputIdx = getEnergyAccumulatorIndex(idx, batchIdx, energyBufferStarts, termBatchStarts);
+    const double energy    = uffAngleBendEnergy(pos,
+                                             idx1[idx],
+                                             idx2[idx],
+                                             idx3[idx],
+                                             theta0[idx],
+                                             forceConstant[idx],
+                                             order[idx],
+                                             C0[idx],
+                                             C1[idx],
+                                             C2[idx]);
+    const int    batchIdx  = atomBatchMap[idx1[idx]];
+    const int    outputIdx = getEnergyAccumulatorIndex(idx, batchIdx, energyBufferStarts, termBatchStarts);
     energyBuffer[outputIdx] += energy;
   }
 }
@@ -94,8 +102,17 @@ __global__ void angleBendGradKernel(const int      numAngles,
                                     double*        grad) {
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < numAngles) {
-    uffAngleBendGrad(
-      pos, idx1[idx], idx2[idx], idx3[idx], theta0[idx], forceConstant[idx], order[idx], C0[idx], C1[idx], C2[idx], grad);
+    uffAngleBendGrad(pos,
+                     idx1[idx],
+                     idx2[idx],
+                     idx3[idx],
+                     theta0[idx],
+                     forceConstant[idx],
+                     order[idx],
+                     C0[idx],
+                     C1[idx],
+                     C2[idx],
+                     grad);
   }
 }
 
@@ -154,10 +171,17 @@ __global__ void inversionEnergyKernel(const int     numInversions,
                                       const int*    termBatchStarts) {
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < numInversions) {
-    const double energy =
-      uffInversionEnergy(pos, idx1[idx], idx2[idx], idx3[idx], idx4[idx], forceConstant[idx], C0[idx], C1[idx], C2[idx]);
-    const int batchIdx  = atomBatchMap[idx1[idx]];
-    const int outputIdx = getEnergyAccumulatorIndex(idx, batchIdx, energyBufferStarts, termBatchStarts);
+    const double energy    = uffInversionEnergy(pos,
+                                             idx1[idx],
+                                             idx2[idx],
+                                             idx3[idx],
+                                             idx4[idx],
+                                             forceConstant[idx],
+                                             C0[idx],
+                                             C1[idx],
+                                             C2[idx]);
+    const int    batchIdx  = atomBatchMap[idx1[idx]];
+    const int    outputIdx = getEnergyAccumulatorIndex(idx, batchIdx, energyBufferStarts, termBatchStarts);
     energyBuffer[outputIdx] += energy;
   }
 }
@@ -191,7 +215,7 @@ __global__ void vdwEnergyKernel(const int     numVdws,
                                 const int*    termBatchStarts) {
   const int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < numVdws) {
-    const double energy = uffVdwEnergy(pos, idx1[idx], idx2[idx], x_ij[idx], wellDepth[idx], threshold[idx]);
+    const double energy    = uffVdwEnergy(pos, idx1[idx], idx2[idx], x_ij[idx], wellDepth[idx], threshold[idx]);
     const int    batchIdx  = atomBatchMap[idx1[idx]];
     const int    outputIdx = getEnergyAccumulatorIndex(idx, batchIdx, energyBufferStarts, termBatchStarts);
     energyBuffer[outputIdx] += energy;
@@ -216,18 +240,18 @@ constexpr int blockSizePerMol = 128;
 
 __global__ void combinedEnergiesKernel(const nvMolKit::UFF::EnergyForceContribsDevicePtr* terms,
                                        const nvMolKit::UFF::BatchedIndicesDevicePtr*      systemIndices,
-                                       const double*                                       coords,
-                                       double*                                             energies) {
+                                       const double*                                      coords,
+                                       double*                                            energies) {
   const int molIdx = blockIdx.x;
   const int tid    = threadIdx.x;
 
-  const int atomStart = systemIndices->atomStarts[molIdx];
-  const double* molCoords = coords + atomStart * 3;
+  const int     atomStart   = systemIndices->atomStarts[molIdx];
+  const double* molCoords   = coords + atomStart * 3;
   const double threadEnergy = nvMolKit::UFF::molEnergy<blockSizePerMol>(*terms, *systemIndices, molCoords, molIdx, tid);
 
   using BlockReduce = cub::BlockReduce<double, blockSizePerMol>;
   __shared__ typename BlockReduce::TempStorage tempStorage;
-  const double blockEnergy = BlockReduce(tempStorage).Sum(threadEnergy);
+  const double                                 blockEnergy = BlockReduce(tempStorage).Sum(threadEnergy);
 
   if (tid == 0) {
     energies[molIdx] = blockEnergy;
@@ -236,8 +260,8 @@ __global__ void combinedEnergiesKernel(const nvMolKit::UFF::EnergyForceContribsD
 
 __global__ void combinedGradKernel(const nvMolKit::UFF::EnergyForceContribsDevicePtr* terms,
                                    const nvMolKit::UFF::BatchedIndicesDevicePtr*      systemIndices,
-                                   const double*                                       coords,
-                                   double*                                             grad) {
+                                   const double*                                      coords,
+                                   double*                                            grad) {
   const int molIdx = blockIdx.x;
   const int tid    = threadIdx.x;
 
@@ -245,7 +269,7 @@ __global__ void combinedGradKernel(const nvMolKit::UFF::EnergyForceContribsDevic
   const int atomEnd   = systemIndices->atomStarts[molIdx + 1];
   const int numAtoms  = atomEnd - atomStart;
 
-  constexpr int maxAtomSize = 256;
+  constexpr int     maxAtomSize = 256;
   __shared__ double accumGrad[maxAtomSize * 3];
 
   const bool useSharedMem = numAtoms <= maxAtomSize;
@@ -286,8 +310,16 @@ cudaError_t launchBondStretchEnergyKernel(int           numBonds,
                                           cudaStream_t  stream) {
   constexpr int blockSize = 256;
   const int     numBlocks = (numBonds + blockSize - 1) / blockSize;
-  bondStretchEnergyKernel<<<numBlocks, blockSize, 0, stream>>>(
-    numBonds, idx1, idx2, restLen, forceConstant, pos, energyBuffer, energyBufferStarts, atomBatchMap, termBatchStarts);
+  bondStretchEnergyKernel<<<numBlocks, blockSize, 0, stream>>>(numBonds,
+                                                               idx1,
+                                                               idx2,
+                                                               restLen,
+                                                               forceConstant,
+                                                               pos,
+                                                               energyBuffer,
+                                                               energyBufferStarts,
+                                                               atomBatchMap,
+                                                               termBatchStarts);
   return cudaGetLastError();
 }
 
@@ -356,8 +388,18 @@ cudaError_t launchAngleBendGradientKernel(int            numAngles,
                                           cudaStream_t   stream) {
   constexpr int blockSize = 256;
   const int     numBlocks = (numAngles + blockSize - 1) / blockSize;
-  angleBendGradKernel<<<numBlocks, blockSize, 0, stream>>>(
-    numAngles, idx1, idx2, idx3, theta0, forceConstant, order, C0, C1, C2, pos, grad);
+  angleBendGradKernel<<<numBlocks, blockSize, 0, stream>>>(numAngles,
+                                                           idx1,
+                                                           idx2,
+                                                           idx3,
+                                                           theta0,
+                                                           forceConstant,
+                                                           order,
+                                                           C0,
+                                                           C1,
+                                                           C2,
+                                                           pos,
+                                                           grad);
   return cudaGetLastError();
 }
 
@@ -406,8 +448,16 @@ cudaError_t launchTorsionGradientKernel(int            numTorsions,
                                         cudaStream_t   stream) {
   constexpr int blockSize = 256;
   const int     numBlocks = (numTorsions + blockSize - 1) / blockSize;
-  torsionGradKernel<<<numBlocks, blockSize, 0, stream>>>(
-    numTorsions, idx1, idx2, idx3, idx4, forceConstant, order, cosTerm, pos, grad);
+  torsionGradKernel<<<numBlocks, blockSize, 0, stream>>>(numTorsions,
+                                                         idx1,
+                                                         idx2,
+                                                         idx3,
+                                                         idx4,
+                                                         forceConstant,
+                                                         order,
+                                                         cosTerm,
+                                                         pos,
+                                                         grad);
   return cudaGetLastError();
 }
 
@@ -428,8 +478,20 @@ cudaError_t launchInversionEnergyKernel(int           numInversions,
                                         cudaStream_t  stream) {
   constexpr int blockSize = 256;
   const int     numBlocks = (numInversions + blockSize - 1) / blockSize;
-  inversionEnergyKernel<<<numBlocks, blockSize, 0, stream>>>(
-    numInversions, idx1, idx2, idx3, idx4, forceConstant, C0, C1, C2, pos, energyBuffer, energyBufferStarts, atomBatchMap, termBatchStarts);
+  inversionEnergyKernel<<<numBlocks, blockSize, 0, stream>>>(numInversions,
+                                                             idx1,
+                                                             idx2,
+                                                             idx3,
+                                                             idx4,
+                                                             forceConstant,
+                                                             C0,
+                                                             C1,
+                                                             C2,
+                                                             pos,
+                                                             energyBuffer,
+                                                             energyBufferStarts,
+                                                             atomBatchMap,
+                                                             termBatchStarts);
   return cudaGetLastError();
 }
 
@@ -448,7 +510,16 @@ cudaError_t launchInversionGradientKernel(int           numInversions,
   (void)C0;
   constexpr int blockSize = 256;
   const int     numBlocks = (numInversions + blockSize - 1) / blockSize;
-  inversionGradKernel<<<numBlocks, blockSize, 0, stream>>>(numInversions, idx1, idx2, idx3, idx4, forceConstant, C1, C2, pos, grad);
+  inversionGradKernel<<<numBlocks, blockSize, 0, stream>>>(numInversions,
+                                                           idx1,
+                                                           idx2,
+                                                           idx3,
+                                                           idx4,
+                                                           forceConstant,
+                                                           C1,
+                                                           C2,
+                                                           pos,
+                                                           grad);
   return cudaGetLastError();
 }
 
@@ -466,8 +537,17 @@ cudaError_t launchVdwEnergyKernel(int           numVdws,
                                   cudaStream_t  stream) {
   constexpr int blockSize = 256;
   const int     numBlocks = (numVdws + blockSize - 1) / blockSize;
-  vdwEnergyKernel<<<numBlocks, blockSize, 0, stream>>>(
-    numVdws, idx1, idx2, x_ij, wellDepth, threshold, pos, energyBuffer, energyBufferStarts, atomBatchMap, termBatchStarts);
+  vdwEnergyKernel<<<numBlocks, blockSize, 0, stream>>>(numVdws,
+                                                       idx1,
+                                                       idx2,
+                                                       x_ij,
+                                                       wellDepth,
+                                                       threshold,
+                                                       pos,
+                                                       energyBuffer,
+                                                       energyBufferStarts,
+                                                       atomBatchMap,
+                                                       termBatchStarts);
   return cudaGetLastError();
 }
 

--- a/src/forcefields/uff_kernels.cu
+++ b/src/forcefields/uff_kernels.cu
@@ -1,0 +1,514 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cub/cub.cuh>
+
+#include "kernel_utils.cuh"
+#include "uff_kernels.h"
+#include "uff_kernels_device.cuh"
+
+using namespace nvMolKit::FFKernelUtils;
+
+namespace {
+
+__global__ void bondStretchEnergyKernel(const int     numBonds,
+                                        const int*    idx1,
+                                        const int*    idx2,
+                                        const double* restLen,
+                                        const double* forceConstant,
+                                        const double* pos,
+                                        double*       energyBuffer,
+                                        const int*    energyBufferStarts,
+                                        const int*    atomBatchMap,
+                                        const int*    termBatchStarts) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numBonds) {
+    const double energy = uffBondStretchEnergy(pos, idx1[idx], idx2[idx], restLen[idx], forceConstant[idx]);
+    const int    batchIdx = atomBatchMap[idx1[idx]];
+    const int    outputIdx = getEnergyAccumulatorIndex(idx, batchIdx, energyBufferStarts, termBatchStarts);
+    energyBuffer[outputIdx] += energy;
+  }
+}
+
+__global__ void bondStretchGradKernel(const int     numBonds,
+                                      const int*    idx1,
+                                      const int*    idx2,
+                                      const double* restLen,
+                                      const double* forceConstant,
+                                      const double* pos,
+                                      double*       grad) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numBonds) {
+    uffBondStretchGrad(pos, idx1[idx], idx2[idx], restLen[idx], forceConstant[idx], grad);
+  }
+}
+
+__global__ void angleBendEnergyKernel(const int      numAngles,
+                                      const int*     idx1,
+                                      const int*     idx2,
+                                      const int*     idx3,
+                                      const double*  theta0,
+                                      const double*  forceConstant,
+                                      const uint8_t* order,
+                                      const double*  C0,
+                                      const double*  C1,
+                                      const double*  C2,
+                                      const double*  pos,
+                                      double*        energyBuffer,
+                                      const int*     energyBufferStarts,
+                                      const int*     atomBatchMap,
+                                      const int*     termBatchStarts) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numAngles) {
+    const double energy = uffAngleBendEnergy(
+      pos, idx1[idx], idx2[idx], idx3[idx], theta0[idx], forceConstant[idx], order[idx], C0[idx], C1[idx], C2[idx]);
+    const int batchIdx  = atomBatchMap[idx1[idx]];
+    const int outputIdx = getEnergyAccumulatorIndex(idx, batchIdx, energyBufferStarts, termBatchStarts);
+    energyBuffer[outputIdx] += energy;
+  }
+}
+
+__global__ void angleBendGradKernel(const int      numAngles,
+                                    const int*     idx1,
+                                    const int*     idx2,
+                                    const int*     idx3,
+                                    const double*  theta0,
+                                    const double*  forceConstant,
+                                    const uint8_t* order,
+                                    const double*  C0,
+                                    const double*  C1,
+                                    const double*  C2,
+                                    const double*  pos,
+                                    double*        grad) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numAngles) {
+    uffAngleBendGrad(
+      pos, idx1[idx], idx2[idx], idx3[idx], theta0[idx], forceConstant[idx], order[idx], C0[idx], C1[idx], C2[idx], grad);
+  }
+}
+
+__global__ void torsionEnergyKernel(const int      numTorsions,
+                                    const int*     idx1,
+                                    const int*     idx2,
+                                    const int*     idx3,
+                                    const int*     idx4,
+                                    const double*  forceConstant,
+                                    const uint8_t* order,
+                                    const double*  cosTerm,
+                                    const double*  pos,
+                                    double*        energyBuffer,
+                                    const int*     energyBufferStarts,
+                                    const int*     atomBatchMap,
+                                    const int*     termBatchStarts) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numTorsions) {
+    const double energy =
+      uffTorsionEnergy(pos, idx1[idx], idx2[idx], idx3[idx], idx4[idx], forceConstant[idx], order[idx], cosTerm[idx]);
+    const int batchIdx  = atomBatchMap[idx1[idx]];
+    const int outputIdx = getEnergyAccumulatorIndex(idx, batchIdx, energyBufferStarts, termBatchStarts);
+    energyBuffer[outputIdx] += energy;
+  }
+}
+
+__global__ void torsionGradKernel(const int      numTorsions,
+                                  const int*     idx1,
+                                  const int*     idx2,
+                                  const int*     idx3,
+                                  const int*     idx4,
+                                  const double*  forceConstant,
+                                  const uint8_t* order,
+                                  const double*  cosTerm,
+                                  const double*  pos,
+                                  double*        grad) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numTorsions) {
+    uffTorsionGrad(pos, idx1[idx], idx2[idx], idx3[idx], idx4[idx], forceConstant[idx], order[idx], cosTerm[idx], grad);
+  }
+}
+
+__global__ void inversionEnergyKernel(const int     numInversions,
+                                      const int*    idx1,
+                                      const int*    idx2,
+                                      const int*    idx3,
+                                      const int*    idx4,
+                                      const double* forceConstant,
+                                      const double* C0,
+                                      const double* C1,
+                                      const double* C2,
+                                      const double* pos,
+                                      double*       energyBuffer,
+                                      const int*    energyBufferStarts,
+                                      const int*    atomBatchMap,
+                                      const int*    termBatchStarts) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numInversions) {
+    const double energy =
+      uffInversionEnergy(pos, idx1[idx], idx2[idx], idx3[idx], idx4[idx], forceConstant[idx], C0[idx], C1[idx], C2[idx]);
+    const int batchIdx  = atomBatchMap[idx1[idx]];
+    const int outputIdx = getEnergyAccumulatorIndex(idx, batchIdx, energyBufferStarts, termBatchStarts);
+    energyBuffer[outputIdx] += energy;
+  }
+}
+
+__global__ void inversionGradKernel(const int     numInversions,
+                                    const int*    idx1,
+                                    const int*    idx2,
+                                    const int*    idx3,
+                                    const int*    idx4,
+                                    const double* forceConstant,
+                                    const double* C1,
+                                    const double* C2,
+                                    const double* pos,
+                                    double*       grad) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numInversions) {
+    uffInversionGrad(pos, idx1[idx], idx2[idx], idx3[idx], idx4[idx], forceConstant[idx], C1[idx], C2[idx], grad);
+  }
+}
+
+__global__ void vdwEnergyKernel(const int     numVdws,
+                                const int*    idx1,
+                                const int*    idx2,
+                                const double* x_ij,
+                                const double* wellDepth,
+                                const double* threshold,
+                                const double* pos,
+                                double*       energyBuffer,
+                                const int*    energyBufferStarts,
+                                const int*    atomBatchMap,
+                                const int*    termBatchStarts) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numVdws) {
+    const double energy = uffVdwEnergy(pos, idx1[idx], idx2[idx], x_ij[idx], wellDepth[idx], threshold[idx]);
+    const int    batchIdx  = atomBatchMap[idx1[idx]];
+    const int    outputIdx = getEnergyAccumulatorIndex(idx, batchIdx, energyBufferStarts, termBatchStarts);
+    energyBuffer[outputIdx] += energy;
+  }
+}
+
+__global__ void vdwGradKernel(const int     numVdws,
+                              const int*    idx1,
+                              const int*    idx2,
+                              const double* x_ij,
+                              const double* wellDepth,
+                              const double* threshold,
+                              const double* pos,
+                              double*       grad) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numVdws) {
+    uffVdwGrad(pos, idx1[idx], idx2[idx], x_ij[idx], wellDepth[idx], threshold[idx], grad);
+  }
+}
+
+constexpr int blockSizePerMol = 128;
+
+__global__ void combinedEnergiesKernel(const nvMolKit::UFF::EnergyForceContribsDevicePtr* terms,
+                                       const nvMolKit::UFF::BatchedIndicesDevicePtr*      systemIndices,
+                                       const double*                                       coords,
+                                       double*                                             energies) {
+  const int molIdx = blockIdx.x;
+  const int tid    = threadIdx.x;
+
+  const int atomStart = systemIndices->atomStarts[molIdx];
+  const double* molCoords = coords + atomStart * 3;
+  const double threadEnergy = nvMolKit::UFF::molEnergy<blockSizePerMol>(*terms, *systemIndices, molCoords, molIdx, tid);
+
+  using BlockReduce = cub::BlockReduce<double, blockSizePerMol>;
+  __shared__ typename BlockReduce::TempStorage tempStorage;
+  const double blockEnergy = BlockReduce(tempStorage).Sum(threadEnergy);
+
+  if (tid == 0) {
+    energies[molIdx] = blockEnergy;
+  }
+}
+
+__global__ void combinedGradKernel(const nvMolKit::UFF::EnergyForceContribsDevicePtr* terms,
+                                   const nvMolKit::UFF::BatchedIndicesDevicePtr*      systemIndices,
+                                   const double*                                       coords,
+                                   double*                                             grad) {
+  const int molIdx = blockIdx.x;
+  const int tid    = threadIdx.x;
+
+  const int atomStart = systemIndices->atomStarts[molIdx];
+  const int atomEnd   = systemIndices->atomStarts[molIdx + 1];
+  const int numAtoms  = atomEnd - atomStart;
+
+  constexpr int maxAtomSize = 256;
+  __shared__ double accumGrad[maxAtomSize * 3];
+
+  const bool useSharedMem = numAtoms <= maxAtomSize;
+  double*    molGradBase  = useSharedMem ? accumGrad : grad + atomStart * 3;
+
+  for (int i = tid; i < numAtoms * 3; i += blockSizePerMol) {
+    molGradBase[i] = 0.0;
+  }
+  __syncthreads();
+
+  const double* molCoords = coords + atomStart * 3;
+  nvMolKit::UFF::molGrad<blockSizePerMol>(*terms, *systemIndices, molCoords, molGradBase, molIdx, tid);
+  __syncthreads();
+
+  if (useSharedMem) {
+    double* globalGrad = grad + atomStart * 3;
+    for (int i = tid; i < numAtoms * 3; i += blockSizePerMol) {
+      globalGrad[i] = molGradBase[i];
+    }
+  }
+}
+
+}  // namespace
+
+namespace nvMolKit {
+namespace UFF {
+
+cudaError_t launchBondStretchEnergyKernel(int           numBonds,
+                                          const int*    idx1,
+                                          const int*    idx2,
+                                          const double* restLen,
+                                          const double* forceConstant,
+                                          const double* pos,
+                                          double*       energyBuffer,
+                                          const int*    energyBufferStarts,
+                                          const int*    atomBatchMap,
+                                          const int*    termBatchStarts,
+                                          cudaStream_t  stream) {
+  constexpr int blockSize = 256;
+  const int     numBlocks = (numBonds + blockSize - 1) / blockSize;
+  bondStretchEnergyKernel<<<numBlocks, blockSize, 0, stream>>>(
+    numBonds, idx1, idx2, restLen, forceConstant, pos, energyBuffer, energyBufferStarts, atomBatchMap, termBatchStarts);
+  return cudaGetLastError();
+}
+
+cudaError_t launchBondStretchGradientKernel(int           numBonds,
+                                            const int*    idx1,
+                                            const int*    idx2,
+                                            const double* restLen,
+                                            const double* forceConstant,
+                                            const double* pos,
+                                            double*       grad,
+                                            cudaStream_t  stream) {
+  constexpr int blockSize = 256;
+  const int     numBlocks = (numBonds + blockSize - 1) / blockSize;
+  bondStretchGradKernel<<<numBlocks, blockSize, 0, stream>>>(numBonds, idx1, idx2, restLen, forceConstant, pos, grad);
+  return cudaGetLastError();
+}
+
+cudaError_t launchAngleBendEnergyKernel(int            numAngles,
+                                        const int*     idx1,
+                                        const int*     idx2,
+                                        const int*     idx3,
+                                        const double*  theta0,
+                                        const double*  forceConstant,
+                                        const uint8_t* order,
+                                        const double*  C0,
+                                        const double*  C1,
+                                        const double*  C2,
+                                        const double*  pos,
+                                        double*        energyBuffer,
+                                        const int*     energyBufferStarts,
+                                        const int*     atomBatchMap,
+                                        const int*     termBatchStarts,
+                                        cudaStream_t   stream) {
+  constexpr int blockSize = 256;
+  const int     numBlocks = (numAngles + blockSize - 1) / blockSize;
+  angleBendEnergyKernel<<<numBlocks, blockSize, 0, stream>>>(numAngles,
+                                                             idx1,
+                                                             idx2,
+                                                             idx3,
+                                                             theta0,
+                                                             forceConstant,
+                                                             order,
+                                                             C0,
+                                                             C1,
+                                                             C2,
+                                                             pos,
+                                                             energyBuffer,
+                                                             energyBufferStarts,
+                                                             atomBatchMap,
+                                                             termBatchStarts);
+  return cudaGetLastError();
+}
+
+cudaError_t launchAngleBendGradientKernel(int            numAngles,
+                                          const int*     idx1,
+                                          const int*     idx2,
+                                          const int*     idx3,
+                                          const double*  theta0,
+                                          const double*  forceConstant,
+                                          const uint8_t* order,
+                                          const double*  C0,
+                                          const double*  C1,
+                                          const double*  C2,
+                                          const double*  pos,
+                                          double*        grad,
+                                          cudaStream_t   stream) {
+  constexpr int blockSize = 256;
+  const int     numBlocks = (numAngles + blockSize - 1) / blockSize;
+  angleBendGradKernel<<<numBlocks, blockSize, 0, stream>>>(
+    numAngles, idx1, idx2, idx3, theta0, forceConstant, order, C0, C1, C2, pos, grad);
+  return cudaGetLastError();
+}
+
+cudaError_t launchTorsionEnergyKernel(int            numTorsions,
+                                      const int*     idx1,
+                                      const int*     idx2,
+                                      const int*     idx3,
+                                      const int*     idx4,
+                                      const double*  forceConstant,
+                                      const uint8_t* order,
+                                      const double*  cosTerm,
+                                      const double*  pos,
+                                      double*        energyBuffer,
+                                      const int*     energyBufferStarts,
+                                      const int*     atomBatchMap,
+                                      const int*     termBatchStarts,
+                                      cudaStream_t   stream) {
+  constexpr int blockSize = 256;
+  const int     numBlocks = (numTorsions + blockSize - 1) / blockSize;
+  torsionEnergyKernel<<<numBlocks, blockSize, 0, stream>>>(numTorsions,
+                                                           idx1,
+                                                           idx2,
+                                                           idx3,
+                                                           idx4,
+                                                           forceConstant,
+                                                           order,
+                                                           cosTerm,
+                                                           pos,
+                                                           energyBuffer,
+                                                           energyBufferStarts,
+                                                           atomBatchMap,
+                                                           termBatchStarts);
+  return cudaGetLastError();
+}
+
+cudaError_t launchTorsionGradientKernel(int            numTorsions,
+                                        const int*     idx1,
+                                        const int*     idx2,
+                                        const int*     idx3,
+                                        const int*     idx4,
+                                        const double*  forceConstant,
+                                        const uint8_t* order,
+                                        const double*  cosTerm,
+                                        const double*  pos,
+                                        double*        grad,
+                                        cudaStream_t   stream) {
+  constexpr int blockSize = 256;
+  const int     numBlocks = (numTorsions + blockSize - 1) / blockSize;
+  torsionGradKernel<<<numBlocks, blockSize, 0, stream>>>(
+    numTorsions, idx1, idx2, idx3, idx4, forceConstant, order, cosTerm, pos, grad);
+  return cudaGetLastError();
+}
+
+cudaError_t launchInversionEnergyKernel(int           numInversions,
+                                        const int*    idx1,
+                                        const int*    idx2,
+                                        const int*    idx3,
+                                        const int*    idx4,
+                                        const double* forceConstant,
+                                        const double* C0,
+                                        const double* C1,
+                                        const double* C2,
+                                        const double* pos,
+                                        double*       energyBuffer,
+                                        const int*    energyBufferStarts,
+                                        const int*    atomBatchMap,
+                                        const int*    termBatchStarts,
+                                        cudaStream_t  stream) {
+  constexpr int blockSize = 256;
+  const int     numBlocks = (numInversions + blockSize - 1) / blockSize;
+  inversionEnergyKernel<<<numBlocks, blockSize, 0, stream>>>(
+    numInversions, idx1, idx2, idx3, idx4, forceConstant, C0, C1, C2, pos, energyBuffer, energyBufferStarts, atomBatchMap, termBatchStarts);
+  return cudaGetLastError();
+}
+
+cudaError_t launchInversionGradientKernel(int           numInversions,
+                                          const int*    idx1,
+                                          const int*    idx2,
+                                          const int*    idx3,
+                                          const int*    idx4,
+                                          const double* forceConstant,
+                                          const double* C0,
+                                          const double* C1,
+                                          const double* C2,
+                                          const double* pos,
+                                          double*       grad,
+                                          cudaStream_t  stream) {
+  (void)C0;
+  constexpr int blockSize = 256;
+  const int     numBlocks = (numInversions + blockSize - 1) / blockSize;
+  inversionGradKernel<<<numBlocks, blockSize, 0, stream>>>(numInversions, idx1, idx2, idx3, idx4, forceConstant, C1, C2, pos, grad);
+  return cudaGetLastError();
+}
+
+cudaError_t launchVdwEnergyKernel(int           numVdws,
+                                  const int*    idx1,
+                                  const int*    idx2,
+                                  const double* x_ij,
+                                  const double* wellDepth,
+                                  const double* threshold,
+                                  const double* pos,
+                                  double*       energyBuffer,
+                                  const int*    energyBufferStarts,
+                                  const int*    atomBatchMap,
+                                  const int*    termBatchStarts,
+                                  cudaStream_t  stream) {
+  constexpr int blockSize = 256;
+  const int     numBlocks = (numVdws + blockSize - 1) / blockSize;
+  vdwEnergyKernel<<<numBlocks, blockSize, 0, stream>>>(
+    numVdws, idx1, idx2, x_ij, wellDepth, threshold, pos, energyBuffer, energyBufferStarts, atomBatchMap, termBatchStarts);
+  return cudaGetLastError();
+}
+
+cudaError_t launchVdwGradientKernel(int           numVdws,
+                                    const int*    idx1,
+                                    const int*    idx2,
+                                    const double* x_ij,
+                                    const double* wellDepth,
+                                    const double* threshold,
+                                    const double* pos,
+                                    double*       grad,
+                                    cudaStream_t  stream) {
+  constexpr int blockSize = 256;
+  const int     numBlocks = (numVdws + blockSize - 1) / blockSize;
+  vdwGradKernel<<<numBlocks, blockSize, 0, stream>>>(numVdws, idx1, idx2, x_ij, wellDepth, threshold, pos, grad);
+  return cudaGetLastError();
+}
+
+cudaError_t launchBlockPerMolEnergyKernel(int                                 numMols,
+                                          const EnergyForceContribsDevicePtr& terms,
+                                          const BatchedIndicesDevicePtr&      systemIndices,
+                                          const double*                       coords,
+                                          double*                             energies,
+                                          cudaStream_t                        stream) {
+  const AsyncDevicePtr<EnergyForceContribsDevicePtr> devTerms(terms, stream);
+  const AsyncDevicePtr<BatchedIndicesDevicePtr>      devSysIdx(systemIndices, stream);
+  combinedEnergiesKernel<<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, energies);
+  return cudaGetLastError();
+}
+
+cudaError_t launchBlockPerMolGradKernel(int                                 numMols,
+                                        const EnergyForceContribsDevicePtr& terms,
+                                        const BatchedIndicesDevicePtr&      systemIndices,
+                                        const double*                       coords,
+                                        double*                             grad,
+                                        cudaStream_t                        stream) {
+  const AsyncDevicePtr<EnergyForceContribsDevicePtr> devTerms(terms, stream);
+  const AsyncDevicePtr<BatchedIndicesDevicePtr>      devSysIdx(systemIndices, stream);
+  combinedGradKernel<<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, grad);
+  return cudaGetLastError();
+}
+
+}  // namespace UFF
+}  // namespace nvMolKit

--- a/src/forcefields/uff_kernels.h
+++ b/src/forcefields/uff_kernels.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/forcefields/uff_kernels.h
+++ b/src/forcefields/uff_kernels.h
@@ -203,11 +203,11 @@ struct VdwTermsDevicePtr {
 };
 
 struct EnergyForceContribsDevicePtr {
-  BondStretchTermsDevicePtr             bondTerms;
-  AngleBendTermsDevicePtr               angleTerms;
-  TorsionTermsDevicePtr                 torsionTerms;
-  InversionTermsDevicePtr               inversionTerms;
-  VdwTermsDevicePtr                     vdwTerms;
+  BondStretchTermsDevicePtr              bondTerms;
+  AngleBendTermsDevicePtr                angleTerms;
+  TorsionTermsDevicePtr                  torsionTerms;
+  InversionTermsDevicePtr                inversionTerms;
+  VdwTermsDevicePtr                      vdwTerms;
   MMFF::DistanceConstraintTermsDevicePtr distanceConstraintTerms;
   MMFF::PositionConstraintTermsDevicePtr positionConstraintTerms;
   MMFF::AngleConstraintTermsDevicePtr    angleConstraintTerms;

--- a/src/forcefields/uff_kernels.h
+++ b/src/forcefields/uff_kernels.h
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NVMOLKIT_UFF_KERNELS_H
+#define NVMOLKIT_UFF_KERNELS_H
+
+#include <cstdint>
+
+#include "mmff_kernels.h"
+
+namespace nvMolKit {
+namespace UFF {
+
+cudaError_t launchBondStretchEnergyKernel(int           numBonds,
+                                          const int*    idx1,
+                                          const int*    idx2,
+                                          const double* restLen,
+                                          const double* forceConstant,
+                                          const double* pos,
+                                          double*       energyBuffer,
+                                          const int*    energyBufferStarts,
+                                          const int*    atomBatchMap,
+                                          const int*    termBatchStarts,
+                                          cudaStream_t  stream = 0);
+
+cudaError_t launchBondStretchGradientKernel(int           numBonds,
+                                            const int*    idx1,
+                                            const int*    idx2,
+                                            const double* restLen,
+                                            const double* forceConstant,
+                                            const double* pos,
+                                            double*       grad,
+                                            cudaStream_t  stream = 0);
+
+cudaError_t launchAngleBendEnergyKernel(int            numAngles,
+                                        const int*     idx1,
+                                        const int*     idx2,
+                                        const int*     idx3,
+                                        const double*  theta0,
+                                        const double*  forceConstant,
+                                        const uint8_t* order,
+                                        const double*  C0,
+                                        const double*  C1,
+                                        const double*  C2,
+                                        const double*  pos,
+                                        double*        energyBuffer,
+                                        const int*     energyBufferStarts,
+                                        const int*     atomBatchMap,
+                                        const int*     termBatchStarts,
+                                        cudaStream_t   stream = 0);
+
+cudaError_t launchAngleBendGradientKernel(int            numAngles,
+                                          const int*     idx1,
+                                          const int*     idx2,
+                                          const int*     idx3,
+                                          const double*  theta0,
+                                          const double*  forceConstant,
+                                          const uint8_t* order,
+                                          const double*  C0,
+                                          const double*  C1,
+                                          const double*  C2,
+                                          const double*  pos,
+                                          double*        grad,
+                                          cudaStream_t   stream = 0);
+
+cudaError_t launchTorsionEnergyKernel(int            numTorsions,
+                                      const int*     idx1,
+                                      const int*     idx2,
+                                      const int*     idx3,
+                                      const int*     idx4,
+                                      const double*  forceConstant,
+                                      const uint8_t* order,
+                                      const double*  cosTerm,
+                                      const double*  pos,
+                                      double*        energyBuffer,
+                                      const int*     energyBufferStarts,
+                                      const int*     atomBatchMap,
+                                      const int*     termBatchStarts,
+                                      cudaStream_t   stream = 0);
+
+cudaError_t launchTorsionGradientKernel(int            numTorsions,
+                                        const int*     idx1,
+                                        const int*     idx2,
+                                        const int*     idx3,
+                                        const int*     idx4,
+                                        const double*  forceConstant,
+                                        const uint8_t* order,
+                                        const double*  cosTerm,
+                                        const double*  pos,
+                                        double*        grad,
+                                        cudaStream_t   stream = 0);
+
+cudaError_t launchInversionEnergyKernel(int           numInversions,
+                                        const int*    idx1,
+                                        const int*    idx2,
+                                        const int*    idx3,
+                                        const int*    idx4,
+                                        const double* forceConstant,
+                                        const double* C0,
+                                        const double* C1,
+                                        const double* C2,
+                                        const double* pos,
+                                        double*       energyBuffer,
+                                        const int*    energyBufferStarts,
+                                        const int*    atomBatchMap,
+                                        const int*    termBatchStarts,
+                                        cudaStream_t  stream = 0);
+
+cudaError_t launchInversionGradientKernel(int           numInversions,
+                                          const int*    idx1,
+                                          const int*    idx2,
+                                          const int*    idx3,
+                                          const int*    idx4,
+                                          const double* forceConstant,
+                                          const double* C0,
+                                          const double* C1,
+                                          const double* C2,
+                                          const double* pos,
+                                          double*       grad,
+                                          cudaStream_t  stream = 0);
+
+cudaError_t launchVdwEnergyKernel(int           numVdws,
+                                  const int*    idx1,
+                                  const int*    idx2,
+                                  const double* x_ij,
+                                  const double* wellDepth,
+                                  const double* threshold,
+                                  const double* pos,
+                                  double*       energyBuffer,
+                                  const int*    energyBufferStarts,
+                                  const int*    atomBatchMap,
+                                  const int*    termBatchStarts,
+                                  cudaStream_t  stream = 0);
+
+cudaError_t launchVdwGradientKernel(int           numVdws,
+                                    const int*    idx1,
+                                    const int*    idx2,
+                                    const double* x_ij,
+                                    const double* wellDepth,
+                                    const double* threshold,
+                                    const double* pos,
+                                    double*       grad,
+                                    cudaStream_t  stream = 0);
+
+struct BondStretchTermsDevicePtr {
+  int*    idx1          = nullptr;
+  int*    idx2          = nullptr;
+  double* restLen       = nullptr;
+  double* forceConstant = nullptr;
+};
+
+struct AngleBendTermsDevicePtr {
+  int*          idx1          = nullptr;
+  int*          idx2          = nullptr;
+  int*          idx3          = nullptr;
+  double*       theta0        = nullptr;
+  double*       forceConstant = nullptr;
+  std::uint8_t* order         = nullptr;
+  double*       C0            = nullptr;
+  double*       C1            = nullptr;
+  double*       C2            = nullptr;
+};
+
+struct TorsionTermsDevicePtr {
+  int*          idx1          = nullptr;
+  int*          idx2          = nullptr;
+  int*          idx3          = nullptr;
+  int*          idx4          = nullptr;
+  double*       forceConstant = nullptr;
+  std::uint8_t* order         = nullptr;
+  double*       cosTerm       = nullptr;
+};
+
+struct InversionTermsDevicePtr {
+  int*    idx1          = nullptr;
+  int*    idx2          = nullptr;
+  int*    idx3          = nullptr;
+  int*    idx4          = nullptr;
+  double* forceConstant = nullptr;
+  double* C0            = nullptr;
+  double* C1            = nullptr;
+  double* C2            = nullptr;
+};
+
+struct VdwTermsDevicePtr {
+  int*    idx1      = nullptr;
+  int*    idx2      = nullptr;
+  double* x_ij      = nullptr;
+  double* wellDepth = nullptr;
+  double* threshold = nullptr;
+};
+
+struct EnergyForceContribsDevicePtr {
+  BondStretchTermsDevicePtr             bondTerms;
+  AngleBendTermsDevicePtr               angleTerms;
+  TorsionTermsDevicePtr                 torsionTerms;
+  InversionTermsDevicePtr               inversionTerms;
+  VdwTermsDevicePtr                     vdwTerms;
+  MMFF::DistanceConstraintTermsDevicePtr distanceConstraintTerms;
+  MMFF::PositionConstraintTermsDevicePtr positionConstraintTerms;
+  MMFF::AngleConstraintTermsDevicePtr    angleConstraintTerms;
+  MMFF::TorsionConstraintTermsDevicePtr  torsionConstraintTerms;
+};
+
+struct BatchedIndicesDevicePtr {
+  int* atomStarts                   = nullptr;
+  int* bondTermStarts               = nullptr;
+  int* angleTermStarts              = nullptr;
+  int* torsionTermStarts            = nullptr;
+  int* inversionTermStarts          = nullptr;
+  int* vdwTermStarts                = nullptr;
+  int* distanceConstraintTermStarts = nullptr;
+  int* positionConstraintTermStarts = nullptr;
+  int* angleConstraintTermStarts    = nullptr;
+  int* torsionConstraintTermStarts  = nullptr;
+};
+
+cudaError_t launchBlockPerMolEnergyKernel(int                                 numMols,
+                                          const EnergyForceContribsDevicePtr& terms,
+                                          const BatchedIndicesDevicePtr&      sytemIndices,
+                                          const double*                       coords,
+                                          double*                             energies,
+                                          cudaStream_t                        stream = nullptr);
+
+cudaError_t launchBlockPerMolGradKernel(int                                 numMols,
+                                        const EnergyForceContribsDevicePtr& terms,
+                                        const BatchedIndicesDevicePtr&      sytemIndices,
+                                        const double*                       coords,
+                                        double*                             grad,
+                                        cudaStream_t                        stream = nullptr);
+
+}  // namespace UFF
+}  // namespace nvMolKit
+
+#endif  // NVMOLKIT_UFF_KERNELS_H

--- a/src/forcefields/uff_kernels_device.cuh
+++ b/src/forcefields/uff_kernels_device.cuh
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/forcefields/uff_kernels_device.cuh
+++ b/src/forcefields/uff_kernels_device.cuh
@@ -26,9 +26,13 @@ namespace {
 constexpr double kUffAngleCorrectionThreshold = 0.8660;
 constexpr double kUffZeroTol                  = 1.0e-16;
 
-__device__ __forceinline__ double squareValue(const double x) { return x * x; }
+__device__ __forceinline__ double squareValue(const double x) {
+  return x * x;
+}
 
-__device__ __forceinline__ double cubeValue(const double x) { return x * x * x; }
+__device__ __forceinline__ double cubeValue(const double x) {
+  return x * x * x;
+}
 
 __device__ __forceinline__ double uffBondStretchEnergy(const double* pos,
                                                        const int     idx1,
@@ -69,8 +73,8 @@ __device__ __forceinline__ void uffBondStretchGrad(const double* pos,
   atomicAdd(&grad[3 * idx2 + 2], -gz);
 }
 
-__device__ __forceinline__ double uffAngleEnergyTerm(const double cosTheta,
-                                                     const double sinThetaSq,
+__device__ __forceinline__ double uffAngleEnergyTerm(const double  cosTheta,
+                                                     const double  sinThetaSq,
                                                      const uint8_t order,
                                                      const double  C0,
                                                      const double  C1,
@@ -101,8 +105,8 @@ __device__ __forceinline__ double uffAngleEnergyTerm(const double cosTheta,
   return (1.0 - result) / static_cast<double>(order * order);
 }
 
-__device__ __forceinline__ double uffAngleThetaDeriv(const double cosTheta,
-                                                     const double sinTheta,
+__device__ __forceinline__ double uffAngleThetaDeriv(const double  cosTheta,
+                                                     const double  sinTheta,
                                                      const uint8_t order,
                                                      const double  forceConstant,
                                                      const double  C1,
@@ -290,9 +294,9 @@ __device__ __forceinline__ double uffTorsionEnergy(const double* pos,
                                                    const double  forceConstant,
                                                    const uint8_t order,
                                                    const double  cosTerm) {
-  const double cosPhi    = uffCalculateCosTorsion(pos, idx1, idx2, idx3, idx4);
-  const double sinPhiSq  = 1.0 - cosPhi * cosPhi;
-  double       cosNPhi   = 0.0;
+  const double cosPhi   = uffCalculateCosTorsion(pos, idx1, idx2, idx3, idx4);
+  const double sinPhiSq = 1.0 - cosPhi * cosPhi;
+  double       cosNPhi  = 0.0;
   switch (order) {
     case 2:
       cosNPhi = 1.0 - 2.0 * sinPhiSq;
@@ -365,19 +369,19 @@ __device__ __forceinline__ void uffTorsionGrad(const double* pos,
   atomicAdd(&grad[3 * idx1 + 1], sinTerm * (dCos_dT0 * r1z - dCos_dT2 * r1x));
   atomicAdd(&grad[3 * idx1 + 2], sinTerm * (dCos_dT1 * r1x - dCos_dT0 * r1y));
 
-  atomicAdd(&grad[3 * idx2 + 0], sinTerm * (dCos_dT1 * (r1z - r0z) + dCos_dT2 * (r0y - r1y) + dCos_dT4 * (-r3z) +
-                                            dCos_dT5 * (r3y)));
-  atomicAdd(&grad[3 * idx2 + 1], sinTerm * (dCos_dT0 * (r0z - r1z) + dCos_dT2 * (r1x - r0x) + dCos_dT3 * (r3z) +
-                                            dCos_dT5 * (-r3x)));
-  atomicAdd(&grad[3 * idx2 + 2], sinTerm * (dCos_dT0 * (r1y - r0y) + dCos_dT1 * (r0x - r1x) + dCos_dT3 * (-r3y) +
-                                            dCos_dT4 * (r3x)));
+  atomicAdd(&grad[3 * idx2 + 0],
+            sinTerm * (dCos_dT1 * (r1z - r0z) + dCos_dT2 * (r0y - r1y) + dCos_dT4 * (-r3z) + dCos_dT5 * (r3y)));
+  atomicAdd(&grad[3 * idx2 + 1],
+            sinTerm * (dCos_dT0 * (r0z - r1z) + dCos_dT2 * (r1x - r0x) + dCos_dT3 * (r3z) + dCos_dT5 * (-r3x)));
+  atomicAdd(&grad[3 * idx2 + 2],
+            sinTerm * (dCos_dT0 * (r1y - r0y) + dCos_dT1 * (r0x - r1x) + dCos_dT3 * (-r3y) + dCos_dT4 * (r3x)));
 
-  atomicAdd(&grad[3 * idx3 + 0], sinTerm * (dCos_dT1 * r0z + dCos_dT2 * (-r0y) + dCos_dT4 * (r3z - r2z) +
-                                            dCos_dT5 * (r2y - r3y)));
-  atomicAdd(&grad[3 * idx3 + 1], sinTerm * (dCos_dT0 * (-r0z) + dCos_dT2 * r0x + dCos_dT3 * (r2z - r3z) +
-                                            dCos_dT5 * (r3x - r2x)));
-  atomicAdd(&grad[3 * idx3 + 2], sinTerm * (dCos_dT0 * r0y + dCos_dT1 * (-r0x) + dCos_dT3 * (r3y - r2y) +
-                                            dCos_dT4 * (r2x - r3x)));
+  atomicAdd(&grad[3 * idx3 + 0],
+            sinTerm * (dCos_dT1 * r0z + dCos_dT2 * (-r0y) + dCos_dT4 * (r3z - r2z) + dCos_dT5 * (r2y - r3y)));
+  atomicAdd(&grad[3 * idx3 + 1],
+            sinTerm * (dCos_dT0 * (-r0z) + dCos_dT2 * r0x + dCos_dT3 * (r2z - r3z) + dCos_dT5 * (r3x - r2x)));
+  atomicAdd(&grad[3 * idx3 + 2],
+            sinTerm * (dCos_dT0 * r0y + dCos_dT1 * (-r0x) + dCos_dT3 * (r3y - r2y) + dCos_dT4 * (r2x - r3x)));
 
   atomicAdd(&grad[3 * idx4 + 0], sinTerm * (dCos_dT4 * r2z - dCos_dT5 * r2y));
   atomicAdd(&grad[3 * idx4 + 1], sinTerm * (dCos_dT5 * r2x - dCos_dT3 * r2z));
@@ -482,8 +486,8 @@ __device__ __forceinline__ void uffInversionGrad(const double* pos,
 
   double cosY = nx * rJLx + ny * rJLy + nz * rJLz;
   clipToOne(cosY);
-  const double sinYSq = 1.0 - cosY * cosY;
-  const double sinY   = fmax(sqrt(sinYSq), 1.0e-8);
+  const double sinYSq   = 1.0 - cosY * cosY;
+  const double sinY     = fmax(sqrt(sinYSq), 1.0e-8);
   double       cosTheta = rJIx * rJKx + rJIy * rJKy + rJIz * rJKz;
   clipToOne(cosTheta);
   const double sinThetaSq = 1.0 - cosTheta * cosTheta;
@@ -596,9 +600,11 @@ __device__ __inline__ double molEnergy(const EnergyForceContribsDevicePtr& terms
   const int bondEnd   = systemIndices.bondTermStarts[molIdx + 1];
 #pragma unroll 1
   for (int i = bondStart + tid; i < bondEnd; i += stride) {
-    energy += uffBondStretchEnergy(
-      molCoords, terms.bondTerms.idx1[i] - atomStart, terms.bondTerms.idx2[i] - atomStart, terms.bondTerms.restLen[i],
-      terms.bondTerms.forceConstant[i]);
+    energy += uffBondStretchEnergy(molCoords,
+                                   terms.bondTerms.idx1[i] - atomStart,
+                                   terms.bondTerms.idx2[i] - atomStart,
+                                   terms.bondTerms.restLen[i],
+                                   terms.bondTerms.forceConstant[i]);
   }
 
   const int angleStart = systemIndices.angleTermStarts[molIdx];
@@ -726,9 +732,12 @@ __device__ __inline__ void molGrad(const EnergyForceContribsDevicePtr& terms,
   const int bondEnd   = systemIndices.bondTermStarts[molIdx + 1];
 #pragma unroll 1
   for (int i = bondStart + tid; i < bondEnd; i += stride) {
-    uffBondStretchGrad(
-      molCoords, terms.bondTerms.idx1[i] - atomStart, terms.bondTerms.idx2[i] - atomStart, terms.bondTerms.restLen[i],
-      terms.bondTerms.forceConstant[i], grad);
+    uffBondStretchGrad(molCoords,
+                       terms.bondTerms.idx1[i] - atomStart,
+                       terms.bondTerms.idx2[i] - atomStart,
+                       terms.bondTerms.restLen[i],
+                       terms.bondTerms.forceConstant[i],
+                       grad);
   }
 
   const int angleStart = systemIndices.angleTermStarts[molIdx];

--- a/src/forcefields/uff_kernels_device.cuh
+++ b/src/forcefields/uff_kernels_device.cuh
@@ -1,0 +1,854 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NVMOLKIT_UFF_KERNELS_DEVICE_CUH
+#define NVMOLKIT_UFF_KERNELS_DEVICE_CUH
+
+#include <cmath>
+
+#include "mmff_kernels_device.cuh"
+
+using namespace nvMolKit::FFKernelUtils;
+
+namespace {
+constexpr double kUffAngleCorrectionThreshold = 0.8660;
+constexpr double kUffZeroTol                  = 1.0e-16;
+
+__device__ __forceinline__ double squareValue(const double x) { return x * x; }
+
+__device__ __forceinline__ double cubeValue(const double x) { return x * x * x; }
+
+__device__ __forceinline__ double uffBondStretchEnergy(const double* pos,
+                                                       const int     idx1,
+                                                       const int     idx2,
+                                                       const double  restLen,
+                                                       const double  forceConstant) {
+  const double dist = sqrt(distanceSquared(pos, idx1, idx2));
+  const double diff = dist - restLen;
+  return 0.5 * forceConstant * diff * diff;
+}
+
+__device__ __forceinline__ void uffBondStretchGrad(const double* pos,
+                                                   const int     idx1,
+                                                   const int     idx2,
+                                                   const double  restLen,
+                                                   const double  forceConstant,
+                                                   double*       grad) {
+  double       dx, dy, dz;
+  const double distSq = distanceSquaredWithComponents(pos, idx1, idx2, dx, dy, dz);
+  const double dist   = sqrt(distSq);
+  const double pref   = forceConstant * (dist - restLen);
+
+  double gx = forceConstant * 0.01;
+  double gy = gx;
+  double gz = gx;
+  if (dist > 0.0) {
+    const double invDist = 1.0 / dist;
+    gx                   = pref * dx * invDist;
+    gy                   = pref * dy * invDist;
+    gz                   = pref * dz * invDist;
+  }
+
+  atomicAdd(&grad[3 * idx1 + 0], gx);
+  atomicAdd(&grad[3 * idx1 + 1], gy);
+  atomicAdd(&grad[3 * idx1 + 2], gz);
+  atomicAdd(&grad[3 * idx2 + 0], -gx);
+  atomicAdd(&grad[3 * idx2 + 1], -gy);
+  atomicAdd(&grad[3 * idx2 + 2], -gz);
+}
+
+__device__ __forceinline__ double uffAngleEnergyTerm(const double cosTheta,
+                                                     const double sinThetaSq,
+                                                     const uint8_t order,
+                                                     const double  C0,
+                                                     const double  C1,
+                                                     const double  C2) {
+  const double cos2Theta = cosTheta * cosTheta - sinThetaSq;
+  if (order == 0) {
+    return C0 + C1 * cosTheta + C2 * cos2Theta;
+  }
+
+  double result = 0.0;
+  switch (order) {
+    case 1:
+      result = -cosTheta;
+      break;
+    case 2:
+      result = cos2Theta;
+      break;
+    case 3:
+      result = cosTheta * (cosTheta * cosTheta - 3.0 * sinThetaSq);
+      break;
+    case 4:
+      result = squareValue(squareValue(cosTheta)) - 6.0 * cosTheta * cosTheta * sinThetaSq + squareValue(sinThetaSq);
+      break;
+    default:
+      result = 0.0;
+      break;
+  }
+  return (1.0 - result) / static_cast<double>(order * order);
+}
+
+__device__ __forceinline__ double uffAngleThetaDeriv(const double cosTheta,
+                                                     const double sinTheta,
+                                                     const uint8_t order,
+                                                     const double  forceConstant,
+                                                     const double  C1,
+                                                     const double  C2) {
+  const double sin2Theta = 2.0 * sinTheta * cosTheta;
+  if (order == 0) {
+    return -forceConstant * (C1 * sinTheta + 2.0 * C2 * sin2Theta);
+  }
+
+  double result = 0.0;
+  switch (order) {
+    case 1:
+      result = -sinTheta;
+      break;
+    case 2:
+      result = sin2Theta;
+      break;
+    case 3:
+      result = sinTheta * (3.0 - 4.0 * sinTheta * sinTheta);
+      break;
+    case 4:
+      result = cosTheta * sinTheta * (4.0 - 8.0 * sinTheta * sinTheta);
+      break;
+    default:
+      return 0.0;
+  }
+  return result * forceConstant / static_cast<double>(order);
+}
+
+__device__ __forceinline__ double uffAngleBendEnergy(const double* pos,
+                                                     const int     idx1,
+                                                     const int     idx2,
+                                                     const int     idx3,
+                                                     const double  theta0,
+                                                     const double  forceConstant,
+                                                     const uint8_t order,
+                                                     const double  C0,
+                                                     const double  C1,
+                                                     const double  C2) {
+  double       dx1, dy1, dz1, dx2, dy2, dz2;
+  const double dist1Sq = distanceSquaredWithComponents(pos, idx1, idx2, dx1, dy1, dz1);
+  const double dist2Sq = distanceSquaredWithComponents(pos, idx3, idx2, dx2, dy2, dz2);
+  const double dist1   = sqrt(dist1Sq);
+  const double dist2   = sqrt(dist2Sq);
+  if (dist1 <= 0.0 || dist2 <= 0.0) {
+    return 0.0;
+  }
+
+  double cosTheta = (dx1 * dx2 + dy1 * dy2 + dz1 * dz2) / (dist1 * dist2);
+  clipToOne(cosTheta);
+  const double sinThetaSq = 1.0 - cosTheta * cosTheta;
+  double       energy     = forceConstant * uffAngleEnergyTerm(cosTheta, sinThetaSq, order, C0, C1, C2);
+
+  if (order > 0 && order < 5 && cosTheta > kUffAngleCorrectionThreshold) {
+    const double theta = acos(cosTheta);
+    energy += exp(-20.0 * (theta - theta0 + 0.25));
+  }
+
+  return energy;
+}
+
+__device__ __forceinline__ void uffAngleBendGrad(const double* pos,
+                                                 const int     idx1,
+                                                 const int     idx2,
+                                                 const int     idx3,
+                                                 const double  theta0,
+                                                 const double  forceConstant,
+                                                 const uint8_t order,
+                                                 const double  C0,
+                                                 const double  C1,
+                                                 const double  C2,
+                                                 double*       grad) {
+  double       dx1, dy1, dz1, dx2, dy2, dz2;
+  const double dist1Sq = distanceSquaredWithComponents(pos, idx1, idx2, dx1, dy1, dz1);
+  const double dist2Sq = distanceSquaredWithComponents(pos, idx3, idx2, dx2, dy2, dz2);
+  if (dist1Sq <= 0.0 || dist2Sq <= 0.0) {
+    return;
+  }
+
+  const double dist1    = sqrt(dist1Sq);
+  const double dist2    = sqrt(dist2Sq);
+  const double invDist1 = 1.0 / dist1;
+  const double invDist2 = 1.0 / dist2;
+  double       cosTheta = (dx1 * dx2 + dy1 * dy2 + dz1 * dz2) * invDist1 * invDist2;
+  clipToOne(cosTheta);
+  const double sinThetaSq = 1.0 - cosTheta * cosTheta;
+  if (isDoubleZero(sinThetaSq)) {
+    return;
+  }
+  const double sinTheta  = fmax(sqrt(sinThetaSq), 1.0e-8);
+  double       dE_dTheta = uffAngleThetaDeriv(cosTheta, sinTheta, order, forceConstant, C1, C2);
+  if (order > 0 && order < 5 && cosTheta > kUffAngleCorrectionThreshold) {
+    const double theta = acos(cosTheta);
+    dE_dTheta += -20.0 * exp(-20.0 * (theta - theta0 + 0.25));
+  }
+
+  const double ndx1 = dx1 * invDist1;
+  const double ndy1 = dy1 * invDist1;
+  const double ndz1 = dz1 * invDist1;
+  const double ndx2 = dx2 * invDist2;
+  const double ndy2 = dy2 * invDist2;
+  const double ndz2 = dz2 * invDist2;
+
+  const double common = dE_dTheta / (-sinTheta);
+
+  const double i1 = invDist1 * (ndx2 - cosTheta * ndx1);
+  const double i2 = invDist1 * (ndy2 - cosTheta * ndy1);
+  const double i3 = invDist1 * (ndz2 - cosTheta * ndz1);
+  const double i4 = invDist2 * (ndx1 - cosTheta * ndx2);
+  const double i5 = invDist2 * (ndy1 - cosTheta * ndy2);
+  const double i6 = invDist2 * (ndz1 - cosTheta * ndz2);
+
+  atomicAdd(&grad[3 * idx1 + 0], common * i1);
+  atomicAdd(&grad[3 * idx1 + 1], common * i2);
+  atomicAdd(&grad[3 * idx1 + 2], common * i3);
+
+  atomicAdd(&grad[3 * idx2 + 0], common * (-i1 - i4));
+  atomicAdd(&grad[3 * idx2 + 1], common * (-i2 - i5));
+  atomicAdd(&grad[3 * idx2 + 2], common * (-i3 - i6));
+
+  atomicAdd(&grad[3 * idx3 + 0], common * i4);
+  atomicAdd(&grad[3 * idx3 + 1], common * i5);
+  atomicAdd(&grad[3 * idx3 + 2], common * i6);
+}
+
+__device__ __forceinline__ double uffCalculateCosTorsion(const double* pos,
+                                                         const int     idx1,
+                                                         const int     idx2,
+                                                         const int     idx3,
+                                                         const int     idx4) {
+  const double r1x = pos[3 * idx1 + 0] - pos[3 * idx2 + 0];
+  const double r1y = pos[3 * idx1 + 1] - pos[3 * idx2 + 1];
+  const double r1z = pos[3 * idx1 + 2] - pos[3 * idx2 + 2];
+  const double r2x = pos[3 * idx3 + 0] - pos[3 * idx2 + 0];
+  const double r2y = pos[3 * idx3 + 1] - pos[3 * idx2 + 1];
+  const double r2z = pos[3 * idx3 + 2] - pos[3 * idx2 + 2];
+  const double r3x = pos[3 * idx2 + 0] - pos[3 * idx3 + 0];
+  const double r3y = pos[3 * idx2 + 1] - pos[3 * idx3 + 1];
+  const double r3z = pos[3 * idx2 + 2] - pos[3 * idx3 + 2];
+  const double r4x = pos[3 * idx4 + 0] - pos[3 * idx3 + 0];
+  const double r4y = pos[3 * idx4 + 1] - pos[3 * idx3 + 1];
+  const double r4z = pos[3 * idx4 + 2] - pos[3 * idx3 + 2];
+
+  double t1x, t1y, t1z, t2x, t2y, t2z;
+  crossProduct(r1x, r1y, r1z, r2x, r2y, r2z, t1x, t1y, t1z);
+  crossProduct(r3x, r3y, r3z, r4x, r4y, r4z, t2x, t2y, t2z);
+  const double d1 = sqrt(t1x * t1x + t1y * t1y + t1z * t1z);
+  const double d2 = sqrt(t2x * t2x + t2y * t2y + t2z * t2z);
+  if (isDoubleZero(d1) || isDoubleZero(d2)) {
+    return 0.0;
+  }
+  double cosPhi = (t1x * t2x + t1y * t2y + t1z * t2z) / (d1 * d2);
+  clipToOne(cosPhi);
+  return cosPhi;
+}
+
+__device__ __forceinline__ double uffTorsionThetaDeriv(const double  cosTheta,
+                                                       const double  sinTheta,
+                                                       const double  forceConstant,
+                                                       const uint8_t order,
+                                                       const double  cosTerm) {
+  const double sinThetaSq = sinTheta * sinTheta;
+  double       result     = 0.0;
+  switch (order) {
+    case 2:
+      result = 2.0 * sinTheta * cosTheta;
+      break;
+    case 3:
+      result = sinTheta * (3.0 - 4.0 * sinThetaSq);
+      break;
+    case 6:
+      result = cosTheta * sinTheta * (32.0 * sinThetaSq * (sinThetaSq - 1.0) + 6.0);
+      break;
+    default:
+      return 0.0;
+  }
+  return result * forceConstant / 2.0 * cosTerm * -1.0 * static_cast<double>(order);
+}
+
+__device__ __forceinline__ double uffTorsionEnergy(const double* pos,
+                                                   const int     idx1,
+                                                   const int     idx2,
+                                                   const int     idx3,
+                                                   const int     idx4,
+                                                   const double  forceConstant,
+                                                   const uint8_t order,
+                                                   const double  cosTerm) {
+  const double cosPhi    = uffCalculateCosTorsion(pos, idx1, idx2, idx3, idx4);
+  const double sinPhiSq  = 1.0 - cosPhi * cosPhi;
+  double       cosNPhi   = 0.0;
+  switch (order) {
+    case 2:
+      cosNPhi = 1.0 - 2.0 * sinPhiSq;
+      break;
+    case 3:
+      cosNPhi = cosPhi * (cosPhi * cosPhi - 3.0 * sinPhiSq);
+      break;
+    case 6:
+      cosNPhi = 1.0 + sinPhiSq * (-32.0 * sinPhiSq * sinPhiSq + 48.0 * sinPhiSq - 18.0);
+      break;
+    default:
+      return 0.0;
+  }
+  return forceConstant / 2.0 * (1.0 - cosTerm * cosNPhi);
+}
+
+__device__ __forceinline__ void uffTorsionGrad(const double* pos,
+                                               const int     idx1,
+                                               const int     idx2,
+                                               const int     idx3,
+                                               const int     idx4,
+                                               const double  forceConstant,
+                                               const uint8_t order,
+                                               const double  cosTerm,
+                                               double*       grad) {
+  const double r0x = pos[3 * idx1 + 0] - pos[3 * idx2 + 0];
+  const double r0y = pos[3 * idx1 + 1] - pos[3 * idx2 + 1];
+  const double r0z = pos[3 * idx1 + 2] - pos[3 * idx2 + 2];
+  const double r1x = pos[3 * idx3 + 0] - pos[3 * idx2 + 0];
+  const double r1y = pos[3 * idx3 + 1] - pos[3 * idx2 + 1];
+  const double r1z = pos[3 * idx3 + 2] - pos[3 * idx2 + 2];
+  const double r2x = -r1x;
+  const double r2y = -r1y;
+  const double r2z = -r1z;
+  const double r3x = pos[3 * idx4 + 0] - pos[3 * idx3 + 0];
+  const double r3y = pos[3 * idx4 + 1] - pos[3 * idx3 + 1];
+  const double r3z = pos[3 * idx4 + 2] - pos[3 * idx3 + 2];
+
+  double t0x, t0y, t0z, t1x, t1y, t1z;
+  crossProduct(r0x, r0y, r0z, r1x, r1y, r1z, t0x, t0y, t0z);
+  crossProduct(r2x, r2y, r2z, r3x, r3y, r3z, t1x, t1y, t1z);
+
+  const double d0 = sqrt(t0x * t0x + t0y * t0y + t0z * t0z);
+  const double d1 = sqrt(t1x * t1x + t1y * t1y + t1z * t1z);
+  if (isDoubleZero(d0) || isDoubleZero(d1)) {
+    return;
+  }
+  t0x /= d0;
+  t0y /= d0;
+  t0z /= d0;
+  t1x /= d1;
+  t1y /= d1;
+  t1z /= d1;
+
+  double cosPhi = t0x * t1x + t0y * t1y + t0z * t1z;
+  clipToOne(cosPhi);
+  const double sinPhiSq = 1.0 - cosPhi * cosPhi;
+  const double sinPhi   = sinPhiSq > 0.0 ? sqrt(sinPhiSq) : 0.0;
+  const double dE_dPhi  = uffTorsionThetaDeriv(cosPhi, sinPhi, forceConstant, order, cosTerm);
+  const double sinTerm  = dE_dPhi * (isDoubleZero(sinPhi) ? (1.0 / fmax(fabs(cosPhi), 1.0e-8)) : (1.0 / sinPhi));
+
+  const double dCos_dT0 = (t1x - cosPhi * t0x) / d0;
+  const double dCos_dT1 = (t1y - cosPhi * t0y) / d0;
+  const double dCos_dT2 = (t1z - cosPhi * t0z) / d0;
+  const double dCos_dT3 = (t0x - cosPhi * t1x) / d1;
+  const double dCos_dT4 = (t0y - cosPhi * t1y) / d1;
+  const double dCos_dT5 = (t0z - cosPhi * t1z) / d1;
+
+  atomicAdd(&grad[3 * idx1 + 0], sinTerm * (dCos_dT2 * r1y - dCos_dT1 * r1z));
+  atomicAdd(&grad[3 * idx1 + 1], sinTerm * (dCos_dT0 * r1z - dCos_dT2 * r1x));
+  atomicAdd(&grad[3 * idx1 + 2], sinTerm * (dCos_dT1 * r1x - dCos_dT0 * r1y));
+
+  atomicAdd(&grad[3 * idx2 + 0], sinTerm * (dCos_dT1 * (r1z - r0z) + dCos_dT2 * (r0y - r1y) + dCos_dT4 * (-r3z) +
+                                            dCos_dT5 * (r3y)));
+  atomicAdd(&grad[3 * idx2 + 1], sinTerm * (dCos_dT0 * (r0z - r1z) + dCos_dT2 * (r1x - r0x) + dCos_dT3 * (r3z) +
+                                            dCos_dT5 * (-r3x)));
+  atomicAdd(&grad[3 * idx2 + 2], sinTerm * (dCos_dT0 * (r1y - r0y) + dCos_dT1 * (r0x - r1x) + dCos_dT3 * (-r3y) +
+                                            dCos_dT4 * (r3x)));
+
+  atomicAdd(&grad[3 * idx3 + 0], sinTerm * (dCos_dT1 * r0z + dCos_dT2 * (-r0y) + dCos_dT4 * (r3z - r2z) +
+                                            dCos_dT5 * (r2y - r3y)));
+  atomicAdd(&grad[3 * idx3 + 1], sinTerm * (dCos_dT0 * (-r0z) + dCos_dT2 * r0x + dCos_dT3 * (r2z - r3z) +
+                                            dCos_dT5 * (r3x - r2x)));
+  atomicAdd(&grad[3 * idx3 + 2], sinTerm * (dCos_dT0 * r0y + dCos_dT1 * (-r0x) + dCos_dT3 * (r3y - r2y) +
+                                            dCos_dT4 * (r2x - r3x)));
+
+  atomicAdd(&grad[3 * idx4 + 0], sinTerm * (dCos_dT4 * r2z - dCos_dT5 * r2y));
+  atomicAdd(&grad[3 * idx4 + 1], sinTerm * (dCos_dT5 * r2x - dCos_dT3 * r2z));
+  atomicAdd(&grad[3 * idx4 + 2], sinTerm * (dCos_dT3 * r2y - dCos_dT4 * r2x));
+}
+
+__device__ __forceinline__ double uffCalculateCosY(const double* pos,
+                                                   const int     idx1,
+                                                   const int     idx2,
+                                                   const int     idx3,
+                                                   const int     idx4) {
+  const double rJIx = pos[3 * idx1 + 0] - pos[3 * idx2 + 0];
+  const double rJIy = pos[3 * idx1 + 1] - pos[3 * idx2 + 1];
+  const double rJIz = pos[3 * idx1 + 2] - pos[3 * idx2 + 2];
+  const double rJKx = pos[3 * idx3 + 0] - pos[3 * idx2 + 0];
+  const double rJKy = pos[3 * idx3 + 1] - pos[3 * idx2 + 1];
+  const double rJKz = pos[3 * idx3 + 2] - pos[3 * idx2 + 2];
+  const double rJLx = pos[3 * idx4 + 0] - pos[3 * idx2 + 0];
+  const double rJLy = pos[3 * idx4 + 1] - pos[3 * idx2 + 1];
+  const double rJLz = pos[3 * idx4 + 2] - pos[3 * idx2 + 2];
+
+  const double l2JI = rJIx * rJIx + rJIy * rJIy + rJIz * rJIz;
+  const double l2JK = rJKx * rJKx + rJKy * rJKy + rJKz * rJKz;
+  const double l2JL = rJLx * rJLx + rJLy * rJLy + rJLz * rJLz;
+  if (l2JI < kUffZeroTol || l2JK < kUffZeroTol || l2JL < kUffZeroTol) {
+    return 0.0;
+  }
+
+  double nx, ny, nz;
+  crossProduct(rJIx, rJIy, rJIz, rJKx, rJKy, rJKz, nx, ny, nz);
+  const double normScale = sqrt(l2JI) * sqrt(l2JK);
+  nx /= normScale;
+  ny /= normScale;
+  nz /= normScale;
+  const double l2n = nx * nx + ny * ny + nz * nz;
+  if (l2n < kUffZeroTol) {
+    return 0.0;
+  }
+  return (nx * rJLx + ny * rJLy + nz * rJLz) / (sqrt(l2JL) * sqrt(l2n));
+}
+
+__device__ __forceinline__ double uffInversionEnergy(const double* pos,
+                                                     const int     idx1,
+                                                     const int     idx2,
+                                                     const int     idx3,
+                                                     const int     idx4,
+                                                     const double  forceConstant,
+                                                     const double  C0,
+                                                     const double  C1,
+                                                     const double  C2) {
+  const double cosY   = uffCalculateCosY(pos, idx1, idx2, idx3, idx4);
+  const double sinYSq = 1.0 - cosY * cosY;
+  const double sinY   = sinYSq > 0.0 ? sqrt(sinYSq) : 0.0;
+  const double cos2W  = 2.0 * sinY * sinY - 1.0;
+  return forceConstant * (C0 + C1 * sinY + C2 * cos2W);
+}
+
+__device__ __forceinline__ void uffInversionGrad(const double* pos,
+                                                 const int     idx1,
+                                                 const int     idx2,
+                                                 const int     idx3,
+                                                 const int     idx4,
+                                                 const double  forceConstant,
+                                                 const double  C1,
+                                                 const double  C2,
+                                                 double*       grad) {
+  double rJIx = pos[3 * idx1 + 0] - pos[3 * idx2 + 0];
+  double rJIy = pos[3 * idx1 + 1] - pos[3 * idx2 + 1];
+  double rJIz = pos[3 * idx1 + 2] - pos[3 * idx2 + 2];
+  double rJKx = pos[3 * idx3 + 0] - pos[3 * idx2 + 0];
+  double rJKy = pos[3 * idx3 + 1] - pos[3 * idx2 + 1];
+  double rJKz = pos[3 * idx3 + 2] - pos[3 * idx2 + 2];
+  double rJLx = pos[3 * idx4 + 0] - pos[3 * idx2 + 0];
+  double rJLy = pos[3 * idx4 + 1] - pos[3 * idx2 + 1];
+  double rJLz = pos[3 * idx4 + 2] - pos[3 * idx2 + 2];
+
+  double dJI = sqrt(rJIx * rJIx + rJIy * rJIy + rJIz * rJIz);
+  double dJK = sqrt(rJKx * rJKx + rJKy * rJKy + rJKz * rJKz);
+  double dJL = sqrt(rJLx * rJLx + rJLy * rJLy + rJLz * rJLz);
+  if (isDoubleZero(dJI) || isDoubleZero(dJK) || isDoubleZero(dJL)) {
+    return;
+  }
+  rJIx /= dJI;
+  rJIy /= dJI;
+  rJIz /= dJI;
+  rJKx /= dJK;
+  rJKy /= dJK;
+  rJKz /= dJK;
+  rJLx /= dJL;
+  rJLy /= dJL;
+  rJLz /= dJL;
+
+  double nx, ny, nz;
+  crossProduct(-rJIx, -rJIy, -rJIz, rJKx, rJKy, rJKz, nx, ny, nz);
+  const double nNorm = sqrt(nx * nx + ny * ny + nz * nz);
+  if (nNorm <= 0.0) {
+    return;
+  }
+  nx /= nNorm;
+  ny /= nNorm;
+  nz /= nNorm;
+
+  double cosY = nx * rJLx + ny * rJLy + nz * rJLz;
+  clipToOne(cosY);
+  const double sinYSq = 1.0 - cosY * cosY;
+  const double sinY   = fmax(sqrt(sinYSq), 1.0e-8);
+  double       cosTheta = rJIx * rJKx + rJIy * rJKy + rJIz * rJKz;
+  clipToOne(cosTheta);
+  const double sinThetaSq = 1.0 - cosTheta * cosTheta;
+  const double sinTheta   = fmax(sqrt(sinThetaSq), 1.0e-8);
+
+  const double dE_dW = -forceConstant * (C1 * cosY - 4.0 * C2 * cosY * sinY);
+  double       t1x, t1y, t1z, t2x, t2y, t2z, t3x, t3y, t3z;
+  crossProduct(rJLx, rJLy, rJLz, rJKx, rJKy, rJKz, t1x, t1y, t1z);
+  crossProduct(rJIx, rJIy, rJIz, rJLx, rJLy, rJLz, t2x, t2y, t2z);
+  crossProduct(rJKx, rJKy, rJKz, rJIx, rJIy, rJIz, t3x, t3y, t3z);
+  const double term1 = sinY * sinTheta;
+  const double term2 = cosY / (sinY * sinThetaSq);
+
+  const double tg1x = (t1x / term1 - (rJIx - rJKx * cosTheta) * term2) / dJI;
+  const double tg1y = (t1y / term1 - (rJIy - rJKy * cosTheta) * term2) / dJI;
+  const double tg1z = (t1z / term1 - (rJIz - rJKz * cosTheta) * term2) / dJI;
+  const double tg3x = (t2x / term1 - (rJKx - rJIx * cosTheta) * term2) / dJK;
+  const double tg3y = (t2y / term1 - (rJKy - rJIy * cosTheta) * term2) / dJK;
+  const double tg3z = (t2z / term1 - (rJKz - rJIz * cosTheta) * term2) / dJK;
+  const double tg4x = (t3x / term1 - rJLx * cosY / sinY) / dJL;
+  const double tg4y = (t3y / term1 - rJLy * cosY / sinY) / dJL;
+  const double tg4z = (t3z / term1 - rJLz * cosY / sinY) / dJL;
+
+  atomicAdd(&grad[3 * idx1 + 0], dE_dW * tg1x);
+  atomicAdd(&grad[3 * idx1 + 1], dE_dW * tg1y);
+  atomicAdd(&grad[3 * idx1 + 2], dE_dW * tg1z);
+  atomicAdd(&grad[3 * idx2 + 0], -dE_dW * (tg1x + tg3x + tg4x));
+  atomicAdd(&grad[3 * idx2 + 1], -dE_dW * (tg1y + tg3y + tg4y));
+  atomicAdd(&grad[3 * idx2 + 2], -dE_dW * (tg1z + tg3z + tg4z));
+  atomicAdd(&grad[3 * idx3 + 0], dE_dW * tg3x);
+  atomicAdd(&grad[3 * idx3 + 1], dE_dW * tg3y);
+  atomicAdd(&grad[3 * idx3 + 2], dE_dW * tg3z);
+  atomicAdd(&grad[3 * idx4 + 0], dE_dW * tg4x);
+  atomicAdd(&grad[3 * idx4 + 1], dE_dW * tg4y);
+  atomicAdd(&grad[3 * idx4 + 2], dE_dW * tg4z);
+}
+
+__device__ __forceinline__ double uffVdwEnergy(const double* pos,
+                                               const int     idx1,
+                                               const int     idx2,
+                                               const double  x_ij,
+                                               const double  wellDepth,
+                                               const double  threshold) {
+  const double dist = sqrt(distanceSquared(pos, idx1, idx2));
+  if (dist > threshold || dist <= 0.0) {
+    return 0.0;
+  }
+  const double r   = x_ij / dist;
+  const double r6  = cubeValue(squareValue(r));
+  const double r12 = r6 * r6;
+  return wellDepth * (r12 - 2.0 * r6);
+}
+
+__device__ __forceinline__ void uffVdwGrad(const double* pos,
+                                           const int     idx1,
+                                           const int     idx2,
+                                           const double  x_ij,
+                                           const double  wellDepth,
+                                           const double  threshold,
+                                           double*       grad) {
+  const double dist = sqrt(distanceSquared(pos, idx1, idx2));
+  if (dist > threshold) {
+    return;
+  }
+  if (dist <= 0.0) {
+    atomicAdd(&grad[3 * idx1 + 0], 100.0);
+    atomicAdd(&grad[3 * idx1 + 1], 100.0);
+    atomicAdd(&grad[3 * idx1 + 2], 100.0);
+    atomicAdd(&grad[3 * idx2 + 0], -100.0);
+    atomicAdd(&grad[3 * idx2 + 1], -100.0);
+    atomicAdd(&grad[3 * idx2 + 2], -100.0);
+    return;
+  }
+
+  const double r         = x_ij / dist;
+  const double r7        = r * cubeValue(squareValue(r));
+  const double r13       = r7 * squareValue(squareValue(r)) * squareValue(r);
+  const double preFactor = 12.0 * wellDepth / x_ij * (r7 - r13);
+
+  const double dx = pos[3 * idx1 + 0] - pos[3 * idx2 + 0];
+  const double dy = pos[3 * idx1 + 1] - pos[3 * idx2 + 1];
+  const double dz = pos[3 * idx1 + 2] - pos[3 * idx2 + 2];
+  const double gx = preFactor * dx / dist;
+  const double gy = preFactor * dy / dist;
+  const double gz = preFactor * dz / dist;
+
+  atomicAdd(&grad[3 * idx1 + 0], gx);
+  atomicAdd(&grad[3 * idx1 + 1], gy);
+  atomicAdd(&grad[3 * idx1 + 2], gz);
+  atomicAdd(&grad[3 * idx2 + 0], -gx);
+  atomicAdd(&grad[3 * idx2 + 1], -gy);
+  atomicAdd(&grad[3 * idx2 + 2], -gz);
+}
+
+}  // namespace
+
+namespace nvMolKit {
+namespace UFF {
+
+template <int stride>
+__device__ __inline__ double molEnergy(const EnergyForceContribsDevicePtr& terms,
+                                       const BatchedIndicesDevicePtr&      systemIndices,
+                                       const double*                       molCoords,
+                                       const int                           molIdx,
+                                       const int                           tid) {
+  const int atomStart = systemIndices.atomStarts[molIdx];
+  double    energy    = 0.0;
+
+  const int bondStart = systemIndices.bondTermStarts[molIdx];
+  const int bondEnd   = systemIndices.bondTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = bondStart + tid; i < bondEnd; i += stride) {
+    energy += uffBondStretchEnergy(
+      molCoords, terms.bondTerms.idx1[i] - atomStart, terms.bondTerms.idx2[i] - atomStart, terms.bondTerms.restLen[i],
+      terms.bondTerms.forceConstant[i]);
+  }
+
+  const int angleStart = systemIndices.angleTermStarts[molIdx];
+  const int angleEnd   = systemIndices.angleTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = angleStart + tid; i < angleEnd; i += stride) {
+    energy += uffAngleBendEnergy(molCoords,
+                                 terms.angleTerms.idx1[i] - atomStart,
+                                 terms.angleTerms.idx2[i] - atomStart,
+                                 terms.angleTerms.idx3[i] - atomStart,
+                                 terms.angleTerms.theta0[i],
+                                 terms.angleTerms.forceConstant[i],
+                                 terms.angleTerms.order[i],
+                                 terms.angleTerms.C0[i],
+                                 terms.angleTerms.C1[i],
+                                 terms.angleTerms.C2[i]);
+  }
+
+  const int torsionStart = systemIndices.torsionTermStarts[molIdx];
+  const int torsionEnd   = systemIndices.torsionTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = torsionStart + tid; i < torsionEnd; i += stride) {
+    energy += uffTorsionEnergy(molCoords,
+                               terms.torsionTerms.idx1[i] - atomStart,
+                               terms.torsionTerms.idx2[i] - atomStart,
+                               terms.torsionTerms.idx3[i] - atomStart,
+                               terms.torsionTerms.idx4[i] - atomStart,
+                               terms.torsionTerms.forceConstant[i],
+                               terms.torsionTerms.order[i],
+                               terms.torsionTerms.cosTerm[i]);
+  }
+
+  const int inversionStart = systemIndices.inversionTermStarts[molIdx];
+  const int inversionEnd   = systemIndices.inversionTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = inversionStart + tid; i < inversionEnd; i += stride) {
+    energy += uffInversionEnergy(molCoords,
+                                 terms.inversionTerms.idx1[i] - atomStart,
+                                 terms.inversionTerms.idx2[i] - atomStart,
+                                 terms.inversionTerms.idx3[i] - atomStart,
+                                 terms.inversionTerms.idx4[i] - atomStart,
+                                 terms.inversionTerms.forceConstant[i],
+                                 terms.inversionTerms.C0[i],
+                                 terms.inversionTerms.C1[i],
+                                 terms.inversionTerms.C2[i]);
+  }
+
+  const int vdwStart = systemIndices.vdwTermStarts[molIdx];
+  const int vdwEnd   = systemIndices.vdwTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = vdwStart + tid; i < vdwEnd; i += stride) {
+    energy += uffVdwEnergy(molCoords,
+                           terms.vdwTerms.idx1[i] - atomStart,
+                           terms.vdwTerms.idx2[i] - atomStart,
+                           terms.vdwTerms.x_ij[i],
+                           terms.vdwTerms.wellDepth[i],
+                           terms.vdwTerms.threshold[i]);
+  }
+
+  const int dcStart = systemIndices.distanceConstraintTermStarts[molIdx];
+  const int dcEnd   = systemIndices.distanceConstraintTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = dcStart + tid; i < dcEnd; i += stride) {
+    energy += distanceConstraintEnergy(molCoords,
+                                       terms.distanceConstraintTerms.idx1[i] - atomStart,
+                                       terms.distanceConstraintTerms.idx2[i] - atomStart,
+                                       terms.distanceConstraintTerms.minLen[i],
+                                       terms.distanceConstraintTerms.maxLen[i],
+                                       terms.distanceConstraintTerms.forceConstant[i]);
+  }
+
+  const int pcStart = systemIndices.positionConstraintTermStarts[molIdx];
+  const int pcEnd   = systemIndices.positionConstraintTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = pcStart + tid; i < pcEnd; i += stride) {
+    energy += positionConstraintEnergy(molCoords,
+                                       terms.positionConstraintTerms.idx[i] - atomStart,
+                                       terms.positionConstraintTerms.refX[i],
+                                       terms.positionConstraintTerms.refY[i],
+                                       terms.positionConstraintTerms.refZ[i],
+                                       terms.positionConstraintTerms.maxDispl[i],
+                                       terms.positionConstraintTerms.forceConstant[i]);
+  }
+
+  const int acStart = systemIndices.angleConstraintTermStarts[molIdx];
+  const int acEnd   = systemIndices.angleConstraintTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = acStart + tid; i < acEnd; i += stride) {
+    energy += angleConstraintEnergy(molCoords,
+                                    terms.angleConstraintTerms.idx1[i] - atomStart,
+                                    terms.angleConstraintTerms.idx2[i] - atomStart,
+                                    terms.angleConstraintTerms.idx3[i] - atomStart,
+                                    terms.angleConstraintTerms.minAngleDeg[i],
+                                    terms.angleConstraintTerms.maxAngleDeg[i],
+                                    terms.angleConstraintTerms.forceConstant[i]);
+  }
+
+  const int tcStart = systemIndices.torsionConstraintTermStarts[molIdx];
+  const int tcEnd   = systemIndices.torsionConstraintTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = tcStart + tid; i < tcEnd; i += stride) {
+    energy += torsionConstraintEnergy(molCoords,
+                                      terms.torsionConstraintTerms.idx1[i] - atomStart,
+                                      terms.torsionConstraintTerms.idx2[i] - atomStart,
+                                      terms.torsionConstraintTerms.idx3[i] - atomStart,
+                                      terms.torsionConstraintTerms.idx4[i] - atomStart,
+                                      terms.torsionConstraintTerms.minDihedralDeg[i],
+                                      terms.torsionConstraintTerms.maxDihedralDeg[i],
+                                      terms.torsionConstraintTerms.forceConstant[i]);
+  }
+
+  return energy;
+}
+
+template <int stride>
+__device__ __inline__ void molGrad(const EnergyForceContribsDevicePtr& terms,
+                                   const BatchedIndicesDevicePtr&      systemIndices,
+                                   const double*                       molCoords,
+                                   double*                             grad,
+                                   const int                           molIdx,
+                                   const int                           tid) {
+  const int atomStart = systemIndices.atomStarts[molIdx];
+
+  const int bondStart = systemIndices.bondTermStarts[molIdx];
+  const int bondEnd   = systemIndices.bondTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = bondStart + tid; i < bondEnd; i += stride) {
+    uffBondStretchGrad(
+      molCoords, terms.bondTerms.idx1[i] - atomStart, terms.bondTerms.idx2[i] - atomStart, terms.bondTerms.restLen[i],
+      terms.bondTerms.forceConstant[i], grad);
+  }
+
+  const int angleStart = systemIndices.angleTermStarts[molIdx];
+  const int angleEnd   = systemIndices.angleTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = angleStart + tid; i < angleEnd; i += stride) {
+    uffAngleBendGrad(molCoords,
+                     terms.angleTerms.idx1[i] - atomStart,
+                     terms.angleTerms.idx2[i] - atomStart,
+                     terms.angleTerms.idx3[i] - atomStart,
+                     terms.angleTerms.theta0[i],
+                     terms.angleTerms.forceConstant[i],
+                     terms.angleTerms.order[i],
+                     terms.angleTerms.C0[i],
+                     terms.angleTerms.C1[i],
+                     terms.angleTerms.C2[i],
+                     grad);
+  }
+
+  const int torsionStart = systemIndices.torsionTermStarts[molIdx];
+  const int torsionEnd   = systemIndices.torsionTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = torsionStart + tid; i < torsionEnd; i += stride) {
+    uffTorsionGrad(molCoords,
+                   terms.torsionTerms.idx1[i] - atomStart,
+                   terms.torsionTerms.idx2[i] - atomStart,
+                   terms.torsionTerms.idx3[i] - atomStart,
+                   terms.torsionTerms.idx4[i] - atomStart,
+                   terms.torsionTerms.forceConstant[i],
+                   terms.torsionTerms.order[i],
+                   terms.torsionTerms.cosTerm[i],
+                   grad);
+  }
+
+  const int inversionStart = systemIndices.inversionTermStarts[molIdx];
+  const int inversionEnd   = systemIndices.inversionTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = inversionStart + tid; i < inversionEnd; i += stride) {
+    uffInversionGrad(molCoords,
+                     terms.inversionTerms.idx1[i] - atomStart,
+                     terms.inversionTerms.idx2[i] - atomStart,
+                     terms.inversionTerms.idx3[i] - atomStart,
+                     terms.inversionTerms.idx4[i] - atomStart,
+                     terms.inversionTerms.forceConstant[i],
+                     terms.inversionTerms.C1[i],
+                     terms.inversionTerms.C2[i],
+                     grad);
+  }
+
+  const int vdwStart = systemIndices.vdwTermStarts[molIdx];
+  const int vdwEnd   = systemIndices.vdwTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = vdwStart + tid; i < vdwEnd; i += stride) {
+    uffVdwGrad(molCoords,
+               terms.vdwTerms.idx1[i] - atomStart,
+               terms.vdwTerms.idx2[i] - atomStart,
+               terms.vdwTerms.x_ij[i],
+               terms.vdwTerms.wellDepth[i],
+               terms.vdwTerms.threshold[i],
+               grad);
+  }
+
+  const int dcStart = systemIndices.distanceConstraintTermStarts[molIdx];
+  const int dcEnd   = systemIndices.distanceConstraintTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = dcStart + tid; i < dcEnd; i += stride) {
+    distanceConstraintGrad(molCoords,
+                           terms.distanceConstraintTerms.idx1[i] - atomStart,
+                           terms.distanceConstraintTerms.idx2[i] - atomStart,
+                           terms.distanceConstraintTerms.minLen[i],
+                           terms.distanceConstraintTerms.maxLen[i],
+                           terms.distanceConstraintTerms.forceConstant[i],
+                           grad);
+  }
+
+  const int pcStart = systemIndices.positionConstraintTermStarts[molIdx];
+  const int pcEnd   = systemIndices.positionConstraintTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = pcStart + tid; i < pcEnd; i += stride) {
+    positionConstraintGrad(molCoords,
+                           terms.positionConstraintTerms.idx[i] - atomStart,
+                           terms.positionConstraintTerms.refX[i],
+                           terms.positionConstraintTerms.refY[i],
+                           terms.positionConstraintTerms.refZ[i],
+                           terms.positionConstraintTerms.maxDispl[i],
+                           terms.positionConstraintTerms.forceConstant[i],
+                           grad);
+  }
+
+  const int acStart = systemIndices.angleConstraintTermStarts[molIdx];
+  const int acEnd   = systemIndices.angleConstraintTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = acStart + tid; i < acEnd; i += stride) {
+    angleConstraintGrad(molCoords,
+                        terms.angleConstraintTerms.idx1[i] - atomStart,
+                        terms.angleConstraintTerms.idx2[i] - atomStart,
+                        terms.angleConstraintTerms.idx3[i] - atomStart,
+                        terms.angleConstraintTerms.minAngleDeg[i],
+                        terms.angleConstraintTerms.maxAngleDeg[i],
+                        terms.angleConstraintTerms.forceConstant[i],
+                        grad);
+  }
+
+  const int tcStart = systemIndices.torsionConstraintTermStarts[molIdx];
+  const int tcEnd   = systemIndices.torsionConstraintTermStarts[molIdx + 1];
+#pragma unroll 1
+  for (int i = tcStart + tid; i < tcEnd; i += stride) {
+    torsionConstraintGrad(molCoords,
+                          terms.torsionConstraintTerms.idx1[i] - atomStart,
+                          terms.torsionConstraintTerms.idx2[i] - atomStart,
+                          terms.torsionConstraintTerms.idx3[i] - atomStart,
+                          terms.torsionConstraintTerms.idx4[i] - atomStart,
+                          terms.torsionConstraintTerms.minDihedralDeg[i],
+                          terms.torsionConstraintTerms.maxDihedralDeg[i],
+                          terms.torsionConstraintTerms.forceConstant[i],
+                          grad);
+  }
+}
+
+}  // namespace UFF
+}  // namespace nvMolKit
+
+#endif  // NVMOLKIT_UFF_KERNELS_DEVICE_CUH

--- a/src/minimizer/bfgs_types.h
+++ b/src/minimizer/bfgs_types.h
@@ -22,7 +22,8 @@ namespace nvMolKit {
 enum class ForceFieldType {
   MMFF = 0,
   ETK  = 1,
-  DG   = 2
+  DG   = 2,
+  UFF  = 3
 };
 
 /// Debug level for BFGS minimization

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,19 @@ target_link_libraries(
           ff_utils
           test_utils)
 
+add_executable(test_uff test_uff.cu)
+target_link_libraries(
+  test_uff
+  PRIVATE ${RDKit_LIBS}
+          uff_batched_forcefield
+          bfgs
+          uff
+          rdkit_uff_flattened
+          device_vector
+          ff_utils
+          ff_kernel_utils
+          test_utils)
+
 add_executable(test_distgeom test_distgeom.cu)
 target_link_libraries(
   test_distgeom
@@ -295,6 +308,7 @@ set(TEST_LIST
     test_etkdg_result_tracker
     test_molecules
     test_mmff
+    test_uff
     test_distgeom
     test_pinned_host_allocator
     test_triangle_smooth

--- a/tests/test_uff.cu
+++ b/tests/test_uff.cu
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_uff.cu
+++ b/tests/test_uff.cu
@@ -63,7 +63,8 @@ double computeEnergyViaForcefield(BatchedMolecularSystemHost& systemHost, AsyncD
   return energy;
 }
 
-std::vector<double> computeGradientViaForcefield(BatchedMolecularSystemHost& systemHost, AsyncDeviceVector<double>& positionsDevice) {
+std::vector<double> computeGradientViaForcefield(BatchedMolecularSystemHost& systemHost,
+                                                 AsyncDeviceVector<double>&  positionsDevice) {
   nvMolKit::UFFBatchedForcefield forcefield(systemHost);
   AsyncDeviceVector<double>      gradDevice;
   gradDevice.resize(positionsDevice.size());
@@ -113,12 +114,12 @@ class UFFGpuTestFixture : public ::testing::Test {
   }
 
  protected:
-  std::string                         testDataFolderPath_;
-  std::unique_ptr<RDKit::RWMol>       mol_;
-  std::vector<double>                 positions_;
-  EnergyForceContribsHost             contribs_;
-  BatchedMolecularSystemHost          systemHost_;
-  BatchedMolecularDeviceBuffers       systemDevice_;
+  std::string                   testDataFolderPath_;
+  std::unique_ptr<RDKit::RWMol> mol_;
+  std::vector<double>           positions_;
+  EnergyForceContribsHost       contribs_;
+  BatchedMolecularSystemHost    systemHost_;
+  BatchedMolecularDeviceBuffers systemDevice_;
 };
 
 TEST_F(UFFGpuTestFixture, FlattenedBuilderPopulatesAllTerms) {
@@ -136,14 +137,14 @@ TEST_F(UFFGpuTestFixture, FlattenedBuilderPopulatesAllTerms) {
 }
 
 TEST_F(UFFGpuTestFixture, CombinedEnergyMatchesRDKit) {
-  auto referenceFF = buildReferenceForceField(*mol_);
-  const double wantEnergy = referenceFF->calcEnergy(positions_.data());
-  const double gotEnergy  = computeEnergyViaForcefield(systemHost_, systemDevice_.positions);
+  auto         referenceFF = buildReferenceForceField(*mol_);
+  const double wantEnergy  = referenceFF->calcEnergy(positions_.data());
+  const double gotEnergy   = computeEnergyViaForcefield(systemHost_, systemDevice_.positions);
   EXPECT_NEAR(gotEnergy, wantEnergy, kEnergyTol);
 }
 
 TEST_F(UFFGpuTestFixture, CombinedGradientMatchesRDKit) {
-  auto referenceFF = buildReferenceForceField(*mol_);
+  auto                referenceFF = buildReferenceForceField(*mol_);
   std::vector<double> wantGrad(referenceFF->dimension() * referenceFF->positions().size(), 0.0);
   referenceFF->calcGrad(positions_.data(), wantGrad.data());
   const std::vector<double> gotGrad = computeGradientViaForcefield(systemHost_, systemDevice_.positions);
@@ -175,8 +176,8 @@ TEST_P(UFFGpuEdgeCases, CombinedEnergyAndGradient) {
   auto mol = buildEmbeddedEdgeCaseMol(GetParam());
   ASSERT_NE(mol, nullptr);
 
-  auto positions = positionsFromMol(*mol);
-  const auto contribs  = constructForcefieldContribs(*mol);
+  auto                       positions = positionsFromMol(*mol);
+  const auto                 contribs  = constructForcefieldContribs(*mol);
   BatchedMolecularSystemHost host;
   addMoleculeToBatch(contribs, positions, host);
 
@@ -185,7 +186,7 @@ TEST_P(UFFGpuEdgeCases, CombinedEnergyAndGradient) {
   const double gotEnergy = computeEnergyViaForcefield(host, positionsDevice);
   const auto   gotGrad   = computeGradientViaForcefield(host, positionsDevice);
 
-  auto referenceFF = buildReferenceForceField(*mol);
+  auto                referenceFF = buildReferenceForceField(*mol);
   std::vector<double> wantGrad(referenceFF->dimension() * referenceFF->positions().size(), 0.0);
   referenceFF->calcGrad(positions.data(), wantGrad.data());
 
@@ -193,21 +194,19 @@ TEST_P(UFFGpuEdgeCases, CombinedEnergyAndGradient) {
   EXPECT_THAT(gotGrad, ::testing::Pointwise(::testing::DoubleNear(2.0e-4), wantGrad));
 }
 
-INSTANTIATE_TEST_SUITE_P(UFFOneTwoAtoms,
-                         UFFGpuEdgeCases,
-                         ::testing::Values("C", "O", "CC", "CO", "CCC"));
+INSTANTIATE_TEST_SUITE_P(UFFOneTwoAtoms, UFFGpuEdgeCases, ::testing::Values("C", "O", "CC", "CO", "CCC"));
 
 TEST(UFFValidationSuite, BatchMatchesRDKitValidationSet) {
-  const std::string sdfPath = getTestDataFolderPath() + "/MMFF94_dative.sdf";
+  const std::string                          sdfPath = getTestDataFolderPath() + "/MMFF94_dative.sdf";
   std::vector<std::unique_ptr<RDKit::ROMol>> mols;
   getMols(sdfPath, mols, 25);
   ASSERT_FALSE(mols.empty());
 
-  BatchedMolecularSystemHost host;
-  std::vector<double>        wantEnergies;
+  BatchedMolecularSystemHost       host;
+  std::vector<double>              wantEnergies;
   std::vector<std::vector<double>> wantGrads;
   for (size_t i = 0; i < mols.size(); ++i) {
-    auto& mol = *mols[i];
+    auto& mol       = *mols[i];
     auto  positions = positionsFromMol(mol);
     auto  contribs  = constructForcefieldContribs(mol);
     addMoleculeToBatch(contribs, positions, host);
@@ -240,15 +239,15 @@ TEST(UFFValidationSuite, BatchMatchesRDKitValidationSet) {
 
   for (size_t i = 0; i < wantEnergies.size(); ++i) {
     EXPECT_NEAR(gotEnergies[i], wantEnergies[i], 1.0e-5) << "molecule " << i;
-    const int atomStart = host.indices.atomStarts[i];
-    const int atomEnd   = host.indices.atomStarts[i + 1];
+    const int           atomStart = host.indices.atomStarts[i];
+    const int           atomEnd   = host.indices.atomStarts[i + 1];
     std::vector<double> gotGradMol(gotGrad.begin() + atomStart * 3, gotGrad.begin() + atomEnd * 3);
     EXPECT_THAT(gotGradMol, ::testing::Pointwise(::testing::DoubleNear(2.0e-4), wantGrads[i])) << "molecule " << i;
   }
 }
 
 TEST(UFFMinimizer, BatchMinimizerMatchesRDKitFinalEnergies) {
-  const std::string sdfPath = getTestDataFolderPath() + "/MMFF94_dative.sdf";
+  const std::string                          sdfPath = getTestDataFolderPath() + "/MMFF94_dative.sdf";
   std::vector<std::unique_ptr<RDKit::ROMol>> mols;
   getMols(sdfPath, mols, 8);
   ASSERT_FALSE(mols.empty());
@@ -256,9 +255,9 @@ TEST(UFFMinimizer, BatchMinimizerMatchesRDKitFinalEnergies) {
   BatchedMolecularSystemHost host;
   std::vector<double>        referenceFinalEnergies;
   for (auto& molPtr : mols) {
-    auto& mol = *molPtr;
-    auto positions = positionsFromMol(mol);
-    auto contribs  = constructForcefieldContribs(mol);
+    auto& mol       = *molPtr;
+    auto  positions = positionsFromMol(mol);
+    auto  contribs  = constructForcefieldContribs(mol);
     addMoleculeToBatch(contribs, positions, host);
 
     const auto optimizeResult = RDKit::UFF::UFFOptimizeMolecule(mol, 1000, 100.0, -1, true);

--- a/tests/test_uff.cu
+++ b/tests/test_uff.cu
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ForceField/ForceField.h>
+#include <gmock/gmock.h>
+#include <GraphMol/DistGeomHelpers/Embedder.h>
+#include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/FileParsers/MolSupplier.h>
+#include <GraphMol/ForceFieldHelpers/UFF/Builder.h>
+#include <GraphMol/ForceFieldHelpers/UFF/UFF.h>
+#include <GraphMol/MolOps.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "device_vector.h"
+#include "ff_utils.h"
+#include "minimizer/bfgs_minimize.h"
+#include "test_utils.h"
+#include "uff.h"
+#include "uff_batched_forcefield.h"
+#include "uff_flattened_builder.h"
+
+using namespace nvMolKit::UFF;
+using nvMolKit::AsyncDeviceVector;
+
+namespace {
+
+constexpr double kEnergyTol         = 1.0e-6;
+constexpr double kGradTol           = 2.0e-4;
+constexpr double kMinimizeEnergyTol = 5.0e-3;
+
+std::vector<double> positionsFromMol(const RDKit::ROMol& mol, const int confId = -1) {
+  std::vector<double> positions;
+  nvMolKit::confPosToVect(mol, positions, confId);
+  return positions;
+}
+
+double computeEnergyViaForcefield(BatchedMolecularSystemHost& systemHost, AsyncDeviceVector<double>& positionsDevice) {
+  nvMolKit::UFFBatchedForcefield forcefield(systemHost);
+  AsyncDeviceVector<double>      energyOuts;
+  energyOuts.resize(1);
+  energyOuts.zero();
+  CHECK_CUDA_RETURN(forcefield.computeEnergy(energyOuts.data(), positionsDevice.data()));
+  double energy = 0.0;
+  CHECK_CUDA_RETURN(cudaMemcpy(&energy, energyOuts.data(), sizeof(double), cudaMemcpyDeviceToHost));
+  return energy;
+}
+
+std::vector<double> computeGradientViaForcefield(BatchedMolecularSystemHost& systemHost, AsyncDeviceVector<double>& positionsDevice) {
+  nvMolKit::UFFBatchedForcefield forcefield(systemHost);
+  AsyncDeviceVector<double>      gradDevice;
+  gradDevice.resize(positionsDevice.size());
+  gradDevice.zero();
+  CHECK_CUDA_RETURN(forcefield.computeGradients(gradDevice.data(), positionsDevice.data()));
+  std::vector<double> grad(positionsDevice.size(), 0.0);
+  gradDevice.copyToHost(grad);
+  cudaDeviceSynchronize();
+  return grad;
+}
+
+std::unique_ptr<ForceFields::ForceField> buildReferenceForceField(RDKit::ROMol& mol, const int confId = -1) {
+  auto ff = std::unique_ptr<ForceFields::ForceField>(RDKit::UFF::constructForceField(mol, 100.0, confId, true));
+  ff->initialize();
+  return ff;
+}
+
+std::unique_ptr<RDKit::ROMol> buildEmbeddedEdgeCaseMol(const std::string& smiles) {
+  auto mol = std::unique_ptr<RDKit::ROMol>(RDKit::SmilesToMol(smiles));
+  EXPECT_NE(mol, nullptr);
+  auto withHs = std::unique_ptr<RDKit::ROMol>(RDKit::MolOps::addHs(*mol));
+  RDKit::DGeomHelpers::EmbedMolecule(*withHs);
+  return withHs;
+}
+
+}  // namespace
+
+class UFFGpuTestFixture : public ::testing::Test {
+ public:
+  UFFGpuTestFixture() { testDataFolderPath_ = getTestDataFolderPath(); }
+
+  void SetUp() override {
+    const std::string mol2FilePath = testDataFolderPath_ + "/rdkit_smallmol_1.mol2";
+    ASSERT_TRUE(std::filesystem::exists(mol2FilePath)) << "Could not find " << mol2FilePath;
+    mol_ = std::unique_ptr<RDKit::RWMol>(RDKit::MolFileToMol(mol2FilePath, false));
+    ASSERT_NE(mol_, nullptr);
+    RDKit::MolOps::sanitizeMol(*mol_);
+
+    positions_ = positionsFromMol(*mol_);
+    contribs_  = constructForcefieldContribs(*mol_);
+    addMoleculeToBatch(contribs_, positions_, systemHost_);
+    sendContribsAndIndicesToDevice(systemHost_, systemDevice_);
+    systemDevice_.positions.setFromVector(systemHost_.positions);
+    allocateIntermediateBuffers(systemHost_, systemDevice_);
+    systemDevice_.grad.resize(systemHost_.positions.size());
+    systemDevice_.grad.zero();
+  }
+
+ protected:
+  std::string                         testDataFolderPath_;
+  std::unique_ptr<RDKit::RWMol>       mol_;
+  std::vector<double>                 positions_;
+  EnergyForceContribsHost             contribs_;
+  BatchedMolecularSystemHost          systemHost_;
+  BatchedMolecularDeviceBuffers       systemDevice_;
+};
+
+TEST_F(UFFGpuTestFixture, FlattenedBuilderPopulatesAllTerms) {
+  EXPECT_GT(contribs_.bondTerms.idx1.size(), 0);
+  EXPECT_GT(contribs_.angleTerms.idx1.size(), 0);
+  EXPECT_GT(contribs_.torsionTerms.idx1.size(), 0);
+  EXPECT_GT(contribs_.inversionTerms.idx1.size(), 0);
+  EXPECT_GT(contribs_.vdwTerms.idx1.size(), 0);
+
+  EXPECT_EQ(contribs_.bondTerms.idx1.size(), contribs_.bondTerms.forceConstant.size());
+  EXPECT_EQ(contribs_.angleTerms.idx1.size(), contribs_.angleTerms.C2.size());
+  EXPECT_EQ(contribs_.torsionTerms.idx1.size(), contribs_.torsionTerms.cosTerm.size());
+  EXPECT_EQ(contribs_.inversionTerms.idx1.size(), contribs_.inversionTerms.C2.size());
+  EXPECT_EQ(contribs_.vdwTerms.idx1.size(), contribs_.vdwTerms.threshold.size());
+}
+
+TEST_F(UFFGpuTestFixture, CombinedEnergyMatchesRDKit) {
+  auto referenceFF = buildReferenceForceField(*mol_);
+  const double wantEnergy = referenceFF->calcEnergy(positions_.data());
+  const double gotEnergy  = computeEnergyViaForcefield(systemHost_, systemDevice_.positions);
+  EXPECT_NEAR(gotEnergy, wantEnergy, kEnergyTol);
+}
+
+TEST_F(UFFGpuTestFixture, CombinedGradientMatchesRDKit) {
+  auto referenceFF = buildReferenceForceField(*mol_);
+  std::vector<double> wantGrad(referenceFF->dimension() * referenceFF->positions().size(), 0.0);
+  referenceFF->calcGrad(positions_.data(), wantGrad.data());
+  const std::vector<double> gotGrad = computeGradientViaForcefield(systemHost_, systemDevice_.positions);
+  EXPECT_THAT(gotGrad, ::testing::Pointwise(::testing::DoubleNear(kGradTol), wantGrad));
+}
+
+TEST_F(UFFGpuTestFixture, BlockPerMolMatchesRDKit) {
+  auto referenceFF = buildReferenceForceField(*mol_);
+  systemDevice_.energyOuts.zero();
+  CHECK_CUDA_RETURN(computeEnergyBlockPerMol(systemDevice_));
+  double gotEnergy = 0.0;
+  CHECK_CUDA_RETURN(cudaMemcpy(&gotEnergy, systemDevice_.energyOuts.data(), sizeof(double), cudaMemcpyDeviceToHost));
+
+  std::vector<double> wantGrad(referenceFF->dimension() * referenceFF->positions().size(), 0.0);
+  referenceFF->calcGrad(positions_.data(), wantGrad.data());
+  systemDevice_.grad.zero();
+  CHECK_CUDA_RETURN(computeGradBlockPerMol(systemDevice_));
+  std::vector<double> gotGrad(systemDevice_.positions.size(), 0.0);
+  systemDevice_.grad.copyToHost(gotGrad);
+  cudaDeviceSynchronize();
+
+  EXPECT_NEAR(gotEnergy, referenceFF->calcEnergy(positions_.data()), kEnergyTol);
+  EXPECT_THAT(gotGrad, ::testing::Pointwise(::testing::DoubleNear(kGradTol), wantGrad));
+}
+
+class UFFGpuEdgeCases : public ::testing::TestWithParam<std::string> {};
+
+TEST_P(UFFGpuEdgeCases, CombinedEnergyAndGradient) {
+  auto mol = buildEmbeddedEdgeCaseMol(GetParam());
+  ASSERT_NE(mol, nullptr);
+
+  auto positions = positionsFromMol(*mol);
+  const auto contribs  = constructForcefieldContribs(*mol);
+  BatchedMolecularSystemHost host;
+  addMoleculeToBatch(contribs, positions, host);
+
+  AsyncDeviceVector<double> positionsDevice;
+  positionsDevice.setFromVector(host.positions);
+  const double gotEnergy = computeEnergyViaForcefield(host, positionsDevice);
+  const auto   gotGrad   = computeGradientViaForcefield(host, positionsDevice);
+
+  auto referenceFF = buildReferenceForceField(*mol);
+  std::vector<double> wantGrad(referenceFF->dimension() * referenceFF->positions().size(), 0.0);
+  referenceFF->calcGrad(positions.data(), wantGrad.data());
+
+  EXPECT_NEAR(gotEnergy, referenceFF->calcEnergy(positions.data()), 1.0e-5);
+  EXPECT_THAT(gotGrad, ::testing::Pointwise(::testing::DoubleNear(2.0e-4), wantGrad));
+}
+
+INSTANTIATE_TEST_SUITE_P(UFFOneTwoAtoms,
+                         UFFGpuEdgeCases,
+                         ::testing::Values("C", "O", "CC", "CO", "CCC"));
+
+TEST(UFFValidationSuite, BatchMatchesRDKitValidationSet) {
+  const std::string sdfPath = getTestDataFolderPath() + "/MMFF94_dative.sdf";
+  std::vector<std::unique_ptr<RDKit::ROMol>> mols;
+  getMols(sdfPath, mols, 25);
+  ASSERT_FALSE(mols.empty());
+
+  BatchedMolecularSystemHost host;
+  std::vector<double>        wantEnergies;
+  std::vector<std::vector<double>> wantGrads;
+  for (size_t i = 0; i < mols.size(); ++i) {
+    auto& mol = *mols[i];
+    auto  positions = positionsFromMol(mol);
+    auto  contribs  = constructForcefieldContribs(mol);
+    addMoleculeToBatch(contribs, positions, host);
+
+    auto ff = buildReferenceForceField(mol);
+    wantEnergies.push_back(ff->calcEnergy(positions.data()));
+    std::vector<double> wantGrad(ff->dimension() * ff->positions().size(), 0.0);
+    ff->calcGrad(positions.data(), wantGrad.data());
+    wantGrads.push_back(std::move(wantGrad));
+  }
+
+  nvMolKit::UFFBatchedForcefield forcefield(host);
+  AsyncDeviceVector<double>      positionsDevice;
+  AsyncDeviceVector<double>      energiesDevice;
+  AsyncDeviceVector<double>      gradDevice;
+  positionsDevice.setFromVector(host.positions);
+  energiesDevice.resize(mols.size());
+  energiesDevice.zero();
+  gradDevice.resize(host.positions.size());
+  gradDevice.zero();
+
+  CHECK_CUDA_RETURN(forcefield.computeEnergy(energiesDevice.data(), positionsDevice.data()));
+  CHECK_CUDA_RETURN(forcefield.computeGradients(gradDevice.data(), positionsDevice.data()));
+
+  std::vector<double> gotEnergies(mols.size(), 0.0);
+  std::vector<double> gotGrad(host.positions.size(), 0.0);
+  energiesDevice.copyToHost(gotEnergies);
+  gradDevice.copyToHost(gotGrad);
+  cudaDeviceSynchronize();
+
+  for (size_t i = 0; i < wantEnergies.size(); ++i) {
+    EXPECT_NEAR(gotEnergies[i], wantEnergies[i], 1.0e-5) << "molecule " << i;
+    const int atomStart = host.indices.atomStarts[i];
+    const int atomEnd   = host.indices.atomStarts[i + 1];
+    std::vector<double> gotGradMol(gotGrad.begin() + atomStart * 3, gotGrad.begin() + atomEnd * 3);
+    EXPECT_THAT(gotGradMol, ::testing::Pointwise(::testing::DoubleNear(2.0e-4), wantGrads[i])) << "molecule " << i;
+  }
+}
+
+TEST(UFFMinimizer, BatchMinimizerMatchesRDKitFinalEnergies) {
+  const std::string sdfPath = getTestDataFolderPath() + "/MMFF94_dative.sdf";
+  std::vector<std::unique_ptr<RDKit::ROMol>> mols;
+  getMols(sdfPath, mols, 8);
+  ASSERT_FALSE(mols.empty());
+
+  BatchedMolecularSystemHost host;
+  std::vector<double>        referenceFinalEnergies;
+  for (auto& molPtr : mols) {
+    auto& mol = *molPtr;
+    auto positions = positionsFromMol(mol);
+    auto contribs  = constructForcefieldContribs(mol);
+    addMoleculeToBatch(contribs, positions, host);
+
+    const auto optimizeResult = RDKit::UFF::UFFOptimizeMolecule(mol, 1000, 100.0, -1, true);
+    referenceFinalEnergies.push_back(optimizeResult.second);
+  }
+
+  AsyncDeviceVector<double> positionsDevice;
+  AsyncDeviceVector<double> gradDevice;
+  AsyncDeviceVector<double> energiesDevice;
+  positionsDevice.setFromVector(host.positions);
+  gradDevice.resize(host.positions.size());
+  gradDevice.zero();
+  energiesDevice.resize(mols.size());
+  energiesDevice.zero();
+
+  nvMolKit::UFFBatchedForcefield forcefield(host);
+  nvMolKit::BfgsBatchMinimizer   minimizer;
+  const bool needsMore = minimizer.minimize(1000, 1.0e-6, forcefield, positionsDevice, gradDevice, energiesDevice);
+  EXPECT_FALSE(needsMore);
+
+  std::vector<double> gotFinalEnergies(mols.size(), 0.0);
+  energiesDevice.copyToHost(gotFinalEnergies);
+  cudaDeviceSynchronize();
+  for (size_t i = 0; i < gotFinalEnergies.size(); ++i) {
+    EXPECT_NEAR(gotFinalEnergies[i], referenceFinalEnergies[i], kMinimizeEnergyTol) << "molecule " << i;
+  }
+}


### PR DESCRIPTION
Adds UFF bond stretch, angle bend, torsion, inversion, and van der Waals terms with batched GPU evaluation. Includes RDKit UFF parameter flattening, batched forcefield wrapper, and C++ tests.

