### PR TITLE
Template forcefield constraints for UFF

### DIFF
--- a/src/forcefields/CMakeLists.txt
+++ b/src/forcefields/CMakeLists.txt
@@ -26,15 +26,23 @@ target_link_libraries(batched_forcefield PUBLIC device_vector)
 target_include_directories(batched_forcefield PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
                                                      ${CMAKE_SOURCE_DIR}/src)
 
-add_library(mmff mmff.cu mmff_kernels.cu forcefield_constraints.cpp)
+add_library(forcefield_constraints forcefield_constraints.cpp)
+target_link_libraries(forcefield_constraints PUBLIC batched_forcefield)
+target_include_directories(forcefield_constraints
+                           PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(mmff mmff.cu mmff_kernels.cu)
 target_link_libraries(
   mmff
-  PUBLIC batched_forcefield
+  PUBLIC batched_forcefield forcefield_constraints
   PRIVATE device_vector ff_kernel_utils)
 target_include_directories(mmff PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(uff uff.cu uff_kernels.cu)
-target_link_libraries(uff PRIVATE device_vector ff_kernel_utils)
+target_link_libraries(
+  uff
+  PUBLIC forcefield_constraints
+  PRIVATE device_vector ff_kernel_utils)
 target_include_directories(uff PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(dist_geom dist_geom.cu dist_geom_kernels.cu coord_gen.cu)

--- a/src/forcefields/forcefield_constraints.cpp
+++ b/src/forcefields/forcefield_constraints.cpp
@@ -126,8 +126,6 @@ double computeDihedralDeg(const std::vector<double>& positions,
   return kRadiansToDegrees * dihedral;
 }
 
-namespace {
-
 template <typename Contribs>
 void appendDistanceConstraintImpl(Contribs&                     contribs,
                                   const std::vector<double>&    positions,
@@ -225,48 +223,46 @@ void appendTorsionConstraintImpl(Contribs&                    contribs,
   contribs.torsionConstraintTerms.forceConstant.push_back(spec.forceConstant);
 }
 
-}  // namespace
-
-void appendDistanceConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c,
-                              const std::vector<double>&               p,
-                              const DistanceConstraintSpec&            s) {
-  appendDistanceConstraintImpl(c, p, s);
+void appendDistanceConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
+                              const std::vector<double>&               positions,
+                              const DistanceConstraintSpec&            spec) {
+  appendDistanceConstraintImpl(contribs, positions, spec);
 }
-void appendPositionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c,
-                              const std::vector<double>&               p,
-                              const PositionConstraintSpec&            s) {
-  appendPositionConstraintImpl(c, p, s);
+void appendPositionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
+                              const std::vector<double>&               positions,
+                              const PositionConstraintSpec&            spec) {
+  appendPositionConstraintImpl(contribs, positions, spec);
 }
-void appendAngleConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c,
-                           const std::vector<double>&               p,
-                           const AngleConstraintSpec&               s) {
-  appendAngleConstraintImpl(c, p, s);
+void appendAngleConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
+                           const std::vector<double>&               positions,
+                           const AngleConstraintSpec&               spec) {
+  appendAngleConstraintImpl(contribs, positions, spec);
 }
-void appendTorsionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c,
-                             const std::vector<double>&               p,
-                             const TorsionConstraintSpec&             s) {
-  appendTorsionConstraintImpl(c, p, s);
+void appendTorsionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
+                             const std::vector<double>&               positions,
+                             const TorsionConstraintSpec&             spec) {
+  appendTorsionConstraintImpl(contribs, positions, spec);
 }
 
-void appendDistanceConstraint(nvMolKit::UFF::EnergyForceContribsHost& c,
-                              const std::vector<double>&              p,
-                              const DistanceConstraintSpec&           s) {
-  appendDistanceConstraintImpl(c, p, s);
+void appendDistanceConstraint(nvMolKit::UFF::EnergyForceContribsHost& contribs,
+                              const std::vector<double>&              positions,
+                              const DistanceConstraintSpec&           spec) {
+  appendDistanceConstraintImpl(contribs, positions, spec);
 }
-void appendPositionConstraint(nvMolKit::UFF::EnergyForceContribsHost& c,
-                              const std::vector<double>&              p,
-                              const PositionConstraintSpec&           s) {
-  appendPositionConstraintImpl(c, p, s);
+void appendPositionConstraint(nvMolKit::UFF::EnergyForceContribsHost& contribs,
+                              const std::vector<double>&              positions,
+                              const PositionConstraintSpec&           spec) {
+  appendPositionConstraintImpl(contribs, positions, spec);
 }
-void appendAngleConstraint(nvMolKit::UFF::EnergyForceContribsHost& c,
-                           const std::vector<double>&              p,
-                           const AngleConstraintSpec&              s) {
-  appendAngleConstraintImpl(c, p, s);
+void appendAngleConstraint(nvMolKit::UFF::EnergyForceContribsHost& contribs,
+                           const std::vector<double>&              positions,
+                           const AngleConstraintSpec&              spec) {
+  appendAngleConstraintImpl(contribs, positions, spec);
 }
-void appendTorsionConstraint(nvMolKit::UFF::EnergyForceContribsHost& c,
-                             const std::vector<double>&              p,
-                             const TorsionConstraintSpec&            s) {
-  appendTorsionConstraintImpl(c, p, s);
+void appendTorsionConstraint(nvMolKit::UFF::EnergyForceContribsHost& contribs,
+                             const std::vector<double>&              positions,
+                             const TorsionConstraintSpec&            spec) {
+  appendTorsionConstraintImpl(contribs, positions, spec);
 }
 
 }  // namespace nvMolKit::ForceFieldConstraints

--- a/src/forcefields/forcefield_constraints.cpp
+++ b/src/forcefields/forcefield_constraints.cpp
@@ -126,9 +126,12 @@ double computeDihedralDeg(const std::vector<double>& positions,
   return kRadiansToDegrees * dihedral;
 }
 
-void appendDistanceConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
-                              const std::vector<double>&               positions,
-                              const DistanceConstraintSpec&            spec) {
+namespace {
+
+template <typename Contribs>
+void appendDistanceConstraintImpl(Contribs&                    contribs,
+                                  const std::vector<double>&   positions,
+                                  const DistanceConstraintSpec& spec) {
   const int numAtoms = static_cast<int>(positions.size() / 3);
   validateAtomIndex(spec.idx1, numAtoms, "Distance constraint atom");
   validateAtomIndex(spec.idx2, numAtoms, "Distance constraint atom");
@@ -149,9 +152,10 @@ void appendDistanceConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
   contribs.distanceConstraintTerms.forceConstant.push_back(spec.forceConstant);
 }
 
-void appendPositionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
-                              const std::vector<double>&               positions,
-                              const PositionConstraintSpec&            spec) {
+template <typename Contribs>
+void appendPositionConstraintImpl(Contribs&                    contribs,
+                                  const std::vector<double>&   positions,
+                                  const PositionConstraintSpec& spec) {
   const int numAtoms = static_cast<int>(positions.size() / 3);
   validateAtomIndex(spec.idx, numAtoms, "Position constraint atom");
   contribs.positionConstraintTerms.idx.push_back(spec.idx);
@@ -162,9 +166,10 @@ void appendPositionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
   contribs.positionConstraintTerms.forceConstant.push_back(spec.forceConstant);
 }
 
-void appendAngleConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
-                           const std::vector<double>&               positions,
-                           const AngleConstraintSpec&               spec) {
+template <typename Contribs>
+void appendAngleConstraintImpl(Contribs&                  contribs,
+                               const std::vector<double>& positions,
+                               const AngleConstraintSpec& spec) {
   const int numAtoms = static_cast<int>(positions.size() / 3);
   validateAtomIndex(spec.idx1, numAtoms, "Angle constraint atom");
   validateAtomIndex(spec.idx2, numAtoms, "Angle constraint atom");
@@ -190,9 +195,10 @@ void appendAngleConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
   contribs.angleConstraintTerms.forceConstant.push_back(spec.forceConstant);
 }
 
-void appendTorsionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
-                             const std::vector<double>&               positions,
-                             const TorsionConstraintSpec&             spec) {
+template <typename Contribs>
+void appendTorsionConstraintImpl(Contribs&                    contribs,
+                                 const std::vector<double>&   positions,
+                                 const TorsionConstraintSpec& spec) {
   const int numAtoms = static_cast<int>(positions.size() / 3);
   validateAtomIndex(spec.idx1, numAtoms, "Torsion constraint atom");
   validateAtomIndex(spec.idx2, numAtoms, "Torsion constraint atom");
@@ -218,5 +224,17 @@ void appendTorsionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
   contribs.torsionConstraintTerms.maxDihedralDeg.push_back(maxDihedralDeg);
   contribs.torsionConstraintTerms.forceConstant.push_back(spec.forceConstant);
 }
+
+}  // namespace
+
+void appendDistanceConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c, const std::vector<double>& p, const DistanceConstraintSpec& s) { appendDistanceConstraintImpl(c, p, s); }
+void appendPositionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c, const std::vector<double>& p, const PositionConstraintSpec& s) { appendPositionConstraintImpl(c, p, s); }
+void appendAngleConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c, const std::vector<double>& p, const AngleConstraintSpec& s) { appendAngleConstraintImpl(c, p, s); }
+void appendTorsionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c, const std::vector<double>& p, const TorsionConstraintSpec& s) { appendTorsionConstraintImpl(c, p, s); }
+
+void appendDistanceConstraint(nvMolKit::UFF::EnergyForceContribsHost& c, const std::vector<double>& p, const DistanceConstraintSpec& s) { appendDistanceConstraintImpl(c, p, s); }
+void appendPositionConstraint(nvMolKit::UFF::EnergyForceContribsHost& c, const std::vector<double>& p, const PositionConstraintSpec& s) { appendPositionConstraintImpl(c, p, s); }
+void appendAngleConstraint(nvMolKit::UFF::EnergyForceContribsHost& c, const std::vector<double>& p, const AngleConstraintSpec& s) { appendAngleConstraintImpl(c, p, s); }
+void appendTorsionConstraint(nvMolKit::UFF::EnergyForceContribsHost& c, const std::vector<double>& p, const TorsionConstraintSpec& s) { appendTorsionConstraintImpl(c, p, s); }
 
 }  // namespace nvMolKit::ForceFieldConstraints

--- a/src/forcefields/forcefield_constraints.cpp
+++ b/src/forcefields/forcefield_constraints.cpp
@@ -129,8 +129,8 @@ double computeDihedralDeg(const std::vector<double>& positions,
 namespace {
 
 template <typename Contribs>
-void appendDistanceConstraintImpl(Contribs&                    contribs,
-                                  const std::vector<double>&   positions,
+void appendDistanceConstraintImpl(Contribs&                     contribs,
+                                  const std::vector<double>&    positions,
                                   const DistanceConstraintSpec& spec) {
   const int numAtoms = static_cast<int>(positions.size() / 3);
   validateAtomIndex(spec.idx1, numAtoms, "Distance constraint atom");
@@ -153,8 +153,8 @@ void appendDistanceConstraintImpl(Contribs&                    contribs,
 }
 
 template <typename Contribs>
-void appendPositionConstraintImpl(Contribs&                    contribs,
-                                  const std::vector<double>&   positions,
+void appendPositionConstraintImpl(Contribs&                     contribs,
+                                  const std::vector<double>&    positions,
                                   const PositionConstraintSpec& spec) {
   const int numAtoms = static_cast<int>(positions.size() / 3);
   validateAtomIndex(spec.idx, numAtoms, "Position constraint atom");
@@ -227,14 +227,46 @@ void appendTorsionConstraintImpl(Contribs&                    contribs,
 
 }  // namespace
 
-void appendDistanceConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c, const std::vector<double>& p, const DistanceConstraintSpec& s) { appendDistanceConstraintImpl(c, p, s); }
-void appendPositionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c, const std::vector<double>& p, const PositionConstraintSpec& s) { appendPositionConstraintImpl(c, p, s); }
-void appendAngleConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c, const std::vector<double>& p, const AngleConstraintSpec& s) { appendAngleConstraintImpl(c, p, s); }
-void appendTorsionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c, const std::vector<double>& p, const TorsionConstraintSpec& s) { appendTorsionConstraintImpl(c, p, s); }
+void appendDistanceConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c,
+                              const std::vector<double>&               p,
+                              const DistanceConstraintSpec&            s) {
+  appendDistanceConstraintImpl(c, p, s);
+}
+void appendPositionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c,
+                              const std::vector<double>&               p,
+                              const PositionConstraintSpec&            s) {
+  appendPositionConstraintImpl(c, p, s);
+}
+void appendAngleConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c,
+                           const std::vector<double>&               p,
+                           const AngleConstraintSpec&               s) {
+  appendAngleConstraintImpl(c, p, s);
+}
+void appendTorsionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& c,
+                             const std::vector<double>&               p,
+                             const TorsionConstraintSpec&             s) {
+  appendTorsionConstraintImpl(c, p, s);
+}
 
-void appendDistanceConstraint(nvMolKit::UFF::EnergyForceContribsHost& c, const std::vector<double>& p, const DistanceConstraintSpec& s) { appendDistanceConstraintImpl(c, p, s); }
-void appendPositionConstraint(nvMolKit::UFF::EnergyForceContribsHost& c, const std::vector<double>& p, const PositionConstraintSpec& s) { appendPositionConstraintImpl(c, p, s); }
-void appendAngleConstraint(nvMolKit::UFF::EnergyForceContribsHost& c, const std::vector<double>& p, const AngleConstraintSpec& s) { appendAngleConstraintImpl(c, p, s); }
-void appendTorsionConstraint(nvMolKit::UFF::EnergyForceContribsHost& c, const std::vector<double>& p, const TorsionConstraintSpec& s) { appendTorsionConstraintImpl(c, p, s); }
+void appendDistanceConstraint(nvMolKit::UFF::EnergyForceContribsHost& c,
+                              const std::vector<double>&              p,
+                              const DistanceConstraintSpec&           s) {
+  appendDistanceConstraintImpl(c, p, s);
+}
+void appendPositionConstraint(nvMolKit::UFF::EnergyForceContribsHost& c,
+                              const std::vector<double>&              p,
+                              const PositionConstraintSpec&           s) {
+  appendPositionConstraintImpl(c, p, s);
+}
+void appendAngleConstraint(nvMolKit::UFF::EnergyForceContribsHost& c,
+                           const std::vector<double>&              p,
+                           const AngleConstraintSpec&              s) {
+  appendAngleConstraintImpl(c, p, s);
+}
+void appendTorsionConstraint(nvMolKit::UFF::EnergyForceContribsHost& c,
+                             const std::vector<double>&              p,
+                             const TorsionConstraintSpec&            s) {
+  appendTorsionConstraintImpl(c, p, s);
+}
 
 }  // namespace nvMolKit::ForceFieldConstraints

--- a/src/forcefields/forcefield_constraints.h
+++ b/src/forcefields/forcefield_constraints.h
@@ -23,6 +23,7 @@
 // mmff.h / mmff_kernels.h but are forcefield-generic. They should be extracted into shared headers
 // so that UFF (and future forcefields) don't depend on MMFF.
 #include "mmff.h"
+#include "uff.h"
 
 namespace nvMolKit::ForceFieldConstraints {
 
@@ -80,6 +81,19 @@ void appendAngleConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
 void appendTorsionConstraint(nvMolKit::MMFF::EnergyForceContribsHost& contribs,
                              const std::vector<double>&               positions,
                              const TorsionConstraintSpec&             spec);
+
+void appendDistanceConstraint(nvMolKit::UFF::EnergyForceContribsHost& contribs,
+                              const std::vector<double>&              positions,
+                              const DistanceConstraintSpec&           spec);
+void appendPositionConstraint(nvMolKit::UFF::EnergyForceContribsHost& contribs,
+                              const std::vector<double>&              positions,
+                              const PositionConstraintSpec&           spec);
+void appendAngleConstraint(nvMolKit::UFF::EnergyForceContribsHost& contribs,
+                           const std::vector<double>&              positions,
+                           const AngleConstraintSpec&              spec);
+void appendTorsionConstraint(nvMolKit::UFF::EnergyForceContribsHost& contribs,
+                             const std::vector<double>&              positions,
+                             const TorsionConstraintSpec&            spec);
 
 }  // namespace nvMolKit::ForceFieldConstraints
 

--- a/tests/test_uff.cu
+++ b/tests/test_uff.cu
@@ -13,7 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <ForceField/AngleConstraints.h>
+#include <ForceField/DistanceConstraints.h>
 #include <ForceField/ForceField.h>
+#include <ForceField/MMFF/PositionConstraint.h>
+#include <ForceField/MMFF/TorsionConstraint.h>
 #include <gmock/gmock.h>
 #include <GraphMol/DistGeomHelpers/Embedder.h>
 #include <GraphMol/FileParsers/FileParsers.h>
@@ -31,6 +35,7 @@
 
 #include "device_vector.h"
 #include "ff_utils.h"
+#include "forcefield_constraints.h"
 #include "minimizer/bfgs_minimize.h"
 #include "test_utils.h"
 #include "uff.h"
@@ -284,4 +289,205 @@ TEST(UFFMinimizer, BatchMinimizerMatchesRDKitFinalEnergies) {
   for (size_t i = 0; i < gotFinalEnergies.size(); ++i) {
     EXPECT_NEAR(gotFinalEnergies[i], referenceFinalEnergies[i], kMinimizeEnergyTol) << "molecule " << i;
   }
+}
+
+namespace {
+
+double getConstraintEnergyViaForcefield(const EnergyForceContribsHost& contribs, const std::vector<double>& positions) {
+  BatchedMolecularSystemHost systemHost;
+  addMoleculeToBatch(contribs, positions, systemHost);
+  AsyncDeviceVector<double> positionsDevice;
+  positionsDevice.setFromVector(systemHost.positions);
+  return computeEnergyViaForcefield(systemHost, positionsDevice);
+}
+
+std::vector<double> getConstraintGradientViaForcefield(const EnergyForceContribsHost& contribs,
+                                                       const std::vector<double>&     positions) {
+  BatchedMolecularSystemHost systemHost;
+  addMoleculeToBatch(contribs, positions, systemHost);
+  AsyncDeviceVector<double> positionsDevice;
+  positionsDevice.setFromVector(systemHost.positions);
+  return computeGradientViaForcefield(systemHost, positionsDevice);
+}
+
+double getReferenceConstraintEnergy(RDKit::ROMol&                  mol,
+                                    const EnergyForceContribsHost& contribs,
+                                    const std::vector<double>&     positions) {
+  auto referenceFF = std::make_unique<ForceFields::ForceField>();
+  nvMolKit::setFFPosFromConf(mol, referenceFF.get());
+  referenceFF->initialize();
+
+  for (size_t i = 0; i < contribs.distanceConstraintTerms.idx1.size(); ++i) {
+    auto* dc = new ForceFields::DistanceConstraintContribs(referenceFF.get());
+    dc->addContrib(contribs.distanceConstraintTerms.idx1[i],
+                   contribs.distanceConstraintTerms.idx2[i],
+                   contribs.distanceConstraintTerms.minLen[i],
+                   contribs.distanceConstraintTerms.maxLen[i],
+                   contribs.distanceConstraintTerms.forceConstant[i]);
+    referenceFF->contribs().push_back(ForceFields::ContribPtr(dc));
+  }
+  for (size_t i = 0; i < contribs.positionConstraintTerms.idx.size(); ++i) {
+    auto* pc = new ForceFields::MMFF::PositionConstraintContrib(referenceFF.get(),
+                                                                contribs.positionConstraintTerms.idx[i],
+                                                                contribs.positionConstraintTerms.maxDispl[i],
+                                                                contribs.positionConstraintTerms.forceConstant[i]);
+    referenceFF->contribs().push_back(ForceFields::ContribPtr(pc));
+  }
+  for (size_t i = 0; i < contribs.angleConstraintTerms.idx1.size(); ++i) {
+    auto* ac = new ForceFields::AngleConstraintContribs(referenceFF.get());
+    ac->addContrib(contribs.angleConstraintTerms.idx1[i],
+                   contribs.angleConstraintTerms.idx2[i],
+                   contribs.angleConstraintTerms.idx3[i],
+                   contribs.angleConstraintTerms.minAngleDeg[i],
+                   contribs.angleConstraintTerms.maxAngleDeg[i],
+                   contribs.angleConstraintTerms.forceConstant[i]);
+    referenceFF->contribs().push_back(ForceFields::ContribPtr(ac));
+  }
+  for (size_t i = 0; i < contribs.torsionConstraintTerms.idx1.size(); ++i) {
+    auto* tc = new ForceFields::MMFF::TorsionConstraintContrib(referenceFF.get(),
+                                                               contribs.torsionConstraintTerms.idx1[i],
+                                                               contribs.torsionConstraintTerms.idx2[i],
+                                                               contribs.torsionConstraintTerms.idx3[i],
+                                                               contribs.torsionConstraintTerms.idx4[i],
+                                                               contribs.torsionConstraintTerms.minDihedralDeg[i],
+                                                               contribs.torsionConstraintTerms.maxDihedralDeg[i],
+                                                               contribs.torsionConstraintTerms.forceConstant[i]);
+    referenceFF->contribs().push_back(ForceFields::ContribPtr(tc));
+  }
+
+  std::vector<double> evalPositions = positions;
+  return referenceFF->calcEnergy(evalPositions.data());
+}
+
+std::vector<double> getReferenceConstraintGradient(RDKit::ROMol&                  mol,
+                                                   const EnergyForceContribsHost& contribs,
+                                                   const std::vector<double>&     positions) {
+  auto referenceFF = std::make_unique<ForceFields::ForceField>();
+  nvMolKit::setFFPosFromConf(mol, referenceFF.get());
+  referenceFF->initialize();
+
+  for (size_t i = 0; i < contribs.distanceConstraintTerms.idx1.size(); ++i) {
+    auto* dc = new ForceFields::DistanceConstraintContribs(referenceFF.get());
+    dc->addContrib(contribs.distanceConstraintTerms.idx1[i],
+                   contribs.distanceConstraintTerms.idx2[i],
+                   contribs.distanceConstraintTerms.minLen[i],
+                   contribs.distanceConstraintTerms.maxLen[i],
+                   contribs.distanceConstraintTerms.forceConstant[i]);
+    referenceFF->contribs().push_back(ForceFields::ContribPtr(dc));
+  }
+  for (size_t i = 0; i < contribs.positionConstraintTerms.idx.size(); ++i) {
+    auto* pc = new ForceFields::MMFF::PositionConstraintContrib(referenceFF.get(),
+                                                                contribs.positionConstraintTerms.idx[i],
+                                                                contribs.positionConstraintTerms.maxDispl[i],
+                                                                contribs.positionConstraintTerms.forceConstant[i]);
+    referenceFF->contribs().push_back(ForceFields::ContribPtr(pc));
+  }
+  for (size_t i = 0; i < contribs.angleConstraintTerms.idx1.size(); ++i) {
+    auto* ac = new ForceFields::AngleConstraintContribs(referenceFF.get());
+    ac->addContrib(contribs.angleConstraintTerms.idx1[i],
+                   contribs.angleConstraintTerms.idx2[i],
+                   contribs.angleConstraintTerms.idx3[i],
+                   contribs.angleConstraintTerms.minAngleDeg[i],
+                   contribs.angleConstraintTerms.maxAngleDeg[i],
+                   contribs.angleConstraintTerms.forceConstant[i]);
+    referenceFF->contribs().push_back(ForceFields::ContribPtr(ac));
+  }
+  for (size_t i = 0; i < contribs.torsionConstraintTerms.idx1.size(); ++i) {
+    auto* tc = new ForceFields::MMFF::TorsionConstraintContrib(referenceFF.get(),
+                                                               contribs.torsionConstraintTerms.idx1[i],
+                                                               contribs.torsionConstraintTerms.idx2[i],
+                                                               contribs.torsionConstraintTerms.idx3[i],
+                                                               contribs.torsionConstraintTerms.idx4[i],
+                                                               contribs.torsionConstraintTerms.minDihedralDeg[i],
+                                                               contribs.torsionConstraintTerms.maxDihedralDeg[i],
+                                                               contribs.torsionConstraintTerms.forceConstant[i]);
+    referenceFF->contribs().push_back(ForceFields::ContribPtr(tc));
+  }
+
+  std::vector<double> evalPositions = positions;
+  std::vector<double> gradients(positions.size(), 0.0);
+  referenceFF->calcGrad(evalPositions.data(), gradients.data());
+  return gradients;
+}
+
+}  // namespace
+
+TEST_F(UFFGpuTestFixture, DistanceConstraintEnergy) {
+  EnergyForceContribsHost                                       contribs;
+  const nvMolKit::ForceFieldConstraints::DistanceConstraintSpec spec{0, 2, true, 0.3, 0.6, 15.0};
+  nvMolKit::ForceFieldConstraints::appendDistanceConstraint(contribs, positions_, spec);
+
+  const double wantEnergy = getReferenceConstraintEnergy(*mol_, contribs, positions_);
+  EXPECT_NEAR(getConstraintEnergyViaForcefield(contribs, positions_), wantEnergy, kEnergyTol);
+}
+
+TEST_F(UFFGpuTestFixture, DistanceConstraintGradient) {
+  EnergyForceContribsHost                                       contribs;
+  const nvMolKit::ForceFieldConstraints::DistanceConstraintSpec spec{0, 2, true, 0.3, 0.6, 15.0};
+  nvMolKit::ForceFieldConstraints::appendDistanceConstraint(contribs, positions_, spec);
+
+  const auto wantGrad = getReferenceConstraintGradient(*mol_, contribs, positions_);
+  const auto gotGrad  = getConstraintGradientViaForcefield(contribs, positions_);
+  EXPECT_THAT(gotGrad, ::testing::Pointwise(::testing::DoubleNear(kGradTol), wantGrad));
+}
+
+TEST_F(UFFGpuTestFixture, PositionConstraintEnergy) {
+  EnergyForceContribsHost                                       contribs;
+  const nvMolKit::ForceFieldConstraints::PositionConstraintSpec spec{0, 0.1, 50.0};
+  nvMolKit::ForceFieldConstraints::appendPositionConstraint(contribs, positions_, spec);
+
+  std::vector<double> evalPositions = positions_;
+  evalPositions[0] += 0.25;
+  const double wantEnergy = getReferenceConstraintEnergy(*mol_, contribs, evalPositions);
+  EXPECT_NEAR(getConstraintEnergyViaForcefield(contribs, evalPositions), wantEnergy, kEnergyTol);
+}
+
+TEST_F(UFFGpuTestFixture, PositionConstraintGradient) {
+  EnergyForceContribsHost                                       contribs;
+  const nvMolKit::ForceFieldConstraints::PositionConstraintSpec spec{0, 0.1, 50.0};
+  nvMolKit::ForceFieldConstraints::appendPositionConstraint(contribs, positions_, spec);
+
+  std::vector<double> evalPositions = positions_;
+  evalPositions[0] += 0.25;
+  const auto wantGrad = getReferenceConstraintGradient(*mol_, contribs, evalPositions);
+  const auto gotGrad  = getConstraintGradientViaForcefield(contribs, evalPositions);
+  EXPECT_THAT(gotGrad, ::testing::Pointwise(::testing::DoubleNear(kGradTol), wantGrad));
+}
+
+TEST_F(UFFGpuTestFixture, AngleConstraintEnergy) {
+  EnergyForceContribsHost                                    contribs;
+  const nvMolKit::ForceFieldConstraints::AngleConstraintSpec spec{0, 1, 2, true, 5.0, 10.0, 20.0};
+  nvMolKit::ForceFieldConstraints::appendAngleConstraint(contribs, positions_, spec);
+
+  const double wantEnergy = getReferenceConstraintEnergy(*mol_, contribs, positions_);
+  EXPECT_NEAR(getConstraintEnergyViaForcefield(contribs, positions_), wantEnergy, kEnergyTol);
+}
+
+TEST_F(UFFGpuTestFixture, AngleConstraintGradient) {
+  EnergyForceContribsHost                                    contribs;
+  const nvMolKit::ForceFieldConstraints::AngleConstraintSpec spec{0, 1, 2, true, 5.0, 10.0, 20.0};
+  nvMolKit::ForceFieldConstraints::appendAngleConstraint(contribs, positions_, spec);
+
+  const auto wantGrad = getReferenceConstraintGradient(*mol_, contribs, positions_);
+  const auto gotGrad  = getConstraintGradientViaForcefield(contribs, positions_);
+  EXPECT_THAT(gotGrad, ::testing::Pointwise(::testing::DoubleNear(1.0e-3), wantGrad));
+}
+
+TEST_F(UFFGpuTestFixture, TorsionConstraintEnergy) {
+  EnergyForceContribsHost                                      contribs;
+  const nvMolKit::ForceFieldConstraints::TorsionConstraintSpec spec{0, 1, 2, 3, true, 15.0, 30.0, 12.0};
+  nvMolKit::ForceFieldConstraints::appendTorsionConstraint(contribs, positions_, spec);
+
+  const double wantEnergy = getReferenceConstraintEnergy(*mol_, contribs, positions_);
+  EXPECT_NEAR(getConstraintEnergyViaForcefield(contribs, positions_), wantEnergy, kEnergyTol);
+}
+
+TEST_F(UFFGpuTestFixture, TorsionConstraintGradient) {
+  EnergyForceContribsHost                                      contribs;
+  const nvMolKit::ForceFieldConstraints::TorsionConstraintSpec spec{0, 1, 2, 3, true, 15.0, 30.0, 12.0};
+  nvMolKit::ForceFieldConstraints::appendTorsionConstraint(contribs, positions_, spec);
+
+  const auto wantGrad = getReferenceConstraintGradient(*mol_, contribs, positions_);
+  const auto gotGrad  = getConstraintGradientViaForcefield(contribs, positions_);
+  EXPECT_THAT(gotGrad, ::testing::Pointwise(::testing::DoubleNear(1.0e-3), wantGrad));
 }


### PR DESCRIPTION
    Templatize the four append*Constraint functions into *Impl templates
    in an anonymous namespace and provide explicit overloads for both
    MMFF::EnergyForceContribsHost and UFF::EnergyForceContribsHost.
    This lets UFF batched forcefields reuse the same constraint logic.
