### PR TITLE
CMake cleanup 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@
 
 cmake_minimum_required(VERSION 3.30)
 
+# Use the FindBoost replacement provided by the upstream Boost project.
+cmake_policy(SET CMP0167 NEW)
+
 project(
   nvmolkit
   VERSION 0.4.0
@@ -39,9 +42,21 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(CMAKE_BUILD_TYPE
-    ${CMAKE_BUILD_TYPE}
-    CACHE STRING "Choose type of build, options are: Debug RelWithDebInfo Release asan tsan ubsan" FORCE)
+get_property(_nvmolkit_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT _nvmolkit_is_multi_config AND NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE
+      "RelWithDebInfo"
+      CACHE STRING "Choose type of build, options are: Debug RelWithDebInfo Release asan tsan ubsan")
+  set_property(
+    CACHE CMAKE_BUILD_TYPE
+    PROPERTY STRINGS
+             Debug
+             RelWithDebInfo
+             Release
+             asan
+             tsan
+             ubsan)
+endif()
 
 # --------------------------------
 # Global compilation features

--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -13,9 +13,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# Suppress deprecation warning using old find boost method
-cmake_policy(SET CMP0167 NEW)
-
 if(NVMOLKIT_BUILD_AGAINST_PIP_RDKIT)
   message(STATUS "Using boost libs from pip RDKit")
 else()

--- a/cmake/nvmolkit_cmake_options.cmake
+++ b/cmake/nvmolkit_cmake_options.cmake
@@ -22,6 +22,8 @@ option(NVMOLKIT_EXTRA_DEV_FLAGS "Enable extra development QA flags" ON)
 # Optional compilation options
 option(NVMOLKIT_BUILD_TESTS "Whether or not to build tests" ON)
 option(NVMOLKIT_BUILD_BENCHMARKS "Whether or not to build benchmarks" ON)
+option(NVMOLKIT_BUILD_PYTHON_BINDINGS "Whether or not to build python bindings"
+       OFF)
 
 set(NVMOLKIT_CUDA_TARGET_MODE
     "default"

--- a/cmake/rdkit.cmake
+++ b/cmake/rdkit.cmake
@@ -13,9 +13,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# Suppress deprecation warning using old find boost method
-cmake_policy(SET CMP0167 NEW)
-
 if(NOT NVMOLKIT_BUILD_AGAINST_PIP_RDKIT)
   find_package(RDKit REQUIRED)
   set(RDKit_LIBS

--- a/nvmolkit/CMakeLists.txt
+++ b/nvmolkit/CMakeLists.txt
@@ -117,8 +117,9 @@ installpythontarget(_conformerRmsd ./)
 
 add_library(_substructure MODULE substructure.cpp)
 target_include_directories(
-  _substructure PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/utils ${Boost_INCLUDE_DIRS}
-                       ${Python_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/src/substruct)
+  _substructure
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/utils ${Boost_INCLUDE_DIRS}
+         ${Python_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/src/substruct)
 target_link_libraries(_substructure PUBLIC ${Boost_LIBRARIES}
                                            ${PYTHON_LIBRARIES})
 target_link_libraries(_substructure PRIVATE ${RDKit_LIBS} substructure_search

--- a/src/forcefields/CMakeLists.txt
+++ b/src/forcefields/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(ff_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(batched_forcefield batched_forcefield.cpp)
 target_link_libraries(batched_forcefield PUBLIC device_vector)
 target_include_directories(batched_forcefield PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                                                     ${CMAKE_SOURCE_DIR}/src)
+                                                     ${PROJECT_SOURCE_DIR}/src)
 
 add_library(forcefield_constraints forcefield_constraints.cpp)
 target_link_libraries(forcefield_constraints PUBLIC batched_forcefield)
@@ -60,7 +60,7 @@ target_link_libraries(
   PRIVATE device_vector)
 target_include_directories(
   mmff_batched_forcefield PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                                 ${CMAKE_SOURCE_DIR}/src)
+                                 ${PROJECT_SOURCE_DIR}/src)
 
 add_library(uff_batched_forcefield uff_batched_forcefield.cu)
 target_link_libraries(
@@ -69,7 +69,7 @@ target_link_libraries(
   PRIVATE device_vector)
 target_include_directories(
   uff_batched_forcefield PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                                ${CMAKE_SOURCE_DIR}/src)
+                                ${PROJECT_SOURCE_DIR}/src)
 
 add_library(dg_batched_forcefield dg_batched_forcefield.cu)
 target_link_libraries(
@@ -78,7 +78,7 @@ target_link_libraries(
   PRIVATE device_vector)
 target_include_directories(
   dg_batched_forcefield PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                               ${CMAKE_SOURCE_DIR}/src)
+                               ${PROJECT_SOURCE_DIR}/src)
 
 add_library(etk_batched_forcefield etk_batched_forcefield.cu)
 target_link_libraries(
@@ -87,4 +87,4 @@ target_link_libraries(
   PRIVATE device_vector)
 target_include_directories(
   etk_batched_forcefield PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                                ${CMAKE_SOURCE_DIR}/src)
+                                ${PROJECT_SOURCE_DIR}/src)

--- a/src/minimizer/CMakeLists.txt
+++ b/src/minimizer/CMakeLists.txt
@@ -42,8 +42,7 @@ target_link_libraries(
           OpenMP::OpenMP_CXX
           openmp_helpers
           cccl_interface)
-target_include_directories(bfgs_mmff PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                                            ${CMAKE_SOURCE_DIR}/src/forcefields)
+target_include_directories(bfgs_mmff PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(bfgs_uff bfgs_uff.cpp)
 target_link_libraries(
@@ -58,5 +57,4 @@ target_link_libraries(
           OpenMP::OpenMP_CXX
           openmp_helpers
           cccl_interface)
-target_include_directories(bfgs_uff PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                                           ${CMAKE_SOURCE_DIR}/src/forcefields)
+target_include_directories(bfgs_uff PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/testutils/CMakeLists.txt
+++ b/src/testutils/CMakeLists.txt
@@ -21,7 +21,7 @@ if(NVMOLKIT_BUILD_TESTS OR NVMOLKIT_BUILD_BENCHMARKS)
   add_library(substruct_validation substruct_validation.cu)
   target_include_directories(
     substruct_validation PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                                ${CMAKE_SOURCE_DIR}/src)
+                                ${PROJECT_SOURCE_DIR}/src)
   target_link_libraries(
     substruct_validation
     PUBLIC ${RDKit_LIBS} substructure_search substruct_definitions

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,7 +74,7 @@ target_link_libraries(
 
 add_executable(smarts_filter smarts_filter.cpp)
 target_link_libraries(smarts_filter PRIVATE molecules molData ${RDKit_LIBS})
-target_include_directories(smarts_filter PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(smarts_filter PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
 add_executable(test_flattened_builder test_flattened_builder.cu)
 target_link_libraries(


### PR DESCRIPTION
Part 1 towards Issue #42

- Declare NVMOLKIT_BUILD_PYTHON_BINDINGS as a real option(); previously it was used in five files but never declared.
- Replace the unconditional set(CMAKE_BUILD_TYPE ... FORCE) with a guarded default that only fires for single-config generators when no build type has been chosen, and add the supported types as cache STRINGS metadata.
- Replace ${CMAKE_SOURCE_DIR} usage in target_include_directories with ${PROJECT_SOURCE_DIR} (or remove redundant entries), so the project is safe to consume as a sub-add and does not leak its source-tree assumption.
- Centralize cmake_policy(SET CMP0167 NEW) at the top of the root CMakeLists.txt; remove duplicates from cmake/boost.cmake and cmake/rdkit.cmake.

