### PR TITLE
CMake Improvements 2 - remove global flags for interface targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,11 @@ endif()
 # ------------------------
 # Subdirectory includes
 # ------------------------
+
+# Apply the project-rooted include search path and project-wide compile options to every first-party target created in
+# the subdirectories below.
+link_libraries(nvmolkit_include_root nvmolkit_warnings nvmolkit_release_opts nvmolkit_cuda_options nvmolkit_sanitizers
+               nvmolkit_cuda_caps)
 add_subdirectory(rdkit_extensions)
 add_subdirectory(src)
 if(NVMOLKIT_BUILD_PYTHON_BINDINGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,10 +107,8 @@ endif()
 # Subdirectory includes
 # ------------------------
 
-# Apply the project-rooted include search path and project-wide compile options to every first-party target created in
-# the subdirectories below.
-link_libraries(nvmolkit_include_root nvmolkit_warnings nvmolkit_release_opts nvmolkit_cuda_options nvmolkit_sanitizers
-               nvmolkit_cuda_caps)
+# Apply project-wide compile options to every first-party target created in the subdirectories below.
+link_libraries(nvmolkit_warnings nvmolkit_release_opts nvmolkit_cuda_options nvmolkit_sanitizers nvmolkit_cuda_caps)
 add_subdirectory(rdkit_extensions)
 add_subdirectory(src)
 if(NVMOLKIT_BUILD_PYTHON_BINDINGS)

--- a/cmake/cuda_targets.cmake
+++ b/cmake/cuda_targets.cmake
@@ -84,7 +84,12 @@ else() # default
   endif()
 endif()
 
-# Identify CUDA compute capabilities for similarity tensor core support.
+# Identify CUDA compute capabilities for similarity tensor core support. The
+# resulting NVMOLKIT_CUDA_CC_* defines are exposed to first-party targets via
+# the nvmolkit_cuda_caps INTERFACE library so they don't leak into FetchContent
+# third-party translation units.
+add_library(nvmolkit_cuda_caps INTERFACE)
+
 if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
   # Write a small CUDA program to detect compute capability
   file(
@@ -109,7 +114,6 @@ if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
     RESULT_VARIABLE _build_result)
 
   if(_build_result EQUAL 0)
-    # Run the program to get the native compute capability
     execute_process(
       COMMAND "${CMAKE_BINARY_DIR}/detect_cuda_arch"
       OUTPUT_VARIABLE _native_cc
@@ -117,12 +121,13 @@ if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
   else()
     message(FATAL_ERROR "Failed to build detect_cuda_arch.cu")
   endif()
-  # _native_cc will be something like "86"
   foreach(cc IN ITEMS 80 86 89 90 100 120)
     if(_native_cc STREQUAL "${cc}")
-      add_definitions(-DNVMOLKIT_CUDA_CC_${cc}=1)
+      target_compile_definitions(nvmolkit_cuda_caps
+                                 INTERFACE NVMOLKIT_CUDA_CC_${cc}=1)
     else()
-      add_definitions(-DNVMOLKIT_CUDA_CC_${cc}=0)
+      target_compile_definitions(nvmolkit_cuda_caps
+                                 INTERFACE NVMOLKIT_CUDA_CC_${cc}=0)
     endif()
   endforeach()
 else()
@@ -130,9 +135,11 @@ else()
     string(REPLACE ";" " " _cuda_arch_str "${CMAKE_CUDA_ARCHITECTURES}")
     string(REGEX MATCH "(^| )${cc}(-real)?( |$)" _match "${_cuda_arch_str}")
     if(_match)
-      add_definitions(-DNVMOLKIT_CUDA_CC_${cc}=1)
+      target_compile_definitions(nvmolkit_cuda_caps
+                                 INTERFACE NVMOLKIT_CUDA_CC_${cc}=1)
     else()
-      add_definitions(-DNVMOLKIT_CUDA_CC_${cc}=0)
+      target_compile_definitions(nvmolkit_cuda_caps
+                                 INTERFACE NVMOLKIT_CUDA_CC_${cc}=0)
     endif()
   endforeach()
 endif()

--- a/cmake/device_compiler_flags.cmake
+++ b/cmake/device_compiler_flags.cmake
@@ -31,7 +31,7 @@ target_compile_options(
   nvmolkit_cuda_options
   INTERFACE
     $<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets;--default-stream=per-thread>
-    $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-G>
+    $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-g;-G>
     $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Release>>:--use_fast_math>
     $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:RelWithDebInfo>>:--use_fast_math;-lineinfo>
 )

--- a/cmake/device_compiler_flags.cmake
+++ b/cmake/device_compiler_flags.cmake
@@ -13,34 +13,25 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# General flags for CUDA compilation Build up all flags in a temporary variable
-# to avoid duplication on reconfigure
-set(NVMOLKIT_NVCC_ALL_FLAGS
-    "-Wno-deprecated-gpu-targets --default-stream per-thread")
+# CUDA half of nvmolkit_warnings (host target is created in
+# cmake/host_compiler_flags.cmake).
 if(NVMOLKIT_EXTRA_DEV_FLAGS)
-  string(APPEND NVMOLKIT_NVCC_ALL_FLAGS " --Werror all-warnings")
+  target_compile_options(
+    nvmolkit_warnings
+    INTERFACE
+      $<$<COMPILE_LANGUAGE:CUDA>:-Werror=all-warnings;-Xcompiler=-Werror,-Wall,-Wextra>
+  )
 endif()
 
-# Combine host flags (from host_compiler_flags.cmake) and device flags
-set(CMAKE_CUDA_FLAGS
-    "${NVMOLKIT_HOST_CUDA_FLAGS} ${NVMOLKIT_NVCC_ALL_FLAGS}"
-    CACHE STRING "All CUDA flags" FORCE)
-
-set(NVMOLKIT_DEBUG_FLAGS "-g -G")
-
-set(NVMOLKIT_RELWITHDEBINFO_FLAGS "-lineinfo --use_fast_math")
-
-set(NVMOLKIT_RELEASE_FLAGS "--use_fast_math")
-
-set(CMAKE_CUDA_FLAGS_DEBUG
-    ${NVMOLKIT_DEBUG_FLAGS}
-    CACHE STRING "Flags to CUDA compiler used during Debug builds" FORCE)
-
-set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO
-    ${NVMOLKIT_RELWITHDEBINFO_FLAGS}
-    CACHE STRING "Flags to CUDA compiler used during RelWithDebInfo builds"
-          FORCE)
-
-set(CMAKE_CUDA_FLAGS_RELEASE
-    ${NVMOLKIT_RELEASE_FLAGS}
-    CACHE STRING "Flags to CUDA compiler used during Release builds" FORCE)
+# Project-specific CUDA options. Per-config flags are layered on top of CMake's
+# defaults (-O3 -DNDEBUG, -O2 -g -DNDEBUG, -g) via generator expressions, rather
+# than overwriting CMAKE_CUDA_FLAGS_<CONFIG>.
+add_library(nvmolkit_cuda_options INTERFACE)
+target_compile_options(
+  nvmolkit_cuda_options
+  INTERFACE
+    $<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets;--default-stream=per-thread>
+    $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-G>
+    $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Release>>:--use_fast_math>
+    $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:RelWithDebInfo>>:--use_fast_math;-lineinfo>
+)

--- a/cmake/host_compiler_flags.cmake
+++ b/cmake/host_compiler_flags.cmake
@@ -13,23 +13,26 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-if(NVMOLKIT_EXTRA_DEV_FLAGS)
-  message(STATUS "Enabling extra development flags")
-  string(APPEND CMAKE_CXX_FLAGS " -Werror -Wall  -Wextra -Wno-sign-compare")
-  set(NVMOLKIT_HOST_CUDA_FLAGS " --compiler-options \"-Werror -Wall  -Wextra\"")
-else()
-  set(NVMOLKIT_HOST_CUDA_FLAGS "")
-endif()
+# Pre-cxx11 ABI must apply to every translation unit (including third-party
+# headers used at build time), so it stays as a global compile definition.
 if(NVMOLKIT_BUILD_AGAINST_PIP_RDKIT)
   message(STATUS "Using pre-cxx11 ABI")
   add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 endif()
 
-set(NVMOLKIT_RELEASE_FLAGS "-ffast-math -O3 -DNDEBUG")
+# Per-target host compile options. The CUDA half of nvmolkit_warnings is added
+# in cmake/device_compiler_flags.cmake.
+add_library(nvmolkit_warnings INTERFACE)
+if(NVMOLKIT_EXTRA_DEV_FLAGS)
+  message(STATUS "Enabling extra development flags")
+  target_compile_options(
+    nvmolkit_warnings
+    INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Werror;-Wall;-Wextra;-Wno-sign-compare>
+  )
+endif()
 
-set(CMAKE_C_FLAGS_RELEASE
-    ${NVMOLKIT_RELEASE_FLAGS}
-    CACHE STRING "Flags used during Release builds" FORCE)
-set(CMAKE_CXX_FLAGS_RELEASE
-    ${NVMOLKIT_RELEASE_FLAGS}
-    CACHE STRING "Flags used during Release builds" FORCE)
+# -ffast-math is a project preference for Release builds and intentionally stays
+# off third-party targets compiled via FetchContent.
+add_library(nvmolkit_release_opts INTERFACE)
+target_compile_options(nvmolkit_release_opts
+                       INTERFACE $<$<CONFIG:Release>:-ffast-math>)

--- a/cmake/host_compiler_flags.cmake
+++ b/cmake/host_compiler_flags.cmake
@@ -31,8 +31,12 @@ if(NVMOLKIT_EXTRA_DEV_FLAGS)
   )
 endif()
 
-# -ffast-math is a project preference for Release builds and intentionally stays
-# off third-party targets compiled via FetchContent.
+# -ffast-math is a project preference for optimized builds and intentionally
+# stays off third-party targets compiled via FetchContent. Host-only; the CUDA
+# equivalent (--use_fast_math) is added by nvmolkit_cuda_options.
 add_library(nvmolkit_release_opts INTERFACE)
-target_compile_options(nvmolkit_release_opts
-                       INTERFACE $<$<CONFIG:Release>:-ffast-math>)
+target_compile_options(
+  nvmolkit_release_opts
+  INTERFACE
+    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>>:-ffast-math>
+)

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -13,33 +13,45 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-set(NVMOLKIT_ASAN_FLAGS "-fsanitize=address -g -O0")
-# cmake-lint: disable=C0301
+# Sanitizers are driven by the NVMOLKIT_SANITIZER cache variable. For backwards
+# compatibility, a build type of asan / tsan / ubsan auto-selects the matching
+# sanitizer when NVMOLKIT_SANITIZER is unset.
+set(NVMOLKIT_SANITIZER
+    "none"
+    CACHE STRING "Active sanitizer (none, asan, tsan, ubsan)")
+set_property(CACHE NVMOLKIT_SANITIZER PROPERTY STRINGS none asan tsan ubsan)
+
+if(NVMOLKIT_SANITIZER STREQUAL "none" AND CMAKE_BUILD_TYPE)
+  string(TOLOWER "${CMAKE_BUILD_TYPE}" _nvmolkit_lc_build_type)
+  if(_nvmolkit_lc_build_type MATCHES "^(asan|tsan|ubsan)$")
+    set(NVMOLKIT_SANITIZER "${_nvmolkit_lc_build_type}")
+    message(
+      STATUS
+        "NVMOLKIT_SANITIZER not set; deriving '${NVMOLKIT_SANITIZER}' from CMAKE_BUILD_TYPE"
+    )
+  endif()
+endif()
+
 set(NVMOLKIT_CTEST_ASAN_ENV_VARS
     "ASAN_OPTIONS=protect_shadow_gap=0:report_globals=1:check_initialization_order=true:detect_stack_use_after_return=true:strict_string_checks=true"
-)
-set(CMAKE_C_FLAGS_ASAN
-    ${NVMOLKIT_ASAN_FLAGS}
-    CACHE STRING "Flags used during ASAN builds" FORCE)
-set(CMAKE_CXX_FLAGS_ASAN
-    ${NVMOLKIT_ASAN_FLAGS}
-    CACHE STRING "Flags used during ASAN builds" FORCE)
+) # cmake-lint: disable=C0301
 
-set(NVMOLKIT_TSAN_FLAGS "-fsanitize=thread -g -O1")
-set(CMAKE_C_FLAGS_TSAN
-    ${NVMOLKIT_TSAN_FLAGS}
-    CACHE STRING "Flags used during TSAN builds" FORCE)
-set(CMAKE_CXX_FLAGS_TSAN
-    ${NVMOLKIT_TSAN_FLAGS}
-    CACHE STRING "Flags used during TSAN builds" FORCE)
-
-set(NVMOLKIT_UBSAN_FLAGS
-    "-fsanitize=undefined,float-divide-by-zero,implicit-conversion,local-bounds,nullability -g -O1" # cmake-lint:
-    # disable=C0301
-)
-set(CMAKE_C_FLAGS_UBSAN
-    ${NVMOLKIT_UBSAN_FLAGS}
-    CACHE STRING "Flags used during UBSAN builds" FORCE)
-set(CMAKE_CXX_FLAGS_UBSAN
-    ${NVMOLKIT_UBSAN_FLAGS}
-    CACHE STRING "Flags used during UBSAN builds" FORCE)
+add_library(nvmolkit_sanitizers INTERFACE)
+if(NVMOLKIT_SANITIZER STREQUAL "asan")
+  target_compile_options(nvmolkit_sanitizers INTERFACE -fsanitize=address -g
+                                                       -O0)
+  target_link_options(nvmolkit_sanitizers INTERFACE -fsanitize=address)
+elseif(NVMOLKIT_SANITIZER STREQUAL "tsan")
+  target_compile_options(nvmolkit_sanitizers INTERFACE -fsanitize=thread -g -O1)
+  target_link_options(nvmolkit_sanitizers INTERFACE -fsanitize=thread)
+elseif(NVMOLKIT_SANITIZER STREQUAL "ubsan")
+  set(_nvmolkit_ubsan_checks
+      "undefined,float-divide-by-zero,implicit-conversion,local-bounds,nullability"
+  ) # cmake-lint: disable=C0301
+  target_compile_options(nvmolkit_sanitizers
+                         INTERFACE -fsanitize=${_nvmolkit_ubsan_checks} -g -O1)
+  target_link_options(nvmolkit_sanitizers INTERFACE
+                      -fsanitize=${_nvmolkit_ubsan_checks})
+elseif(NOT NVMOLKIT_SANITIZER STREQUAL "none")
+  message(FATAL_ERROR "Unknown NVMOLKIT_SANITIZER value: ${NVMOLKIT_SANITIZER}")
+endif()

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -33,8 +33,11 @@ if(NVMOLKIT_SANITIZER STREQUAL "none" AND CMAKE_BUILD_TYPE)
 endif()
 
 set(NVMOLKIT_CTEST_ASAN_ENV_VARS
-    "ASAN_OPTIONS=protect_shadow_gap=0:report_globals=1:check_initialization_order=true:detect_stack_use_after_return=true:strict_string_checks=true"
-) # cmake-lint: disable=C0301
+    "ASAN_OPTIONS=protect_shadow_gap=0" ":report_globals=1"
+    ":check_initialization_order=true" ":detect_stack_use_after_return=true"
+    ":strict_string_checks=true")
+string(REPLACE ";" "" NVMOLKIT_CTEST_ASAN_ENV_VARS
+               "${NVMOLKIT_CTEST_ASAN_ENV_VARS}")
 
 add_library(nvmolkit_sanitizers INTERFACE)
 if(NVMOLKIT_SANITIZER STREQUAL "asan")

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -32,12 +32,14 @@ if(NVMOLKIT_SANITIZER STREQUAL "none" AND CMAKE_BUILD_TYPE)
   endif()
 endif()
 
-set(NVMOLKIT_CTEST_ASAN_ENV_VARS
-    "ASAN_OPTIONS=protect_shadow_gap=0" ":report_globals=1"
-    ":check_initialization_order=true" ":detect_stack_use_after_return=true"
-    ":strict_string_checks=true")
-string(REPLACE ";" "" NVMOLKIT_CTEST_ASAN_ENV_VARS
-               "${NVMOLKIT_CTEST_ASAN_ENV_VARS}")
+# cmake-format: off
+string(CONCAT NVMOLKIT_CTEST_ASAN_ENV_VARS
+       "ASAN_OPTIONS=protect_shadow_gap=0"
+       ":report_globals=1"
+       ":check_initialization_order=true"
+       ":detect_stack_use_after_return=true"
+       ":strict_string_checks=true")
+# cmake-format: on
 
 add_library(nvmolkit_sanitizers INTERFACE)
 if(NVMOLKIT_SANITIZER STREQUAL "asan")


### PR DESCRIPTION
Gets rid of `add_definitions` and friends, which are global and would propagate to an users (torch does this with its c++ flags and it's horribly obnoxious)