### PR TITLE
[Autotune PR 1/5] Add configuration serialization support and prep for autotune support

### DIFF
--- a/nvmolkit/substructure.py
+++ b/nvmolkit/substructure.py
@@ -138,6 +138,33 @@ class SubstructSearchConfig:
         """Internal: return the underlying native config object."""
         return self._native
 
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable dictionary of this object's fields."""
+        return {
+            "batchSize": self.batchSize,
+            "workerThreads": self.workerThreads,
+            "preprocessingThreads": self.preprocessingThreads,
+            "maxMatches": self.maxMatches,
+            "uniquify": self.uniquify,
+            "gpuIds": list(self.gpuIds),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SubstructSearchConfig":
+        """Create a :class:`SubstructSearchConfig` from a dictionary produced by :meth:`to_dict`."""
+        known = {"batchSize", "workerThreads", "preprocessingThreads", "maxMatches", "uniquify", "gpuIds"}
+        unknown = set(data) - known
+        if unknown:
+            raise KeyError(f"Unknown SubstructSearchConfig keys: {sorted(unknown)}")
+        return cls(
+            batchSize=data.get("batchSize", 1024),
+            workerThreads=data.get("workerThreads", -1),
+            preprocessingThreads=data.get("preprocessingThreads", -1),
+            maxMatches=data.get("maxMatches", 0),
+            uniquify=data.get("uniquify", False),
+            gpuIds=data.get("gpuIds"),
+        )
+
 
 @dataclass(frozen=True)
 class SubstructMatchResults:

--- a/nvmolkit/substructure.py
+++ b/nvmolkit/substructure.py
@@ -30,7 +30,7 @@ Execution can be tuned with :class:`SubstructSearchConfig`.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Any, Sequence
 
 import numpy as np
 from rdkit.Chem import Mol
@@ -138,7 +138,7 @@ class SubstructSearchConfig:
         """Internal: return the underlying native config object."""
         return self._native
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable dictionary of this object's fields."""
         return {
             "batchSize": self.batchSize,
@@ -150,20 +150,13 @@ class SubstructSearchConfig:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> "SubstructSearchConfig":
+    def from_dict(cls, data: dict[str, Any]) -> "SubstructSearchConfig":
         """Create a :class:`SubstructSearchConfig` from a dictionary produced by :meth:`to_dict`."""
         known = {"batchSize", "workerThreads", "preprocessingThreads", "maxMatches", "uniquify", "gpuIds"}
         unknown = set(data) - known
         if unknown:
-            raise KeyError(f"Unknown SubstructSearchConfig keys: {sorted(unknown)}")
-        return cls(
-            batchSize=data.get("batchSize", 1024),
-            workerThreads=data.get("workerThreads", -1),
-            preprocessingThreads=data.get("preprocessingThreads", -1),
-            maxMatches=data.get("maxMatches", 0),
-            uniquify=data.get("uniquify", False),
-            gpuIds=data.get("gpuIds"),
-        )
+            raise ValueError(f"Unknown SubstructSearchConfig keys: {sorted(unknown)}")
+        return cls(**{key: data[key] for key in known if key in data})
 
 
 @dataclass(frozen=True)

--- a/nvmolkit/types.py
+++ b/nvmolkit/types.py
@@ -117,13 +117,8 @@ class HardwareOptions:
         known = {"preprocessingThreads", "batchSize", "batchesPerGpu", "gpuIds"}
         unknown = set(data) - known
         if unknown:
-            raise KeyError(f"Unknown HardwareOptions keys: {sorted(unknown)}")
-        return cls(
-            preprocessingThreads=data.get("preprocessingThreads", -1),
-            batchSize=data.get("batchSize", -1),
-            batchesPerGpu=data.get("batchesPerGpu", -1),
-            gpuIds=data.get("gpuIds"),
-        )
+            raise ValueError(f"Unknown HardwareOptions keys: {sorted(unknown)}")
+        return cls(**{key: data[key] for key in known if key in data})
 
 
 class AsyncGpuResult:

--- a/nvmolkit/types.py
+++ b/nvmolkit/types.py
@@ -16,7 +16,7 @@
 """Types facilitating GPU-accelerated operations."""
 
 import torch
-from typing import Iterable, List
+from typing import Any, Iterable, List
 
 
 from nvmolkit import _embedMolecules  # type: ignore
@@ -93,6 +93,37 @@ class HardwareOptions:
     def _as_native(self):
         """Internal: return the underlying BatchHardwareOptions object."""
         return self._native
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dictionary of this object's fields.
+
+        The returned dictionary can be persisted with :func:`json.dump` and
+        round-tripped through :meth:`from_dict`.
+        """
+        return {
+            "preprocessingThreads": self.preprocessingThreads,
+            "batchSize": self.batchSize,
+            "batchesPerGpu": self.batchesPerGpu,
+            "gpuIds": list(self.gpuIds),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "HardwareOptions":
+        """Create a :class:`HardwareOptions` from a dictionary produced by :meth:`to_dict`.
+
+        Unknown keys are rejected so callers catch typos early. Missing keys
+        fall back to the constructor defaults.
+        """
+        known = {"preprocessingThreads", "batchSize", "batchesPerGpu", "gpuIds"}
+        unknown = set(data) - known
+        if unknown:
+            raise KeyError(f"Unknown HardwareOptions keys: {sorted(unknown)}")
+        return cls(
+            preprocessingThreads=data.get("preprocessingThreads", -1),
+            batchSize=data.get("batchSize", -1),
+            batchesPerGpu=data.get("batchesPerGpu", -1),
+            gpuIds=data.get("gpuIds"),
+        )
 
 
 class AsyncGpuResult:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ docs = [
     "myst-parser",
     "jupyter-sphinx",
 ]
+autotune = [
+    "optuna",
+]
 
 [tool.pytest.ini_options]
 log_cli = true

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@
 
 import os
 
+from setuptools import find_packages
 from skbuild import setup
 
 pyroot = os.getenv("CONDA_PREFIX")
@@ -58,7 +59,7 @@ if __name__ == "__main__":
             # "-DBoost_NO_BOOST_CMAKE=TRUE"
         ]
         + cmake_extra_args,
-        packages=["nvmolkit"],
+        packages=find_packages(include=["nvmolkit", "nvmolkit.*"], exclude=["nvmolkit.tests*"]),
         exclude_package_data={"nvmolkit": ["tests/*", "*.cpp"]},
         package_data={"nvmolkit": ["**/*.csv"]},
         cmake_install_dir="nvmolkit",


### PR DESCRIPTION
Add to_dict() and from_dict() methods to HardwareOptions and SubstructSearchConfig to enable JSON serialization. Update package discovery to find nvmolkit submodules. Add autotune optional extra to pyproject.toml.

These changes provide the foundation for configuration persistence and will be used by the autotune module.