### PR TITLE
Add shared benchmark utilities module

### DIFF
--- a/benchmarks/bench_utils/__init__.py
+++ b/benchmarks/bench_utils/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared utilities for nvMolKit benchmarks.
+
+Re-exports timing primitives, file loaders, and molecule preparation helpers
+so individual bench scripts can ``from bench_utils import time_it, load_smiles``.
+"""
+
+from bench_utils.loaders import load_pickle, load_sdf, load_smarts, load_smiles
+from bench_utils.molprep import clone_mols_with_conformers, prep_mols
+from bench_utils.timing import TimingResult, time_it
+
+__all__ = [
+    "TimingResult",
+    "clone_mols_with_conformers",
+    "load_pickle",
+    "load_sdf",
+    "load_smarts",
+    "load_smiles",
+    "prep_mols",
+    "time_it",
+]

--- a/benchmarks/bench_utils/loaders.py
+++ b/benchmarks/bench_utils/loaders.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared molecule and pattern loaders for nvMolKit benchmarks.
+
+All loaders accept ``max_count`` to cap the workload, with a uniform random
+sample drawn (via reservoir sampling for streaming inputs) when the source
+contains more entries than requested.
+"""
+
+import pickle
+import random
+from functools import partial
+from typing import Iterator
+
+from rdkit import Chem, RDLogger
+from tqdm.contrib.concurrent import process_map
+
+
+def _mol_from_binary(binary_mol: bytes) -> Chem.Mol:
+    return Chem.Mol(binary_mol)
+
+
+def load_pickle(filepath: str, max_count: int = 0, seed: int | None = None) -> list[Chem.Mol]:
+    """Load molecules from a pickle file containing a list of RDKit binary molecules.
+
+    Args:
+        filepath: Path to the pickle file. Must contain a list of ``bytes``
+            payloads as produced by :meth:`Chem.Mol.ToBinary`.
+        max_count: When positive and the source has more entries, draw a
+            uniform random sample of this size before unpickling.
+        seed: Optional seed for the sampling RNG.
+
+    Returns:
+        List of parsed RDKit molecules.
+    """
+    with open(filepath, "rb") as fh:
+        binary_mols = pickle.load(fh)
+    if max_count > 0 and len(binary_mols) > max_count:
+        binary_mols = random.Random(seed).sample(binary_mols, max_count)
+    mols = process_map(
+        _mol_from_binary,
+        binary_mols,
+        desc="Unpickling molecules",
+        chunksize=1000,
+    )
+    print(f"  Loaded {len(mols)} molecules from {filepath}")
+    return mols
+
+
+def _parse_smiles(smi: str, sanitize: bool) -> Chem.Mol | None:
+    return Chem.MolFromSmiles(smi, sanitize=sanitize)
+
+
+def _iter_smiles_tokens(filepath: str, sanitize: bool) -> Iterator[str]:
+    """Yield SMILES tokens from a file, dropping a parse-failing first line as a header."""
+    with open(filepath, "r") as fh:
+        first_data_seen = False
+        for line in fh:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            smi = stripped.split()[0]
+            if not first_data_seen:
+                first_data_seen = True
+                RDLogger.DisableLog("rdApp.*")
+                mol = Chem.MolFromSmiles(smi, sanitize=sanitize)
+                RDLogger.EnableLog("rdApp.*")
+                if mol is None:
+                    continue
+            yield smi
+
+
+def load_smiles(
+    filepath: str,
+    max_count: int = 0,
+    sanitize: bool = True,
+    seed: int | None = None,
+) -> list[Chem.Mol]:
+    """Load and parse molecules from a SMILES file.
+
+    Reservoir-samples a uniform subset when ``max_count > 0`` so the input file
+    does not have to fit in memory and only the sampled SMILES are parsed. A
+    10% buffer is read past ``max_count`` to absorb parse failures, after which
+    the result is trimmed back to ``max_count``.
+    """
+    read_limit = int(max_count * 1.1) if max_count > 0 else 0
+
+    if read_limit > 0:
+        rng = random.Random(seed)
+        reservoir: list[str] = []
+        for index, smi in enumerate(_iter_smiles_tokens(filepath, sanitize)):
+            if index < read_limit:
+                reservoir.append(smi)
+            else:
+                replace_index = rng.randint(0, index)
+                if replace_index < read_limit:
+                    reservoir[replace_index] = smi
+        smiles_list = reservoir
+    else:
+        smiles_list = list(_iter_smiles_tokens(filepath, sanitize))
+
+    mols: list[Chem.Mol] = []
+    if smiles_list:
+        parse_func = partial(_parse_smiles, sanitize=sanitize)
+        parsed = process_map(parse_func, smiles_list, desc="Parsing molecules", chunksize=1000)
+        parse_failures = 0
+        for mol in parsed:
+            if mol is None:
+                parse_failures += 1
+            else:
+                mols.append(mol)
+        if parse_failures > 0:
+            print(f"    ({parse_failures} parse failures)")
+
+    if max_count > 0 and len(mols) > max_count:
+        mols = mols[:max_count]
+
+    print(f"  Loaded {len(mols)} molecules from {filepath}")
+    return mols
+
+
+def load_smarts(filepath: str, max_count: int = 0) -> tuple[list[Chem.Mol], list[str]]:
+    """Load and parse query patterns from a SMARTS file.
+
+    Returns:
+        ``(queries, smarts_strings)`` parallel lists.
+    """
+    queries: list[Chem.Mol] = []
+    smarts_list: list[str] = []
+    parse_failures = 0
+
+    with open(filepath, "r") as fh:
+        for line in fh:
+            if max_count > 0 and len(queries) >= max_count:
+                break
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            smarts = stripped.split()[0]
+            query = Chem.MolFromSmarts(smarts)
+            if query is None:
+                parse_failures += 1
+                continue
+            queries.append(query)
+            smarts_list.append(smarts)
+
+    print(f"  Loaded {len(queries)} SMARTS patterns from {filepath}")
+    if parse_failures > 0:
+        print(f"    ({parse_failures} parse failures)")
+    return queries, smarts_list
+
+
+def load_sdf(
+    filepath: str,
+    max_count: int = 0,
+    seed: int | None = None,
+    removeHs: bool = False,
+    sanitize: bool = True,
+) -> list[Chem.Mol]:
+    """Load molecules from an SDF file with optional reservoir sampling."""
+    supplier = Chem.SDMolSupplier(filepath, removeHs=removeHs, sanitize=sanitize)
+    read_limit = int(max_count * 1.1) if max_count > 0 else 0
+
+    parse_failures = 0
+    if read_limit > 0:
+        rng = random.Random(seed)
+        reservoir: list[Chem.Mol] = []
+        index = 0
+        for mol in supplier:
+            if mol is None:
+                parse_failures += 1
+                continue
+            if index < read_limit:
+                reservoir.append(mol)
+            else:
+                replace_index = rng.randint(0, index)
+                if replace_index < read_limit:
+                    reservoir[replace_index] = mol
+            index += 1
+        mols = reservoir
+    else:
+        mols = []
+        for mol in supplier:
+            if mol is None:
+                parse_failures += 1
+                continue
+            mols.append(mol)
+
+    if max_count > 0 and len(mols) > max_count:
+        mols = mols[:max_count]
+
+    if parse_failures > 0:
+        print(f"    ({parse_failures} parse failures)")
+    print(f"  Loaded {len(mols)} molecules from {filepath}")
+    return mols

--- a/benchmarks/bench_utils/loaders.py
+++ b/benchmarks/bench_utils/loaders.py
@@ -15,9 +15,9 @@
 
 """Shared molecule and pattern loaders for nvMolKit benchmarks.
 
-All loaders accept ``max_count`` to cap the workload, with a uniform random
-sample drawn (via reservoir sampling for streaming inputs) when the source
-contains more entries than requested.
+Molecule loaders accept ``max_count`` to cap the workload, with a uniform
+random sample drawn (via reservoir sampling for streaming inputs) when the
+source contains more entries than requested.
 """
 
 import pickle
@@ -97,9 +97,9 @@ def load_smiles(
     the result is trimmed back to ``max_count``.
     """
     read_limit = int(max_count * 1.1) if max_count > 0 else 0
+    rng = random.Random(seed)
 
     if read_limit > 0:
-        rng = random.Random(seed)
         reservoir: list[str] = []
         for index, smi in enumerate(_iter_smiles_tokens(filepath, sanitize)):
             if index < read_limit:
@@ -126,14 +126,14 @@ def load_smiles(
             print(f"    ({parse_failures} parse failures)")
 
     if max_count > 0 and len(mols) > max_count:
-        mols = mols[:max_count]
+        mols = rng.sample(mols, max_count)
 
     print(f"  Loaded {len(mols)} molecules from {filepath}")
     return mols
 
 
-def load_smarts(filepath: str, max_count: int = 0) -> tuple[list[Chem.Mol], list[str]]:
-    """Load and parse query patterns from a SMARTS file.
+def load_smarts(filepath: str) -> tuple[list[Chem.Mol], list[str]]:
+    """Load and parse every query pattern from a SMARTS file.
 
     Returns:
         ``(queries, smarts_strings)`` parallel lists.
@@ -144,8 +144,6 @@ def load_smarts(filepath: str, max_count: int = 0) -> tuple[list[Chem.Mol], list
 
     with open(filepath, "r") as fh:
         for line in fh:
-            if max_count > 0 and len(queries) >= max_count:
-                break
             stripped = line.strip()
             if not stripped or stripped.startswith("#"):
                 continue
@@ -173,10 +171,10 @@ def load_sdf(
     """Load molecules from an SDF file with optional reservoir sampling."""
     supplier = Chem.SDMolSupplier(filepath, removeHs=removeHs, sanitize=sanitize)
     read_limit = int(max_count * 1.1) if max_count > 0 else 0
+    rng = random.Random(seed)
 
     parse_failures = 0
     if read_limit > 0:
-        rng = random.Random(seed)
         reservoir: list[Chem.Mol] = []
         index = 0
         for mol in supplier:
@@ -200,7 +198,7 @@ def load_sdf(
             mols.append(mol)
 
     if max_count > 0 and len(mols) > max_count:
-        mols = mols[:max_count]
+        mols = rng.sample(mols, max_count)
 
     if parse_failures > 0:
         print(f"    ({parse_failures} parse failures)")

--- a/benchmarks/bench_utils/molprep.py
+++ b/benchmarks/bench_utils/molprep.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Molecule preparation helpers shared across nvMolKit benchmarks."""
+
+from rdkit import Chem
+
+
+def prep_mols(
+    mols: list[Chem.Mol],
+    *,
+    add_hs: bool = True,
+    sanitize: bool = True,
+    clear_conformers: bool = True,
+) -> list[Chem.Mol]:
+    """Return new molecule copies prepared for conformer generation.
+
+    For each input:
+        - skip ``None`` entries,
+        - optionally add explicit hydrogens,
+        - optionally sanitize (no-op when already sanitized),
+        - optionally drop existing conformers so timed runs start clean.
+
+    Molecules that fail any step are dropped and a count is printed.
+    """
+    prepped: list[Chem.Mol] = []
+    drop_count = 0
+    for mol in mols:
+        if mol is None:
+            drop_count += 1
+            continue
+        try:
+            current = Chem.AddHs(mol) if add_hs else Chem.Mol(mol)
+            if sanitize:
+                Chem.SanitizeMol(current)
+            if clear_conformers:
+                current.RemoveAllConformers()
+            prepped.append(current)
+        except Exception:
+            drop_count += 1
+    if drop_count > 0:
+        print(f"  Dropped {drop_count} molecules during prep (None or sanitize failure)")
+    return prepped
+
+
+def clone_mols_with_conformers(mols: list[Chem.Mol]) -> list[Chem.RWMol]:
+    """Deep-copy molecules including their conformers.
+
+    Useful for benches whose timed routines mutate conformer state in place
+    (such as ETKDG embedding or FF optimization), so each iteration sees a
+    pristine input.
+    """
+    return [Chem.RWMol(mol) for mol in mols]

--- a/benchmarks/bench_utils/timing.py
+++ b/benchmarks/bench_utils/timing.py
@@ -63,6 +63,9 @@ def time_it(func: Callable, runs: int = 3, warmups: int = 1, gpu_sync: bool = Fa
     Returns:
         A TimingResult with per-iteration times in milliseconds.
     """
+    if runs <= 0:
+        raise ValueError(f"runs must be positive, got {runs}")
+
     if gpu_sync:
         import torch
 
@@ -75,9 +78,6 @@ def time_it(func: Callable, runs: int = 3, warmups: int = 1, gpu_sync: bool = Fa
     for _ in range(warmups):
         func()
         sync()
-
-    if runs <= 0:
-        raise ValueError(f"runs must be positive, got {runs}")
 
     times_ms = []
     for _ in range(runs):

--- a/benchmarks/bench_utils/timing.py
+++ b/benchmarks/bench_utils/timing.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared timing utilities for nvMolKit benchmarks."""
+
+import statistics
+import time
+from dataclasses import dataclass, field
+from typing import Callable
+
+
+@dataclass
+class TimingResult:
+    """Holds timing results from a benchmark run."""
+
+    times_ms: list[float] = field(default_factory=list)
+
+    @property
+    def median_ms(self) -> float:
+        """Median time in milliseconds."""
+        return statistics.median(self.times_ms)
+
+    @property
+    def mean_ms(self) -> float:
+        """Mean time in milliseconds."""
+        return statistics.mean(self.times_ms)
+
+    @property
+    def std_ms(self) -> float:
+        """Sample standard deviation in milliseconds."""
+        if len(self.times_ms) < 2:
+            return 0.0
+        return statistics.stdev(self.times_ms)
+
+    @property
+    def median_s(self) -> float:
+        """Median time in seconds."""
+        return self.median_ms / 1000.0
+
+
+def time_it(func: Callable, runs: int = 3, warmups: int = 1, gpu_sync: bool = False) -> TimingResult:
+    """Time a callable with warmup iterations and optional CUDA synchronization.
+
+    Args:
+        func: Zero-argument callable to benchmark.
+        runs: Number of timed iterations.
+        warmups: Number of untimed warmup iterations.
+        gpu_sync: If True, call torch.cuda.synchronize() before and after each
+                  timed iteration to ensure GPU work is included in the measurement.
+
+    Returns:
+        A TimingResult with per-iteration times in milliseconds.
+    """
+    if gpu_sync:
+        import torch
+
+        sync = torch.cuda.synchronize
+    else:
+
+        def sync() -> None:
+            pass
+
+    for _ in range(warmups):
+        func()
+        sync()
+
+    if runs <= 0:
+        raise ValueError(f"runs must be positive, got {runs}")
+
+    times_ms = []
+    for _ in range(runs):
+        sync()
+        t0 = time.perf_counter()
+        func()
+        sync()
+        t1 = time.perf_counter()
+        times_ms.append((t1 - t0) * 1000.0)
+
+    return TimingResult(times_ms=times_ms)


### PR DESCRIPTION
Create benchmarks/bench_utils with:
- timing.py: Timing primitives for benchmarking
- loaders.py: Molecule/pattern loaders with reservoir sampling
- molprep.py: Molecule preparation helpers

Downstream changes will refactor all of our python APIs to use these.