### PR TITLE
Wire autotune into ETKDG, FF-optimize, and substruct benchmarks

### DIFF
--- a/benchmarks/etkdg_bench.py
+++ b/benchmarks/etkdg_bench.py
@@ -27,6 +27,7 @@ Usage:
 """
 
 import argparse
+import random
 import statistics
 import sys
 
@@ -40,8 +41,12 @@ from bench_utils import (
     prep_mols,
     time_it,
 )
+from nvmolkit import autotune as nv_autotune
+from nvmolkit.types import HardwareOptions
 from rdkit import Chem
 from rdkit.Chem import AllChem, rdDistGeom
+
+OPTUNA_AVAILABLE = nv_autotune.is_available()
 
 
 def _conformer_count(mols: list[Chem.Mol]) -> int:
@@ -162,8 +167,6 @@ def _build_hardware_options(
     prep_threads: int,
     num_gpus: int,
 ):
-    from nvmolkit.types import HardwareOptions
-
     return HardwareOptions(
         preprocessingThreads=prep_threads,
         batchSize=batch_size,
@@ -227,6 +230,57 @@ def main() -> None:
     parser.add_argument("--num_gpus", type=int, default=1, help="Number of GPUs to use (default: 1)")
 
     parser.add_argument(
+        "--autotune",
+        action="store_true",
+        help=(
+            "Tune nvmolkit HardwareOptions (batchSize/batchesPerGpu/preprocessingThreads) "
+            "before timing. Requires the [autotune] extra (optuna)."
+        ),
+    )
+    parser.add_argument(
+        "--autotune_save",
+        type=str,
+        default=None,
+        help="Path to save the tuned HardwareOptions as JSON (only with --autotune)",
+    )
+    parser.add_argument(
+        "--autotune_load",
+        type=str,
+        default=None,
+        help=(
+            "Path to a previously-saved HardwareOptions JSON. "
+            "Overrides --batch_size/--batches_per_gpu/--prep_threads (and --num_gpus if gpuIds present in the file)."
+        ),
+    )
+    parser.add_argument(
+        "--autotune_trials",
+        type=int,
+        default=20,
+        help="Number of Optuna trials when --autotune is set (default: 20)",
+    )
+    parser.add_argument(
+        "--autotune_time_budget",
+        type=float,
+        default=10.0,
+        help="Target wall-clock seconds per Optuna trial (default: 10.0)",
+    )
+    parser.add_argument(
+        "--autotune_calibration_size",
+        type=int,
+        default=0,
+        help=(
+            "Number of molecules to use per autotune trial. "
+            "0 = auto-subsample (~10%% of the workload, capped at 2000). Default: 0"
+        ),
+    )
+    parser.add_argument(
+        "--autotune_seed",
+        type=int,
+        default=42,
+        help="Seed for the Optuna sampler (default: 42)",
+    )
+
+    parser.add_argument(
         "--validate", action="store_true", dest="validate", help="Compute MMFF energy diffs vs RDKit (default)"
     )
     parser.add_argument("--no_validate", action="store_false", dest="validate", help="Skip energy validation")
@@ -248,6 +302,15 @@ def main() -> None:
         sys.exit(1)
     if args.no_nvmolkit and args.no_rdkit:
         print("Error: cannot disable both nvmolkit and RDKit")
+        sys.exit(1)
+    if args.autotune and args.no_nvmolkit:
+        print("Error: --autotune requires nvmolkit; remove --no_nvmolkit")
+        sys.exit(1)
+    if args.autotune_save and not args.autotune:
+        print("Error: --autotune_save requires --autotune")
+        sys.exit(1)
+    if args.autotune and args.autotune_load:
+        print("Error: --autotune and --autotune_load are mutually exclusive")
         sys.exit(1)
     input_file = input_paths[0]
     if args.smiles:
@@ -307,11 +370,69 @@ def main() -> None:
         try:
             import torch
 
-            from nvmolkit.types import HardwareOptions
+            gpu_ids = list(range(args.num_gpus))
+            if args.autotune_load:
+                print(f"\nLoading tuned HardwareOptions from {args.autotune_load}...")
+                loaded = nv_autotune.load(args.autotune_load)
+                if not isinstance(loaded, HardwareOptions):
+                    print(f"Error: {args.autotune_load} contains {type(loaded).__name__}, expected HardwareOptions")
+                    sys.exit(1)
+                hardware_options = loaded
+                if not hardware_options.gpuIds:
+                    hardware_options.gpuIds = gpu_ids
+                config_source = "loaded"
+                print(
+                    f"  Loaded: batchSize={hardware_options.batchSize}, "
+                    f"batchesPerGpu={hardware_options.batchesPerGpu}, "
+                    f"preprocessingThreads={hardware_options.preprocessingThreads}, "
+                    f"gpuIds={list(hardware_options.gpuIds) if hardware_options.gpuIds else []}"
+                )
+            elif args.autotune:
+                if not OPTUNA_AVAILABLE:
+                    print(
+                        "Error: --autotune requires the optional 'optuna' dependency. "
+                        "Install with `pip install nvmolkit[autotune]` or `conda install -c conda-forge optuna`."
+                    )
+                    sys.exit(1)
+                print(
+                    f"\nAutotuning HardwareOptions (n_trials={args.autotune_trials}, "
+                    f"per-trial target={args.autotune_time_budget:.1f}s)..."
+                )
+                explicit_calibration = None
+                if args.autotune_calibration_size > 0:
+                    rng = random.Random(args.autotune_seed)
+                    size = min(args.autotune_calibration_size, len(mols))
+                    explicit_calibration = rng.sample(range(len(mols)), size)
+                tune_result = nv_autotune.tune_embed_molecules(
+                    mols,
+                    params,
+                    confsPerMolecule=args.confs_per_mol,
+                    maxIterations=args.max_iterations,
+                    gpuIds=gpu_ids,
+                    n_trials=args.autotune_trials,
+                    target_seconds_per_trial=args.autotune_time_budget,
+                    calibration_set=explicit_calibration,
+                    seed=args.autotune_seed,
+                    verbose=True,
+                )
+                hardware_options = tune_result.best_config
+                config_source = "autotuned"
+                print(
+                    f"  Best: batchSize={hardware_options.batchSize}, "
+                    f"batchesPerGpu={hardware_options.batchesPerGpu}, "
+                    f"preprocessingThreads={hardware_options.preprocessingThreads} "
+                    f"(throughput={tune_result.best_throughput:.2f} confs/s, "
+                    f"trials_run={tune_result.n_trials_run}, "
+                    f"calibration_size={tune_result.calibration_size})"
+                )
+                if args.autotune_save:
+                    nv_autotune.save(hardware_options, args.autotune_save)
+                    print(f"  Saved tuned config to {args.autotune_save}")
+            else:
+                hardware_options = _build_hardware_options(
+                    args.batch_size, args.batches_per_gpu, args.prep_threads, args.num_gpus
+                )
 
-            hardware_options = _build_hardware_options(
-                args.batch_size, args.batches_per_gpu, args.prep_threads, args.num_gpus
-            )
             applied_batch_size = int(hardware_options.batchSize)
             applied_batches_per_gpu = int(hardware_options.batchesPerGpu)
             applied_prep_threads = int(hardware_options.preprocessingThreads)

--- a/benchmarks/ff_optimize_bench.py
+++ b/benchmarks/ff_optimize_bench.py
@@ -31,6 +31,7 @@ Usage:
 import argparse
 import gc
 import math
+import random
 import statistics
 import sys
 
@@ -44,9 +45,12 @@ from bench_utils import (
     prep_mols,
     time_it,
 )
+from nvmolkit import autotune as nv_autotune
 from nvmolkit.types import HardwareOptions
 from rdkit import Chem
 from rdkit.Chem import AllChem, rdDistGeom
+
+OPTUNA_AVAILABLE = nv_autotune.is_available()
 
 
 def _embed_conformers(mols: list[Chem.Mol], confs_per_mol: int, seed: int) -> list[Chem.Mol]:
@@ -210,7 +214,7 @@ def _build_hardware_options(
 
 CSV_HEADER = (
     "method,ff,input_file,input_type,num_mols,confs_per_mol,max_iters,"
-    "batch_size,batches_per_gpu,prep_threads,num_gpus,"
+    "batch_size,batches_per_gpu,prep_threads,num_gpus,nvmolkit_config_source,"
     "rdkit_threads,time_ms,std_ms,energies_compared,mean_abs_energy_diff,max_abs_energy_diff"
 )
 
@@ -264,6 +268,58 @@ def main() -> None:
     parser.add_argument("--num_gpus", type=int, default=1, help="Number of GPUs to use (default: 1)")
 
     parser.add_argument(
+        "--autotune",
+        action="store_true",
+        help=(
+            "Tune nvmolkit HardwareOptions (batchSize/batchesPerGpu) before timing using "
+            "tune_mmff_optimize or tune_uff_optimize (depending on --ff). Requires the "
+            "[autotune] extra (optuna)."
+        ),
+    )
+    parser.add_argument(
+        "--autotune_save",
+        type=str,
+        default=None,
+        help="Path to save the tuned HardwareOptions as JSON (only with --autotune)",
+    )
+    parser.add_argument(
+        "--autotune_load",
+        type=str,
+        default=None,
+        help=(
+            "Path to a previously-saved HardwareOptions JSON. "
+            "Overrides --batch_size/--batches_per_gpu/--prep_threads (and --num_gpus if gpuIds present in the file)."
+        ),
+    )
+    parser.add_argument(
+        "--autotune_trials",
+        type=int,
+        default=20,
+        help="Number of Optuna trials when --autotune is set (default: 20)",
+    )
+    parser.add_argument(
+        "--autotune_time_budget",
+        type=float,
+        default=10.0,
+        help="Target wall-clock seconds per Optuna trial (default: 10.0)",
+    )
+    parser.add_argument(
+        "--autotune_calibration_size",
+        type=int,
+        default=0,
+        help=(
+            "Number of molecules to use per autotune trial. "
+            "0 = auto-subsample (~10%% of the workload, capped at 2000). Default: 0"
+        ),
+    )
+    parser.add_argument(
+        "--autotune_seed",
+        type=int,
+        default=42,
+        help="Seed for the Optuna sampler (default: 42)",
+    )
+
+    parser.add_argument(
         "--validate", action="store_true", dest="validate", help="Compute absolute energy diffs vs RDKit (default)"
     )
     parser.add_argument("--no_validate", action="store_false", dest="validate", help="Skip energy validation")
@@ -285,6 +341,15 @@ def main() -> None:
         sys.exit(1)
     if args.no_nvmolkit and args.no_rdkit:
         print("Error: cannot disable both nvmolkit and RDKit")
+        sys.exit(1)
+    if args.autotune and args.no_nvmolkit:
+        print("Error: --autotune requires nvmolkit; remove --no_nvmolkit")
+        sys.exit(1)
+    if args.autotune_save and not args.autotune:
+        print("Error: --autotune_save requires --autotune")
+        sys.exit(1)
+    if args.autotune and args.autotune_load:
+        print("Error: --autotune and --autotune_load are mutually exclusive")
         sys.exit(1)
     input_file = input_paths[0]
     if args.smiles:
@@ -343,10 +408,70 @@ def main() -> None:
     results: dict[str, tuple[float, float, list[float]]] = {}
 
     hardware_options = None
+    config_source = "cli"
     if not args.no_nvmolkit:
-        hardware_options = _build_hardware_options(
-            args.batch_size, args.batches_per_gpu, args.prep_threads, args.num_gpus
-        )
+        gpu_ids = list(range(args.num_gpus))
+        if args.autotune_load:
+            print(f"\nLoading tuned HardwareOptions from {args.autotune_load}...")
+            loaded = nv_autotune.load(args.autotune_load)
+            if not isinstance(loaded, HardwareOptions):
+                print(f"Error: {args.autotune_load} contains {type(loaded).__name__}, expected HardwareOptions")
+                sys.exit(1)
+            hardware_options = loaded
+            if not hardware_options.gpuIds:
+                hardware_options.gpuIds = gpu_ids
+            config_source = "loaded"
+            print(
+                f"  Loaded: batchSize={hardware_options.batchSize}, "
+                f"batchesPerGpu={hardware_options.batchesPerGpu}, "
+                f"preprocessingThreads={hardware_options.preprocessingThreads}, "
+                f"gpuIds={list(hardware_options.gpuIds) if hardware_options.gpuIds else []}"
+            )
+        elif args.autotune:
+            if not OPTUNA_AVAILABLE:
+                print(
+                    "Error: --autotune requires the optional 'optuna' dependency. "
+                    "Install with `pip install nvmolkit[autotune]` or `conda install -c conda-forge optuna`."
+                )
+                sys.exit(1)
+            print(
+                f"\nAutotuning HardwareOptions for {args.ff.upper()} "
+                f"(n_trials={args.autotune_trials}, per-trial target={args.autotune_time_budget:.1f}s)..."
+            )
+            explicit_calibration = None
+            if args.autotune_calibration_size > 0:
+                rng = random.Random(args.autotune_seed)
+                size = min(args.autotune_calibration_size, len(mols))
+                explicit_calibration = rng.sample(range(len(mols)), size)
+            tune_kwargs = dict(
+                maxIters=args.max_iters,
+                gpuIds=gpu_ids,
+                n_trials=args.autotune_trials,
+                target_seconds_per_trial=args.autotune_time_budget,
+                calibration_set=explicit_calibration,
+                seed=args.autotune_seed,
+                verbose=True,
+            )
+            if args.ff == "mmff":
+                tune_result = nv_autotune.tune_mmff_optimize(mols, **tune_kwargs)
+            else:
+                tune_result = nv_autotune.tune_uff_optimize(mols, **tune_kwargs)
+            hardware_options = tune_result.best_config
+            config_source = "autotuned"
+            print(
+                f"  Best: batchSize={hardware_options.batchSize}, "
+                f"batchesPerGpu={hardware_options.batchesPerGpu} "
+                f"(throughput={tune_result.best_throughput:.2f} confs/s, "
+                f"trials_run={tune_result.n_trials_run}, "
+                f"calibration_size={tune_result.calibration_size})"
+            )
+            if args.autotune_save:
+                nv_autotune.save(hardware_options, args.autotune_save)
+                print(f"  Saved tuned config to {args.autotune_save}")
+        else:
+            hardware_options = _build_hardware_options(
+                args.batch_size, args.batches_per_gpu, args.prep_threads, args.num_gpus
+            )
 
         torch.cuda.cudart().cudaProfilerStart()
         print(f"\nRunning nvmolkit {args.ff.upper()} optimize benchmark...")
@@ -410,6 +535,7 @@ def main() -> None:
         batches_per_gpu = applied_batches_per_gpu if is_nv else "N/A"
         prep_threads = applied_prep_threads if is_nv else "N/A"
         num_gpus = applied_num_gpus if is_nv else "N/A"
+        nvmolkit_config_source = config_source if is_nv else "N/A"
         rdkit_threads = args.rdkit_threads if name == "rdkit" else "N/A"
         mean_diff = energy_mean if (args.validate and is_nv) else "N/A"
         max_diff = energy_max if (args.validate and is_nv) else "N/A"
@@ -417,7 +543,7 @@ def main() -> None:
         csv_rows.append(
             f"{name},{args.ff},{input_file},{input_type},{len(mols)},{args.confs_per_mol},"
             f"{args.max_iters},{batch_size},{batches_per_gpu},{prep_threads},{num_gpus},"
-            f"{rdkit_threads},{avg_ms:.2f},{std_ms:.2f},"
+            f"{nvmolkit_config_source},{rdkit_threads},{avg_ms:.2f},{std_ms:.2f},"
             f"{pairs},{mean_diff},{max_diff}"
         )
 

--- a/benchmarks/substruct_bench.py
+++ b/benchmarks/substruct_bench.py
@@ -64,9 +64,18 @@ from typing import Callable, Iterator
 import nvtx
 import pandas as pd
 from benchmark_timing import time_it as _time_it
+from nvmolkit import autotune as nv_autotune
+from nvmolkit.substructure import (
+    SubstructSearchConfig,
+    countSubstructMatches,
+    getSubstructMatches,
+    hasSubstructMatch,
+)
 from rdkit import Chem, RDLogger
 from rdkit.Chem import rdSubstructLibrary
 from tqdm.contrib.concurrent import process_map
+
+OPTUNA_AVAILABLE = nv_autotune.is_available()
 
 
 def time_it(func: Callable, runs: int = 1, gpu_sync: bool = False) -> tuple[float, float]:
@@ -353,8 +362,6 @@ def bench_nvmolkit(
     mols: list[Chem.Mol], queries: list[Chem.Mol], runs: int, mode: str, config
 ) -> tuple[float, float, object]:
     """Benchmark nvmolkit GPU substructure search."""
-    from nvmolkit.substructure import countSubstructMatches, getSubstructMatches, hasSubstructMatch
-
     results_data: object = None
 
     @nvtx.annotate("nvmolkit_run", color="orange")
@@ -432,6 +439,56 @@ def main():
     parser.add_argument("--no_warmup", action="store_false", dest="warmup", help="Skip warmup run")
     parser.set_defaults(warmup=True)
     parser.add_argument(
+        "--autotune",
+        action="store_true",
+        help=(
+            "Tune nvmolkit SubstructSearchConfig (batchSize/workerThreads/preprocessingThreads) "
+            "before timing. Requires the [autotune] extra (optuna). Single-config mode only."
+        ),
+    )
+    parser.add_argument(
+        "--autotune_save",
+        type=str,
+        default=None,
+        help="Path to save the tuned SubstructSearchConfig as JSON (only with --autotune)",
+    )
+    parser.add_argument(
+        "--autotune_load",
+        type=str,
+        default=None,
+        help=(
+            "Path to a previously-saved SubstructSearchConfig JSON. "
+            "Overrides --batch_size/--workers/--prep_threads (and --num_gpus if gpuIds present in the file)."
+        ),
+    )
+    parser.add_argument(
+        "--autotune_trials",
+        type=int,
+        default=20,
+        help="Number of Optuna trials when --autotune is set (default: 20)",
+    )
+    parser.add_argument(
+        "--autotune_time_budget",
+        type=float,
+        default=10.0,
+        help="Target wall-clock seconds per Optuna trial (default: 10.0)",
+    )
+    parser.add_argument(
+        "--autotune_calibration_size",
+        type=int,
+        default=0,
+        help=(
+            "Number of target molecules to use per autotune trial. "
+            "0 = auto-subsample (~10%% of the workload, capped at 2000). Default: 0"
+        ),
+    )
+    parser.add_argument(
+        "--autotune_seed",
+        type=int,
+        default=42,
+        help="Seed for the Optuna sampler (default: 42)",
+    )
+    parser.add_argument(
         "--validate", action="store_true", dest="validate", help="Validate nvmolkit vs RDKit (default)"
     )
     parser.add_argument("--no_validate", action="store_false", dest="validate", help="Skip validation checks")
@@ -462,6 +519,19 @@ def main():
 
     if args.num_gpus <= 0:
         print("Error: --num_gpus must be >= 1")
+        sys.exit(1)
+
+    if args.autotune and args.config:
+        print("Error: --autotune is only supported in single-config mode (use --smarts, not --config)")
+        sys.exit(1)
+    if args.autotune and args.no_nvmolkit:
+        print("Error: --autotune requires nvmolkit; remove --no_nvmolkit")
+        sys.exit(1)
+    if args.autotune_save and not args.autotune:
+        print("Error: --autotune_save requires --autotune")
+        sys.exit(1)
+    if args.autotune and args.autotune_load:
+        print("Error: --autotune and --autotune_load are mutually exclusive")
         sys.exit(1)
 
     print("\nConfiguration:")
@@ -554,20 +624,79 @@ def main():
             try:
                 import torch
 
-                from nvmolkit.substructure import (
-                    SubstructSearchConfig,
-                    countSubstructMatches,
-                    getSubstructMatches,
-                    hasSubstructMatch,
-                )
+                api_for_mode = {
+                    "hasSubstructMatch": hasSubstructMatch,
+                    "countSubstructMatches": countSubstructMatches,
+                    "getSubstructMatches": getSubstructMatches,
+                }[mode]
+                gpu_ids = list(range(config_row["num_gpus"]))
 
-                config = SubstructSearchConfig()
-                config.batchSize = config_row["batch_size"]
-                config.workerThreads = config_row["workers"]
-                config.preprocessingThreads = config_row["prep_threads"]
-                config.gpuIds = list(range(config_row["num_gpus"]))
-                if args.max_matches > 0:
-                    config.maxMatches = args.max_matches
+                if args.autotune_load:
+                    print(f"\nLoading tuned SubstructSearchConfig from {args.autotune_load}...")
+                    loaded = nv_autotune.load(args.autotune_load)
+                    if not isinstance(loaded, SubstructSearchConfig):
+                        print(
+                            f"Error: {args.autotune_load} contains {type(loaded).__name__}, "
+                            "expected SubstructSearchConfig"
+                        )
+                        sys.exit(1)
+                    config = loaded
+                    if args.max_matches > 0:
+                        config.maxMatches = args.max_matches
+                    if not config.gpuIds:
+                        config.gpuIds = gpu_ids
+                    print(
+                        f"  Loaded: batchSize={config.batchSize}, workerThreads={config.workerThreads}, "
+                        f"preprocessingThreads={config.preprocessingThreads}, gpuIds={list(config.gpuIds)}"
+                    )
+                elif args.autotune:
+                    if not OPTUNA_AVAILABLE:
+                        print(
+                            "Error: --autotune requires the optional 'optuna' dependency. "
+                            "Install with `pip install nvmolkit[autotune]` or `conda install -c conda-forge optuna`."
+                        )
+                        sys.exit(1)
+                    print(
+                        f"\nAutotuning SubstructSearchConfig (mode={mode}, n_trials={args.autotune_trials}, "
+                        f"per-trial target={args.autotune_time_budget:.1f}s)..."
+                    )
+                    explicit_calibration = None
+                    if args.autotune_calibration_size > 0:
+                        rng = random.Random(args.autotune_seed)
+                        size = min(args.autotune_calibration_size, len(mols))
+                        explicit_calibration = rng.sample(range(len(mols)), size)
+                    tune_result = nv_autotune.tune_substructure(
+                        mols,
+                        queries,
+                        api=api_for_mode,
+                        maxMatches=args.max_matches,
+                        gpuIds=gpu_ids,
+                        n_trials=args.autotune_trials,
+                        target_seconds_per_trial=args.autotune_time_budget,
+                        calibration_set=explicit_calibration,
+                        seed=args.autotune_seed,
+                        verbose=True,
+                    )
+                    config = tune_result.best_config
+                    print(
+                        f"  Best: batchSize={config.batchSize}, workerThreads={config.workerThreads}, "
+                        f"preprocessingThreads={config.preprocessingThreads} "
+                        f"(throughput={tune_result.best_throughput:.2f} pairs/s, "
+                        f"trials_run={tune_result.n_trials_run}, "
+                        f"calibration_size={tune_result.calibration_size})"
+                    )
+                    if args.autotune_save:
+                        nv_autotune.save(config, args.autotune_save)
+                        print(f"  Saved tuned config to {args.autotune_save}")
+                else:
+                    config = SubstructSearchConfig()
+                    config.batchSize = config_row["batch_size"]
+                    config.workerThreads = config_row["workers"]
+                    config.preprocessingThreads = config_row["prep_threads"]
+                    config.gpuIds = gpu_ids
+                    if args.max_matches > 0:
+                        config.maxMatches = args.max_matches
+
                 ran_nvmolkit = True
                 torch_module = torch
                 torch.cuda.cudart().cudaProfilerStart()
@@ -667,10 +796,30 @@ def main():
                 pct = 100.0 * matches / total if total > 0 else 0
                 print(f"  Full match agreement: {matches}/{total} ({pct:.1f}%)")
 
+        if ran_nvmolkit:
+            applied_batch_size = int(config.batchSize)
+            applied_workers = int(config.workerThreads)
+            applied_prep_threads = int(config.preprocessingThreads)
+            applied_num_gpus = len(list(config.gpuIds)) if config.gpuIds else config_row["num_gpus"]
+        else:
+            applied_batch_size = config_row["batch_size"]
+            applied_workers = config_row["workers"]
+            applied_prep_threads = config_row["prep_threads"]
+            applied_num_gpus = config_row["num_gpus"]
+
+        if args.autotune:
+            config_source = "autotuned"
+        elif args.autotune_load:
+            config_source = "loaded"
+        else:
+            config_source = "cli"
+
         for name, (avg_ms, std_ms, _) in results.items():
-            batch_size = config_row["batch_size"] if name == "nvmolkit" else "N/A"
-            workers = config_row["workers"] if name == "nvmolkit" else "N/A"
-            prep_threads = config_row["prep_threads"] if name == "nvmolkit" else "N/A"
+            batch_size = applied_batch_size if name == "nvmolkit" else "N/A"
+            workers = applied_workers if name == "nvmolkit" else "N/A"
+            prep_threads = applied_prep_threads if name == "nvmolkit" else "N/A"
+            num_gpus = applied_num_gpus if name == "nvmolkit" else config_row["num_gpus"]
+            nvmolkit_config_source = config_source if name == "nvmolkit" else "N/A"
             rdkit_threads = args.rdkit_threads if name == "rdkit" else "N/A"
             rdkit_match_mode = args.rdkit_match_mode if name == "rdkit" else "N/A"
             csv_rows.append(
@@ -685,9 +834,10 @@ def main():
                     num_patterns,
                     args.max_matches,
                     batch_size,
-                    config_row["num_gpus"],
+                    num_gpus,
                     workers,
                     prep_threads,
+                    nvmolkit_config_source,
                     rdkit_threads,
                     rdkit_match_mode,
                     avg_ms,
@@ -704,7 +854,8 @@ def main():
     print("\n\nCSV Results:")
     print(
         "method,mode,smarts,input_file,input_type,sanitize,num_mols,num_patterns,"
-        "max_matches,batch_size,num_gpus,workers,prep_threads,rdkit_threads,rdkit_match_mode,time_ms,std_ms"
+        "max_matches,batch_size,num_gpus,workers,prep_threads,nvmolkit_config_source,"
+        "rdkit_threads,rdkit_match_mode,time_ms,std_ms"
     )
     for row in csv_rows:
         (
@@ -721,6 +872,7 @@ def main():
             num_gpus,
             workers,
             prep_threads,
+            nvmolkit_config_source,
             rdkit_threads,
             rdkit_match_mode,
             avg_ms,
@@ -729,7 +881,7 @@ def main():
         print(
             f"{name},{mode},{smarts_path},{input_file},{input_type},{sanitize},"
             f"{num_mols},{num_patterns},{max_matches},{batch_size},{num_gpus},{workers},{prep_threads},"
-            f"{rdkit_threads},{rdkit_match_mode},{avg_ms:.2f},{std_ms:.2f}"
+            f"{nvmolkit_config_source},{rdkit_threads},{rdkit_match_mode},{avg_ms:.2f},{std_ms:.2f}"
         )
 
 

--- a/benchmarks/substruct_bench.py
+++ b/benchmarks/substruct_bench.py
@@ -524,6 +524,12 @@ def main():
     if args.autotune and args.config:
         print("Error: --autotune is only supported in single-config mode (use --smarts, not --config)")
         sys.exit(1)
+    if args.autotune_load and args.config:
+        print(
+            "Error: --autotune_load is only supported in single-config mode "
+            "(it would override batch_size/workers/prep_threads/gpuIds on every row)"
+        )
+        sys.exit(1)
     if args.autotune and args.no_nvmolkit:
         print("Error: --autotune requires nvmolkit; remove --no_nvmolkit")
         sys.exit(1)


### PR DESCRIPTION
Adds --autotune / --autotune_save / --autotune_load / --autotune_trials / --autotune_time_budget / --autotune_calibration_size / --autotune_seed flags to the three benchmarks whose corresponding tune_* function exists in nvmolkit.autotune. Each bench dispatches to the matching wrapper (tune_embed_molecules, tune_mmff_optimize / tune_uff_optimize selected by --ff, tune_substructure) and records the resulting config source in a new nvmolkit_config_source CSV column.