### PR TITLE
Add Python build and GPU test CI

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -66,14 +66,33 @@ jobs:
           set -xeuo pipefail
           . /usr/local/anaconda/etc/profile.d/conda.sh && conda activate base
           python -m pip install --upgrade pip
+          # The colossus runner is a V100 (sm_70). PyPI torch wheels from 2.5+
+          # dropped sm_70 from their default arch list, so anything newer hits
+          # cudaErrorNoKernelImageForDevice on this runner. Pin to the last
+          # 2.4.x release that still ships sm_70.
           python -m pip install \
             "scikit-build>=0.18" \
             "numpy>=1.23" \
-            "torch>=2.1" \
+            "torch>=2.1,<2.5" \
             triton \
             pandas \
             psutil \
             optuna
+
+      - name: Report torch CUDA arch coverage
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          . /usr/local/anaconda/etc/profile.d/conda.sh && conda activate base
+          python - <<'PY'
+          import torch
+          print("torch", torch.__version__)
+          print("torch.version.cuda", torch.version.cuda)
+          print("torch.cuda.get_arch_list()", torch.cuda.get_arch_list())
+          for i in range(torch.cuda.device_count()):
+              props = torch.cuda.get_device_properties(i)
+              print(f"device[{i}]", props.name, f"sm_{props.major}{props.minor}")
+          PY
 
       - name: Build & install nvmolkit
         shell: bash

--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -42,9 +42,11 @@ jobs:
       matrix:
         include:
           # Latest python + rdkit pair from the conda-build matrix that targets
-          # CUDA 12.x. Bump these together when conda-build.yml's matrix moves.
-          - python: "3.13"
-            rdkit: "2025.9.2"
+          # CUDA 12.x AND has pip torch wheels covering sm_70 (the colossus
+          # runner is a V100). Python 3.13 needs torch >=2.5, which dropped
+          # sm_70 from its default arch list, so we stay on 3.12 for now.
+          - python: "3.12"
+            rdkit: "2025.3.6"
 
     steps:
       - name: Verify GPU access
@@ -66,10 +68,10 @@ jobs:
           set -xeuo pipefail
           . /usr/local/anaconda/etc/profile.d/conda.sh && conda activate base
           python -m pip install --upgrade pip
-          # The colossus runner is a V100 (sm_70). PyPI torch wheels from 2.5+
-          # dropped sm_70 from their default arch list, so anything newer hits
-          # cudaErrorNoKernelImageForDevice on this runner. Pin to the last
-          # 2.4.x release that still ships sm_70.
+          # torch is pinned <2.5 because 2.5+ dropped sm_70 from its default
+          # arch list and the colossus runner is a V100. Bumping the python
+          # matrix entry past 3.12 will require a torch source on this runner
+          # (e.g. conda-forge) since 3.13 wheels start at 2.5.
           python -m pip install \
             "scikit-build>=0.18" \
             "numpy>=1.23" \

--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Python Build & Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-build-test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: py${{ matrix.python }} rdkit${{ matrix.rdkit }}
+    runs-on: colossus
+    container:
+      image: nvcr.io/nvidia/cuda:12.6.3-devel-ubuntu22.04
+      options: --gpus all
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Latest python + rdkit pair from the conda-build matrix that targets
+          # CUDA 12.x. Bump these together when conda-build.yml's matrix moves.
+          - python: "3.13"
+            rdkit: "2025.9.2"
+
+    steps:
+      - name: Verify GPU access
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          nvidia-smi
+
+      - name: Check out source tree
+        uses: actions/checkout@v4
+
+      - name: Install conda + native dependencies
+        shell: bash
+        run: bash admin/ci/setup_dependencies.sh ${{ matrix.python }} ${{ matrix.rdkit }}
+
+      - name: Install Python build & test deps
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          . /usr/local/anaconda/etc/profile.d/conda.sh && conda activate base
+          python -m pip install --upgrade pip
+          python -m pip install \
+            "scikit-build>=0.18" \
+            "numpy>=1.23" \
+            "torch>=2.1" \
+            triton \
+            pandas \
+            psutil \
+            optuna
+
+      - name: Build & install nvmolkit
+        shell: bash
+        env:
+          CUDA_HOME: /usr/local/cuda
+          NVMOLKIT_CUDA_TARGET_MODE: native
+        run: |
+          set -xeo pipefail
+          . /usr/local/anaconda/etc/profile.d/conda.sh && conda activate base
+          export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
+          python -m pip install . --no-deps --no-build-isolation -v
+
+      - name: Run pytest
+        shell: bash
+        working-directory: /tmp
+        run: |
+          set -xeo pipefail
+          . /usr/local/anaconda/etc/profile.d/conda.sh && conda activate base
+          python -m pytest "${GITHUB_WORKSPACE}/nvmolkit/tests" --tb=short -k 'not long'

--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -42,11 +42,9 @@ jobs:
       matrix:
         include:
           # Latest python + rdkit pair from the conda-build matrix that targets
-          # CUDA 12.x AND has pip torch wheels covering sm_70 (the colossus
-          # runner is a V100). Python 3.13 needs torch >=2.5, which dropped
-          # sm_70 from its default arch list, so we stay on 3.12 for now.
-          - python: "3.12"
-            rdkit: "2025.3.6"
+          # CUDA 12.x. Bump these together when conda-build.yml's matrix moves.
+          - python: "3.13"
+            rdkit: "2025.9.2"
 
     steps:
       - name: Verify GPU access
@@ -68,33 +66,23 @@ jobs:
           set -xeuo pipefail
           . /usr/local/anaconda/etc/profile.d/conda.sh && conda activate base
           python -m pip install --upgrade pip
-          # torch is pinned <2.5 because 2.5+ dropped sm_70 from its default
-          # arch list and the colossus runner is a V100. Bumping the python
-          # matrix entry past 3.12 will require a torch source on this runner
-          # (e.g. conda-forge) since 3.13 wheels start at 2.5.
+          # Torch must come from the cu126 channel: the default PyPI wheel
+          # bundles a libcudart from an older CUDA minor that predates
+          # cudaGraphAddNode (added in CUDA 12.4) and gets picked up by the
+          # dynamic linker ahead of the container's libcudart, breaking
+          # nvmolkit's clustering module. cu126 also keeps sm_70 in the wheel,
+          # which the cu128 / cu129 channels have dropped — required for the
+          # V100 colossus runner.
+          python -m pip install \
+            --index-url https://download.pytorch.org/whl/cu126 \
+            torch
           python -m pip install \
             "scikit-build>=0.18" \
             "numpy>=1.23" \
-            "torch>=2.1,<2.5" \
             triton \
             pandas \
             psutil \
             optuna
-
-      - name: Report torch CUDA arch coverage
-        shell: bash
-        run: |
-          set -xeuo pipefail
-          . /usr/local/anaconda/etc/profile.d/conda.sh && conda activate base
-          python - <<'PY'
-          import torch
-          print("torch", torch.__version__)
-          print("torch.version.cuda", torch.version.cuda)
-          print("torch.cuda.get_arch_list()", torch.cuda.get_arch_list())
-          for i in range(torch.cuda.device_count()):
-              props = torch.cuda.get_device_properties(i)
-              print(f"device[{i}]", props.name, f"sm_{props.major}{props.minor}")
-          PY
 
       - name: Build & install nvmolkit
         shell: bash

--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Python Build & Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-build-test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: py${{ matrix.python }} rdkit${{ matrix.rdkit }} cuda${{ matrix.cuda }}
+    runs-on: colossus
+    container:
+      image: nvcr.io/nvidia/cuda:12.6.3-devel-ubuntu22.04
+      options: --gpus all
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Exercise the latest RDKit release that supports CUDA 12 in the
+          # conda-build matrix. Python 3.12 keeps this job compatible with the
+          # minimum supported Volta GPU while still testing a current Python.
+          - python: "3.12"
+            rdkit: "2025.9.6"
+            cuda: "12.6"
+
+    steps:
+      - name: Verify GPU access and select CUDA architectures
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          nvidia-smi
+
+          mapfile -t compute_caps < <(
+            nvidia-smi --query-gpu=compute_cap --format=csv,noheader |
+              tr -d ' .' |
+              sort -u
+          )
+          if (( ${#compute_caps[@]} == 0 )); then
+            echo "No GPU compute capabilities were reported" >&2
+            exit 1
+          fi
+          for compute_cap in "${compute_caps[@]}"; do
+            if [[ ! "${compute_cap}" =~ ^[0-9]+$ ]] || (( compute_cap < 70 )); then
+              echo "Unsupported GPU compute capability: ${compute_cap}" >&2
+              exit 1
+            fi
+          done
+          cuda_architectures=$(IFS=';'; echo "${compute_caps[*]}")
+          echo "CUDA_ARCHITECTURES=${cuda_architectures}" | tee -a "${GITHUB_ENV}"
+
+      - name: Check out source tree
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Install conda and native dependencies
+        shell: bash
+        run: bash admin/ci/setup_dependencies.sh "${{ matrix.python }}" "${{ matrix.rdkit }}"
+
+      - name: Install Python runtime and test dependencies
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          . /usr/local/anaconda/etc/profile.d/conda.sh
+          conda activate base
+          conda install -q -y \
+            "cuda-version=${{ matrix.cuda }}" \
+            pytorch-gpu \
+            "scikit-build>=0.18" \
+            "setuptools>=42" \
+            ninja \
+            wheel \
+            pandas \
+            psutil \
+            optuna
+
+      - name: Verify PyTorch GPU support
+        shell: bash
+        working-directory: /tmp
+        run: |
+          set -xeuo pipefail
+          . /usr/local/anaconda/etc/profile.d/conda.sh
+          conda activate base
+          python - <<'PY'
+          import torch
+
+          assert torch.cuda.is_available(), "PyTorch cannot access CUDA"
+          print(f"PyTorch {torch.__version__}, CUDA {torch.version.cuda}")
+          print(f"PyTorch architectures: {torch.cuda.get_arch_list()}")
+          for device in range(torch.cuda.device_count()):
+              print(f"GPU {device}: {torch.cuda.get_device_name(device)}")
+              torch.zeros(1, device=f"cuda:{device}")
+          PY
+
+      - name: Build and install nvMolKit
+        shell: bash
+        working-directory: /tmp
+        env:
+          CUDA_HOME: /usr/local/cuda
+          NVMOLKIT_CUDA_TARGET_MODE: default
+        run: |
+          set -xeuo pipefail
+          . /usr/local/anaconda/etc/profile.d/conda.sh
+          conda activate base
+          export CMAKE_ARGS="-DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}"
+          CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
+          export CMAKE_BUILD_PARALLEL_LEVEL
+          python -m pip install \
+            --no-deps \
+            --no-build-isolation \
+            --verbose \
+            "${GITHUB_WORKSPACE}"
+
+      - name: Run pytest
+        shell: bash
+        working-directory: /tmp
+        run: |
+          set -xeuo pipefail
+          . /usr/local/anaconda/etc/profile.d/conda.sh
+          conda activate base
+          python -m pytest \
+            "${GITHUB_WORKSPACE}/nvmolkit/tests" \
+            --tb=short \
+            -m "not long"


### PR DESCRIPTION
Builds nvMolKit from source and runs the non-long Python pytest suite on the colossus GPU runner.
