### PR TITLE
Template per-mol MMFF/UFF kernels on constraints

### DIFF
--- a/src/forcefields/mmff.cu
+++ b/src/forcefields/mmff.cu
@@ -892,24 +892,28 @@ cudaError_t computeGradients(BatchedMolecularDeviceBuffers& molSystemDevice, cud
 cudaError_t computeEnergyBlockPerMol(BatchedMolecularDeviceBuffers& molSystemDevice,
                                      const double*                  coords,
                                      cudaStream_t                   stream) {
-  const auto pointers = toPointerStruct(molSystemDevice.contribs);
-  const auto indices  = toPointerStruct(molSystemDevice.indices);
+  const auto pointers       = toPointerStruct(molSystemDevice.contribs);
+  const auto indices        = toPointerStruct(molSystemDevice.indices);
+  const bool hasConstraints = batchHasConstraints(molSystemDevice.contribs);
   return launchBlockPerMolEnergyKernel(molSystemDevice.indices.atomStarts.size() - 1,
                                        pointers,
                                        indices,
                                        coords != nullptr ? coords : molSystemDevice.positions.data(),
                                        molSystemDevice.energyOuts.data(),
+                                       hasConstraints,
                                        stream);
 }
 
 cudaError_t computeGradBlockPerMol(BatchedMolecularDeviceBuffers& molSystemDevice, cudaStream_t stream) {
-  const auto pointers = toPointerStruct(molSystemDevice.contribs);
-  const auto indices  = toPointerStruct(molSystemDevice.indices);
+  const auto pointers       = toPointerStruct(molSystemDevice.contribs);
+  const auto indices        = toPointerStruct(molSystemDevice.indices);
+  const bool hasConstraints = batchHasConstraints(molSystemDevice.contribs);
   return launchBlockPerMolGradKernel(molSystemDevice.indices.atomStarts.size() - 1,
                                      pointers,
                                      indices,
                                      molSystemDevice.positions.data(),
                                      molSystemDevice.grad.data(),
+                                     hasConstraints,
                                      stream);
 }
 
@@ -919,6 +923,11 @@ EnergyForceContribsDevicePtr toEnergyForceContribsDevicePtr(const BatchedMolecul
 
 BatchedIndicesDevicePtr toBatchedIndicesDevicePtr(const BatchedMolecularDeviceBuffers& molSystemDevice) {
   return toPointerStruct(molSystemDevice.indices);
+}
+
+bool batchHasConstraints(const EnergyForceContribsDevice& contribs) {
+  return contribs.distanceConstraintTerms.idx1.size() > 0 || contribs.positionConstraintTerms.idx.size() > 0 ||
+         contribs.angleConstraintTerms.idx1.size() > 0 || contribs.torsionConstraintTerms.idx1.size() > 0;
 }
 }  // namespace MMFF
 }  // namespace nvMolKit

--- a/src/forcefields/mmff.h
+++ b/src/forcefields/mmff.h
@@ -425,6 +425,11 @@ EnergyForceContribsDevicePtr toEnergyForceContribsDevicePtr(const BatchedMolecul
 //! Create pointer struct from device indices for use in per-molecule kernels
 BatchedIndicesDevicePtr toBatchedIndicesDevicePtr(const BatchedMolecularDeviceBuffers& molSystemDevice);
 
+//! Returns true if any molecule in the batch contributes a distance, position, angle, or torsion
+//! constraint term. Used by per-molecule kernels to dispatch to a specialization that compiles out
+//! the constraint loops, recovering register pressure when no constraints are active.
+bool batchHasConstraints(const EnergyForceContribsDevice& contribs);
+
 }  // namespace MMFF
 }  // namespace nvMolKit
 

--- a/src/forcefields/mmff_kernels.cu
+++ b/src/forcefields/mmff_kernels.cu
@@ -1063,6 +1063,7 @@ cudaError_t launchReduceEnergiesKernel(const int      numBlocks,
 
 constexpr int blockSizePerMol = 128;
 
+template <bool HasConstraints>
 __global__ void combinedEnergiesKernel(const EnergyForceContribsDevicePtr* terms,
                                        const BatchedIndicesDevicePtr*      systemIndices,
                                        const double*                       coords,
@@ -1073,16 +1074,18 @@ __global__ void combinedEnergiesKernel(const EnergyForceContribsDevicePtr* terms
   using BlockReduce = cub::BlockReduce<double, blockSizePerMol>;
   __shared__ typename BlockReduce::TempStorage tempStorage;
 
-  const int     atomStart    = systemIndices->atomStarts[molIdx];
-  const double* molCoords    = coords + atomStart * 3;
-  const double  threadEnergy = molEnergy<blockSizePerMol>(*terms, *systemIndices, molCoords, molIdx, tid);
-  const double  blockEnergy  = BlockReduce(tempStorage).Sum(threadEnergy);
+  const int     atomStart = systemIndices->atomStarts[molIdx];
+  const double* molCoords = coords + atomStart * 3;
+  const double  threadEnergy =
+    molEnergy<blockSizePerMol, HasConstraints>(*terms, *systemIndices, molCoords, molIdx, tid);
+  const double blockEnergy = BlockReduce(tempStorage).Sum(threadEnergy);
 
   if (tid == 0) {
     energies[molIdx] = blockEnergy;
   }
 }
 
+template <bool HasConstraints>
 __global__ void combinedGradKernel(const EnergyForceContribsDevicePtr* terms,
                                    const BatchedIndicesDevicePtr*      systemIndices,
                                    const double*                       coords,
@@ -1106,7 +1109,7 @@ __global__ void combinedGradKernel(const EnergyForceContribsDevicePtr* terms,
   __syncthreads();
 
   const double* molCoords = coords + atomStart * 3;
-  molGrad<blockSizePerMol>(*terms, *systemIndices, molCoords, molGradBase, molIdx, tid);
+  molGrad<blockSizePerMol, HasConstraints>(*terms, *systemIndices, molCoords, molGradBase, molIdx, tid);
   __syncthreads();
 
   if (useSharedMem) {
@@ -1122,10 +1125,17 @@ cudaError_t launchBlockPerMolEnergyKernel(int                                 nu
                                           const BatchedIndicesDevicePtr&      sytemIndices,
                                           const double*                       coords,
                                           double*                             energies,
+                                          bool                                hasConstraints,
                                           cudaStream_t                        stream) {
   const AsyncDevicePtr<EnergyForceContribsDevicePtr> devTerms(terms, stream);
   const AsyncDevicePtr<BatchedIndicesDevicePtr>      devSysIdx(sytemIndices, stream);
-  combinedEnergiesKernel<<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, energies);
+  if (hasConstraints) {
+    combinedEnergiesKernel<true>
+      <<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, energies);
+  } else {
+    combinedEnergiesKernel<false>
+      <<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, energies);
+  }
   return cudaGetLastError();
 }
 
@@ -1134,10 +1144,15 @@ cudaError_t launchBlockPerMolGradKernel(int                                 numM
                                         const BatchedIndicesDevicePtr&      sytemIndices,
                                         const double*                       coords,
                                         double*                             grad,
+                                        bool                                hasConstraints,
                                         cudaStream_t                        stream) {
   const AsyncDevicePtr<EnergyForceContribsDevicePtr> devTerms(terms, stream);
   const AsyncDevicePtr<BatchedIndicesDevicePtr>      devSysIdx(sytemIndices, stream);
-  combinedGradKernel<<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, grad);
+  if (hasConstraints) {
+    combinedGradKernel<true><<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, grad);
+  } else {
+    combinedGradKernel<false><<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, grad);
+  }
   return cudaGetLastError();
 }
 }  // namespace MMFF

--- a/src/forcefields/mmff_kernels.h
+++ b/src/forcefields/mmff_kernels.h
@@ -439,6 +439,7 @@ cudaError_t launchBlockPerMolEnergyKernel(int                                 nu
                                           const BatchedIndicesDevicePtr&      sytemIndices,
                                           const double*                       coords,
                                           double*                             energies,
+                                          bool                                hasConstraints,
                                           cudaStream_t                        stream = nullptr);
 
 cudaError_t launchBlockPerMolGradKernel(int                                 numMols,
@@ -446,6 +447,7 @@ cudaError_t launchBlockPerMolGradKernel(int                                 numM
                                         const BatchedIndicesDevicePtr&      sytemIndices,
                                         const double*                       coords,
                                         double*                             grad,
+                                        bool                                hasConstraints,
                                         cudaStream_t                        stream = nullptr);
 
 }  // namespace MMFF

--- a/src/forcefields/mmff_kernels_device.cuh
+++ b/src/forcefields/mmff_kernels_device.cuh
@@ -1035,7 +1035,7 @@ static __device__ __forceinline__ void torsionConstraintGrad(const double* pos,
 namespace nvMolKit {
 namespace MMFF {
 
-template <int stride>
+template <int stride, bool HasConstraints>
 static __device__ __inline__ double molEnergy(const EnergyForceContribsDevicePtr& terms,
                                               const BatchedIndicesDevicePtr&      systemIndices,
                                               const double*                       molCoords,
@@ -1133,67 +1133,70 @@ static __device__ __inline__ double molEnergy(const EnergyForceContribsDevicePtr
     energy += eleEnergy(molCoords, localIdx1, localIdx2, chargeTerms[i], dielModel, is14);
   }
 
-  const auto& [dc_idx1s, dc_idx2s, minLens, maxLens, dcForceConstants] = terms.distanceConstraintTerms;
-  const int dcStart = systemIndices.distanceConstraintTermStarts[molIdx];
-  const int dcEnd   = systemIndices.distanceConstraintTermStarts[molIdx + 1];
+  if constexpr (HasConstraints) {
+    const auto& [dc_idx1s, dc_idx2s, minLens, maxLens, dcForceConstants] = terms.distanceConstraintTerms;
+    const int dcStart = systemIndices.distanceConstraintTermStarts[molIdx];
+    const int dcEnd   = systemIndices.distanceConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = dcStart + tid; i < dcEnd; i += stride) {
-    const int localIdx1 = dc_idx1s[i] - atomStart;
-    const int localIdx2 = dc_idx2s[i] - atomStart;
-    energy += distanceConstraintEnergy(molCoords, localIdx1, localIdx2, minLens[i], maxLens[i], dcForceConstants[i]);
-  }
+    for (int i = dcStart + tid; i < dcEnd; i += stride) {
+      const int localIdx1 = dc_idx1s[i] - atomStart;
+      const int localIdx2 = dc_idx2s[i] - atomStart;
+      energy += distanceConstraintEnergy(molCoords, localIdx1, localIdx2, minLens[i], maxLens[i], dcForceConstants[i]);
+    }
 
-  const auto& [pc_idxs, refXs, refYs, refZs, maxDispls, pcForceConstants] = terms.positionConstraintTerms;
-  const int pcStart = systemIndices.positionConstraintTermStarts[molIdx];
-  const int pcEnd   = systemIndices.positionConstraintTermStarts[molIdx + 1];
+    const auto& [pc_idxs, refXs, refYs, refZs, maxDispls, pcForceConstants] = terms.positionConstraintTerms;
+    const int pcStart = systemIndices.positionConstraintTermStarts[molIdx];
+    const int pcEnd   = systemIndices.positionConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = pcStart + tid; i < pcEnd; i += stride) {
-    const int localIdx = pc_idxs[i] - atomStart;
-    energy +=
-      positionConstraintEnergy(molCoords, localIdx, refXs[i], refYs[i], refZs[i], maxDispls[i], pcForceConstants[i]);
-  }
+    for (int i = pcStart + tid; i < pcEnd; i += stride) {
+      const int localIdx = pc_idxs[i] - atomStart;
+      energy +=
+        positionConstraintEnergy(molCoords, localIdx, refXs[i], refYs[i], refZs[i], maxDispls[i], pcForceConstants[i]);
+    }
 
-  const auto& [ac_idx1s, ac_idx2s, ac_idx3s, minAngleDegs, maxAngleDegs, acForceConstants] = terms.angleConstraintTerms;
-  const int acStart = systemIndices.angleConstraintTermStarts[molIdx];
-  const int acEnd   = systemIndices.angleConstraintTermStarts[molIdx + 1];
+    const auto& [ac_idx1s, ac_idx2s, ac_idx3s, minAngleDegs, maxAngleDegs, acForceConstants] =
+      terms.angleConstraintTerms;
+    const int acStart = systemIndices.angleConstraintTermStarts[molIdx];
+    const int acEnd   = systemIndices.angleConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = acStart + tid; i < acEnd; i += stride) {
-    const int localIdx1 = ac_idx1s[i] - atomStart;
-    const int localIdx2 = ac_idx2s[i] - atomStart;
-    const int localIdx3 = ac_idx3s[i] - atomStart;
-    energy += angleConstraintEnergy(molCoords,
-                                    localIdx1,
-                                    localIdx2,
-                                    localIdx3,
-                                    minAngleDegs[i],
-                                    maxAngleDegs[i],
-                                    acForceConstants[i]);
-  }
-
-  const auto& [tc_idx1s, tc_idx2s, tc_idx3s, tc_idx4s, minDihedralDegs, maxDihedralDegs, tcForceConstants] =
-    terms.torsionConstraintTerms;
-  const int tcStart = systemIndices.torsionConstraintTermStarts[molIdx];
-  const int tcEnd   = systemIndices.torsionConstraintTermStarts[molIdx + 1];
-#pragma unroll 1
-  for (int i = tcStart + tid; i < tcEnd; i += stride) {
-    const int localIdx1 = tc_idx1s[i] - atomStart;
-    const int localIdx2 = tc_idx2s[i] - atomStart;
-    const int localIdx3 = tc_idx3s[i] - atomStart;
-    const int localIdx4 = tc_idx4s[i] - atomStart;
-    energy += torsionConstraintEnergy(molCoords,
+    for (int i = acStart + tid; i < acEnd; i += stride) {
+      const int localIdx1 = ac_idx1s[i] - atomStart;
+      const int localIdx2 = ac_idx2s[i] - atomStart;
+      const int localIdx3 = ac_idx3s[i] - atomStart;
+      energy += angleConstraintEnergy(molCoords,
                                       localIdx1,
                                       localIdx2,
                                       localIdx3,
-                                      localIdx4,
-                                      minDihedralDegs[i],
-                                      maxDihedralDegs[i],
-                                      tcForceConstants[i]);
+                                      minAngleDegs[i],
+                                      maxAngleDegs[i],
+                                      acForceConstants[i]);
+    }
+
+    const auto& [tc_idx1s, tc_idx2s, tc_idx3s, tc_idx4s, minDihedralDegs, maxDihedralDegs, tcForceConstants] =
+      terms.torsionConstraintTerms;
+    const int tcStart = systemIndices.torsionConstraintTermStarts[molIdx];
+    const int tcEnd   = systemIndices.torsionConstraintTermStarts[molIdx + 1];
+#pragma unroll 1
+    for (int i = tcStart + tid; i < tcEnd; i += stride) {
+      const int localIdx1 = tc_idx1s[i] - atomStart;
+      const int localIdx2 = tc_idx2s[i] - atomStart;
+      const int localIdx3 = tc_idx3s[i] - atomStart;
+      const int localIdx4 = tc_idx4s[i] - atomStart;
+      energy += torsionConstraintEnergy(molCoords,
+                                        localIdx1,
+                                        localIdx2,
+                                        localIdx3,
+                                        localIdx4,
+                                        minDihedralDegs[i],
+                                        maxDihedralDegs[i],
+                                        tcForceConstants[i]);
+    }
   }
 
   return energy;
 }
 
-template <int stride>
+template <int stride, bool HasConstraints>
 static __device__ __inline__ void molGrad(const EnergyForceContribsDevicePtr& terms,
                                           const BatchedIndicesDevicePtr&      systemIndices,
                                           const double*                       molCoords,
@@ -1290,62 +1293,72 @@ static __device__ __inline__ void molGrad(const EnergyForceContribsDevicePtr& te
     eleGrad(molCoords, localIdx1, localIdx2, chargeTerms[i], dielModels[i], is14, grad);
   }
 
-  const auto& [dc_idx1s, dc_idx2s, minLens, maxLens, dcForceConstants] = terms.distanceConstraintTerms;
-  const int dcStart = systemIndices.distanceConstraintTermStarts[molIdx];
-  const int dcEnd   = systemIndices.distanceConstraintTermStarts[molIdx + 1];
+  if constexpr (HasConstraints) {
+    const auto& [dc_idx1s, dc_idx2s, minLens, maxLens, dcForceConstants] = terms.distanceConstraintTerms;
+    const int dcStart = systemIndices.distanceConstraintTermStarts[molIdx];
+    const int dcEnd   = systemIndices.distanceConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = dcStart + tid; i < dcEnd; i += stride) {
-    const int localIdx1 = dc_idx1s[i] - atomStart;
-    const int localIdx2 = dc_idx2s[i] - atomStart;
-    distanceConstraintGrad(molCoords, localIdx1, localIdx2, minLens[i], maxLens[i], dcForceConstants[i], grad);
-  }
+    for (int i = dcStart + tid; i < dcEnd; i += stride) {
+      const int localIdx1 = dc_idx1s[i] - atomStart;
+      const int localIdx2 = dc_idx2s[i] - atomStart;
+      distanceConstraintGrad(molCoords, localIdx1, localIdx2, minLens[i], maxLens[i], dcForceConstants[i], grad);
+    }
 
-  const auto& [pc_idxs, refXs, refYs, refZs, maxDispls, pcForceConstants] = terms.positionConstraintTerms;
-  const int pcStart = systemIndices.positionConstraintTermStarts[molIdx];
-  const int pcEnd   = systemIndices.positionConstraintTermStarts[molIdx + 1];
+    const auto& [pc_idxs, refXs, refYs, refZs, maxDispls, pcForceConstants] = terms.positionConstraintTerms;
+    const int pcStart = systemIndices.positionConstraintTermStarts[molIdx];
+    const int pcEnd   = systemIndices.positionConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = pcStart + tid; i < pcEnd; i += stride) {
-    const int localIdx = pc_idxs[i] - atomStart;
-    positionConstraintGrad(molCoords, localIdx, refXs[i], refYs[i], refZs[i], maxDispls[i], pcForceConstants[i], grad);
-  }
+    for (int i = pcStart + tid; i < pcEnd; i += stride) {
+      const int localIdx = pc_idxs[i] - atomStart;
+      positionConstraintGrad(molCoords,
+                             localIdx,
+                             refXs[i],
+                             refYs[i],
+                             refZs[i],
+                             maxDispls[i],
+                             pcForceConstants[i],
+                             grad);
+    }
 
-  const auto& [ac_idx1s, ac_idx2s, ac_idx3s, minAngleDegs, maxAngleDegs, acForceConstants] = terms.angleConstraintTerms;
-  const int acStart = systemIndices.angleConstraintTermStarts[molIdx];
-  const int acEnd   = systemIndices.angleConstraintTermStarts[molIdx + 1];
+    const auto& [ac_idx1s, ac_idx2s, ac_idx3s, minAngleDegs, maxAngleDegs, acForceConstants] =
+      terms.angleConstraintTerms;
+    const int acStart = systemIndices.angleConstraintTermStarts[molIdx];
+    const int acEnd   = systemIndices.angleConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = acStart + tid; i < acEnd; i += stride) {
-    const int localIdx1 = ac_idx1s[i] - atomStart;
-    const int localIdx2 = ac_idx2s[i] - atomStart;
-    const int localIdx3 = ac_idx3s[i] - atomStart;
-    angleConstraintGrad(molCoords,
-                        localIdx1,
-                        localIdx2,
-                        localIdx3,
-                        minAngleDegs[i],
-                        maxAngleDegs[i],
-                        acForceConstants[i],
-                        grad);
-  }
-
-  const auto& [tc_idx1s, tc_idx2s, tc_idx3s, tc_idx4s, minDihedralDegs, maxDihedralDegs, tcForceConstants] =
-    terms.torsionConstraintTerms;
-  const int tcStart = systemIndices.torsionConstraintTermStarts[molIdx];
-  const int tcEnd   = systemIndices.torsionConstraintTermStarts[molIdx + 1];
-#pragma unroll 1
-  for (int i = tcStart + tid; i < tcEnd; i += stride) {
-    const int localIdx1 = tc_idx1s[i] - atomStart;
-    const int localIdx2 = tc_idx2s[i] - atomStart;
-    const int localIdx3 = tc_idx3s[i] - atomStart;
-    const int localIdx4 = tc_idx4s[i] - atomStart;
-    torsionConstraintGrad(molCoords,
+    for (int i = acStart + tid; i < acEnd; i += stride) {
+      const int localIdx1 = ac_idx1s[i] - atomStart;
+      const int localIdx2 = ac_idx2s[i] - atomStart;
+      const int localIdx3 = ac_idx3s[i] - atomStart;
+      angleConstraintGrad(molCoords,
                           localIdx1,
                           localIdx2,
                           localIdx3,
-                          localIdx4,
-                          minDihedralDegs[i],
-                          maxDihedralDegs[i],
-                          tcForceConstants[i],
+                          minAngleDegs[i],
+                          maxAngleDegs[i],
+                          acForceConstants[i],
                           grad);
+    }
+
+    const auto& [tc_idx1s, tc_idx2s, tc_idx3s, tc_idx4s, minDihedralDegs, maxDihedralDegs, tcForceConstants] =
+      terms.torsionConstraintTerms;
+    const int tcStart = systemIndices.torsionConstraintTermStarts[molIdx];
+    const int tcEnd   = systemIndices.torsionConstraintTermStarts[molIdx + 1];
+#pragma unroll 1
+    for (int i = tcStart + tid; i < tcEnd; i += stride) {
+      const int localIdx1 = tc_idx1s[i] - atomStart;
+      const int localIdx2 = tc_idx2s[i] - atomStart;
+      const int localIdx3 = tc_idx3s[i] - atomStart;
+      const int localIdx4 = tc_idx4s[i] - atomStart;
+      torsionConstraintGrad(molCoords,
+                            localIdx1,
+                            localIdx2,
+                            localIdx3,
+                            localIdx4,
+                            minDihedralDegs[i],
+                            maxDihedralDegs[i],
+                            tcForceConstants[i],
+                            grad);
+    }
   }
 }
 

--- a/src/forcefields/uff.cu
+++ b/src/forcefields/uff.cu
@@ -766,6 +766,7 @@ cudaError_t computeEnergyBlockPerMol(BatchedMolecularDeviceBuffers& molSystemDev
                                        toPointerStruct(molSystemDevice.indices),
                                        coords != nullptr ? coords : molSystemDevice.positions.data(),
                                        molSystemDevice.energyOuts.data(),
+                                       batchHasConstraints(molSystemDevice.contribs),
                                        stream);
 }
 
@@ -775,6 +776,7 @@ cudaError_t computeGradBlockPerMol(BatchedMolecularDeviceBuffers& molSystemDevic
                                      toPointerStruct(molSystemDevice.indices),
                                      molSystemDevice.positions.data(),
                                      molSystemDevice.grad.data(),
+                                     batchHasConstraints(molSystemDevice.contribs),
                                      stream);
 }
 
@@ -784,6 +786,11 @@ EnergyForceContribsDevicePtr toEnergyForceContribsDevicePtr(const BatchedMolecul
 
 BatchedIndicesDevicePtr toBatchedIndicesDevicePtr(const BatchedMolecularDeviceBuffers& molSystemDevice) {
   return toPointerStruct(molSystemDevice.indices);
+}
+
+bool batchHasConstraints(const EnergyForceContribsDevice& contribs) {
+  return contribs.distanceConstraintTerms.idx1.size() > 0 || contribs.positionConstraintTerms.idx.size() > 0 ||
+         contribs.angleConstraintTerms.idx1.size() > 0 || contribs.torsionConstraintTerms.idx1.size() > 0;
 }
 
 }  // namespace UFF

--- a/src/forcefields/uff.h
+++ b/src/forcefields/uff.h
@@ -261,6 +261,11 @@ EnergyForceContribsDevicePtr toEnergyForceContribsDevicePtr(const BatchedMolecul
 
 BatchedIndicesDevicePtr toBatchedIndicesDevicePtr(const BatchedMolecularDeviceBuffers& molSystemDevice);
 
+//! Returns true if any molecule in the batch contributes a distance, position, angle, or torsion
+//! constraint term. Used by per-molecule kernels to dispatch to a specialization that compiles out
+//! the constraint loops, recovering register pressure when no constraints are active.
+bool batchHasConstraints(const EnergyForceContribsDevice& contribs);
+
 }  // namespace UFF
 }  // namespace nvMolKit
 

--- a/src/forcefields/uff_kernels.cu
+++ b/src/forcefields/uff_kernels.cu
@@ -238,6 +238,7 @@ __global__ void vdwGradKernel(const int     numVdws,
 
 constexpr int blockSizePerMol = 128;
 
+template <bool HasConstraints>
 __global__ void combinedEnergiesKernel(const nvMolKit::UFF::EnergyForceContribsDevicePtr* terms,
                                        const nvMolKit::UFF::BatchedIndicesDevicePtr*      systemIndices,
                                        const double*                                      coords,
@@ -245,9 +246,10 @@ __global__ void combinedEnergiesKernel(const nvMolKit::UFF::EnergyForceContribsD
   const int molIdx = blockIdx.x;
   const int tid    = threadIdx.x;
 
-  const int     atomStart   = systemIndices->atomStarts[molIdx];
-  const double* molCoords   = coords + atomStart * 3;
-  const double threadEnergy = nvMolKit::UFF::molEnergy<blockSizePerMol>(*terms, *systemIndices, molCoords, molIdx, tid);
+  const int     atomStart = systemIndices->atomStarts[molIdx];
+  const double* molCoords = coords + atomStart * 3;
+  const double  threadEnergy =
+    nvMolKit::UFF::molEnergy<blockSizePerMol, HasConstraints>(*terms, *systemIndices, molCoords, molIdx, tid);
 
   using BlockReduce = cub::BlockReduce<double, blockSizePerMol>;
   __shared__ typename BlockReduce::TempStorage tempStorage;
@@ -258,6 +260,7 @@ __global__ void combinedEnergiesKernel(const nvMolKit::UFF::EnergyForceContribsD
   }
 }
 
+template <bool HasConstraints>
 __global__ void combinedGradKernel(const nvMolKit::UFF::EnergyForceContribsDevicePtr* terms,
                                    const nvMolKit::UFF::BatchedIndicesDevicePtr*      systemIndices,
                                    const double*                                      coords,
@@ -281,7 +284,7 @@ __global__ void combinedGradKernel(const nvMolKit::UFF::EnergyForceContribsDevic
   __syncthreads();
 
   const double* molCoords = coords + atomStart * 3;
-  nvMolKit::UFF::molGrad<blockSizePerMol>(*terms, *systemIndices, molCoords, molGradBase, molIdx, tid);
+  nvMolKit::UFF::molGrad<blockSizePerMol, HasConstraints>(*terms, *systemIndices, molCoords, molGradBase, molIdx, tid);
   __syncthreads();
 
   if (useSharedMem) {
@@ -571,10 +574,17 @@ cudaError_t launchBlockPerMolEnergyKernel(int                                 nu
                                           const BatchedIndicesDevicePtr&      systemIndices,
                                           const double*                       coords,
                                           double*                             energies,
+                                          bool                                hasConstraints,
                                           cudaStream_t                        stream) {
   const AsyncDevicePtr<EnergyForceContribsDevicePtr> devTerms(terms, stream);
   const AsyncDevicePtr<BatchedIndicesDevicePtr>      devSysIdx(systemIndices, stream);
-  combinedEnergiesKernel<<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, energies);
+  if (hasConstraints) {
+    combinedEnergiesKernel<true>
+      <<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, energies);
+  } else {
+    combinedEnergiesKernel<false>
+      <<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, energies);
+  }
   return cudaGetLastError();
 }
 
@@ -583,10 +593,15 @@ cudaError_t launchBlockPerMolGradKernel(int                                 numM
                                         const BatchedIndicesDevicePtr&      systemIndices,
                                         const double*                       coords,
                                         double*                             grad,
+                                        bool                                hasConstraints,
                                         cudaStream_t                        stream) {
   const AsyncDevicePtr<EnergyForceContribsDevicePtr> devTerms(terms, stream);
   const AsyncDevicePtr<BatchedIndicesDevicePtr>      devSysIdx(systemIndices, stream);
-  combinedGradKernel<<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, grad);
+  if (hasConstraints) {
+    combinedGradKernel<true><<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, grad);
+  } else {
+    combinedGradKernel<false><<<numMols, blockSizePerMol, 0, stream>>>(devTerms.data(), devSysIdx.data(), coords, grad);
+  }
   return cudaGetLastError();
 }
 

--- a/src/forcefields/uff_kernels.h
+++ b/src/forcefields/uff_kernels.h
@@ -232,6 +232,7 @@ cudaError_t launchBlockPerMolEnergyKernel(int                                 nu
                                           const BatchedIndicesDevicePtr&      sytemIndices,
                                           const double*                       coords,
                                           double*                             energies,
+                                          bool                                hasConstraints,
                                           cudaStream_t                        stream = nullptr);
 
 cudaError_t launchBlockPerMolGradKernel(int                                 numMols,
@@ -239,6 +240,7 @@ cudaError_t launchBlockPerMolGradKernel(int                                 numM
                                         const BatchedIndicesDevicePtr&      sytemIndices,
                                         const double*                       coords,
                                         double*                             grad,
+                                        bool                                hasConstraints,
                                         cudaStream_t                        stream = nullptr);
 
 }  // namespace UFF

--- a/src/forcefields/uff_kernels_device.cuh
+++ b/src/forcefields/uff_kernels_device.cuh
@@ -587,7 +587,7 @@ __device__ __forceinline__ void uffVdwGrad(const double* pos,
 namespace nvMolKit {
 namespace UFF {
 
-template <int stride>
+template <int stride, bool HasConstraints>
 __device__ __inline__ double molEnergy(const EnergyForceContribsDevicePtr& terms,
                                        const BatchedIndicesDevicePtr&      systemIndices,
                                        const double*                       molCoords,
@@ -664,62 +664,64 @@ __device__ __inline__ double molEnergy(const EnergyForceContribsDevicePtr& terms
                            terms.vdwTerms.threshold[i]);
   }
 
-  const int dcStart = systemIndices.distanceConstraintTermStarts[molIdx];
-  const int dcEnd   = systemIndices.distanceConstraintTermStarts[molIdx + 1];
+  if constexpr (HasConstraints) {
+    const int dcStart = systemIndices.distanceConstraintTermStarts[molIdx];
+    const int dcEnd   = systemIndices.distanceConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = dcStart + tid; i < dcEnd; i += stride) {
-    energy += distanceConstraintEnergy(molCoords,
-                                       terms.distanceConstraintTerms.idx1[i] - atomStart,
-                                       terms.distanceConstraintTerms.idx2[i] - atomStart,
-                                       terms.distanceConstraintTerms.minLen[i],
-                                       terms.distanceConstraintTerms.maxLen[i],
-                                       terms.distanceConstraintTerms.forceConstant[i]);
-  }
+    for (int i = dcStart + tid; i < dcEnd; i += stride) {
+      energy += distanceConstraintEnergy(molCoords,
+                                         terms.distanceConstraintTerms.idx1[i] - atomStart,
+                                         terms.distanceConstraintTerms.idx2[i] - atomStart,
+                                         terms.distanceConstraintTerms.minLen[i],
+                                         terms.distanceConstraintTerms.maxLen[i],
+                                         terms.distanceConstraintTerms.forceConstant[i]);
+    }
 
-  const int pcStart = systemIndices.positionConstraintTermStarts[molIdx];
-  const int pcEnd   = systemIndices.positionConstraintTermStarts[molIdx + 1];
+    const int pcStart = systemIndices.positionConstraintTermStarts[molIdx];
+    const int pcEnd   = systemIndices.positionConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = pcStart + tid; i < pcEnd; i += stride) {
-    energy += positionConstraintEnergy(molCoords,
-                                       terms.positionConstraintTerms.idx[i] - atomStart,
-                                       terms.positionConstraintTerms.refX[i],
-                                       terms.positionConstraintTerms.refY[i],
-                                       terms.positionConstraintTerms.refZ[i],
-                                       terms.positionConstraintTerms.maxDispl[i],
-                                       terms.positionConstraintTerms.forceConstant[i]);
-  }
+    for (int i = pcStart + tid; i < pcEnd; i += stride) {
+      energy += positionConstraintEnergy(molCoords,
+                                         terms.positionConstraintTerms.idx[i] - atomStart,
+                                         terms.positionConstraintTerms.refX[i],
+                                         terms.positionConstraintTerms.refY[i],
+                                         terms.positionConstraintTerms.refZ[i],
+                                         terms.positionConstraintTerms.maxDispl[i],
+                                         terms.positionConstraintTerms.forceConstant[i]);
+    }
 
-  const int acStart = systemIndices.angleConstraintTermStarts[molIdx];
-  const int acEnd   = systemIndices.angleConstraintTermStarts[molIdx + 1];
+    const int acStart = systemIndices.angleConstraintTermStarts[molIdx];
+    const int acEnd   = systemIndices.angleConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = acStart + tid; i < acEnd; i += stride) {
-    energy += angleConstraintEnergy(molCoords,
-                                    terms.angleConstraintTerms.idx1[i] - atomStart,
-                                    terms.angleConstraintTerms.idx2[i] - atomStart,
-                                    terms.angleConstraintTerms.idx3[i] - atomStart,
-                                    terms.angleConstraintTerms.minAngleDeg[i],
-                                    terms.angleConstraintTerms.maxAngleDeg[i],
-                                    terms.angleConstraintTerms.forceConstant[i]);
-  }
+    for (int i = acStart + tid; i < acEnd; i += stride) {
+      energy += angleConstraintEnergy(molCoords,
+                                      terms.angleConstraintTerms.idx1[i] - atomStart,
+                                      terms.angleConstraintTerms.idx2[i] - atomStart,
+                                      terms.angleConstraintTerms.idx3[i] - atomStart,
+                                      terms.angleConstraintTerms.minAngleDeg[i],
+                                      terms.angleConstraintTerms.maxAngleDeg[i],
+                                      terms.angleConstraintTerms.forceConstant[i]);
+    }
 
-  const int tcStart = systemIndices.torsionConstraintTermStarts[molIdx];
-  const int tcEnd   = systemIndices.torsionConstraintTermStarts[molIdx + 1];
+    const int tcStart = systemIndices.torsionConstraintTermStarts[molIdx];
+    const int tcEnd   = systemIndices.torsionConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = tcStart + tid; i < tcEnd; i += stride) {
-    energy += torsionConstraintEnergy(molCoords,
-                                      terms.torsionConstraintTerms.idx1[i] - atomStart,
-                                      terms.torsionConstraintTerms.idx2[i] - atomStart,
-                                      terms.torsionConstraintTerms.idx3[i] - atomStart,
-                                      terms.torsionConstraintTerms.idx4[i] - atomStart,
-                                      terms.torsionConstraintTerms.minDihedralDeg[i],
-                                      terms.torsionConstraintTerms.maxDihedralDeg[i],
-                                      terms.torsionConstraintTerms.forceConstant[i]);
+    for (int i = tcStart + tid; i < tcEnd; i += stride) {
+      energy += torsionConstraintEnergy(molCoords,
+                                        terms.torsionConstraintTerms.idx1[i] - atomStart,
+                                        terms.torsionConstraintTerms.idx2[i] - atomStart,
+                                        terms.torsionConstraintTerms.idx3[i] - atomStart,
+                                        terms.torsionConstraintTerms.idx4[i] - atomStart,
+                                        terms.torsionConstraintTerms.minDihedralDeg[i],
+                                        terms.torsionConstraintTerms.maxDihedralDeg[i],
+                                        terms.torsionConstraintTerms.forceConstant[i]);
+    }
   }
 
   return energy;
 }
 
-template <int stride>
+template <int stride, bool HasConstraints>
 __device__ __inline__ void molGrad(const EnergyForceContribsDevicePtr& terms,
                                    const BatchedIndicesDevicePtr&      systemIndices,
                                    const double*                       molCoords,
@@ -800,60 +802,62 @@ __device__ __inline__ void molGrad(const EnergyForceContribsDevicePtr& terms,
                grad);
   }
 
-  const int dcStart = systemIndices.distanceConstraintTermStarts[molIdx];
-  const int dcEnd   = systemIndices.distanceConstraintTermStarts[molIdx + 1];
+  if constexpr (HasConstraints) {
+    const int dcStart = systemIndices.distanceConstraintTermStarts[molIdx];
+    const int dcEnd   = systemIndices.distanceConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = dcStart + tid; i < dcEnd; i += stride) {
-    distanceConstraintGrad(molCoords,
-                           terms.distanceConstraintTerms.idx1[i] - atomStart,
-                           terms.distanceConstraintTerms.idx2[i] - atomStart,
-                           terms.distanceConstraintTerms.minLen[i],
-                           terms.distanceConstraintTerms.maxLen[i],
-                           terms.distanceConstraintTerms.forceConstant[i],
-                           grad);
-  }
+    for (int i = dcStart + tid; i < dcEnd; i += stride) {
+      distanceConstraintGrad(molCoords,
+                             terms.distanceConstraintTerms.idx1[i] - atomStart,
+                             terms.distanceConstraintTerms.idx2[i] - atomStart,
+                             terms.distanceConstraintTerms.minLen[i],
+                             terms.distanceConstraintTerms.maxLen[i],
+                             terms.distanceConstraintTerms.forceConstant[i],
+                             grad);
+    }
 
-  const int pcStart = systemIndices.positionConstraintTermStarts[molIdx];
-  const int pcEnd   = systemIndices.positionConstraintTermStarts[molIdx + 1];
+    const int pcStart = systemIndices.positionConstraintTermStarts[molIdx];
+    const int pcEnd   = systemIndices.positionConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = pcStart + tid; i < pcEnd; i += stride) {
-    positionConstraintGrad(molCoords,
-                           terms.positionConstraintTerms.idx[i] - atomStart,
-                           terms.positionConstraintTerms.refX[i],
-                           terms.positionConstraintTerms.refY[i],
-                           terms.positionConstraintTerms.refZ[i],
-                           terms.positionConstraintTerms.maxDispl[i],
-                           terms.positionConstraintTerms.forceConstant[i],
-                           grad);
-  }
+    for (int i = pcStart + tid; i < pcEnd; i += stride) {
+      positionConstraintGrad(molCoords,
+                             terms.positionConstraintTerms.idx[i] - atomStart,
+                             terms.positionConstraintTerms.refX[i],
+                             terms.positionConstraintTerms.refY[i],
+                             terms.positionConstraintTerms.refZ[i],
+                             terms.positionConstraintTerms.maxDispl[i],
+                             terms.positionConstraintTerms.forceConstant[i],
+                             grad);
+    }
 
-  const int acStart = systemIndices.angleConstraintTermStarts[molIdx];
-  const int acEnd   = systemIndices.angleConstraintTermStarts[molIdx + 1];
+    const int acStart = systemIndices.angleConstraintTermStarts[molIdx];
+    const int acEnd   = systemIndices.angleConstraintTermStarts[molIdx + 1];
 #pragma unroll 1
-  for (int i = acStart + tid; i < acEnd; i += stride) {
-    angleConstraintGrad(molCoords,
-                        terms.angleConstraintTerms.idx1[i] - atomStart,
-                        terms.angleConstraintTerms.idx2[i] - atomStart,
-                        terms.angleConstraintTerms.idx3[i] - atomStart,
-                        terms.angleConstraintTerms.minAngleDeg[i],
-                        terms.angleConstraintTerms.maxAngleDeg[i],
-                        terms.angleConstraintTerms.forceConstant[i],
-                        grad);
-  }
-
-  const int tcStart = systemIndices.torsionConstraintTermStarts[molIdx];
-  const int tcEnd   = systemIndices.torsionConstraintTermStarts[molIdx + 1];
-#pragma unroll 1
-  for (int i = tcStart + tid; i < tcEnd; i += stride) {
-    torsionConstraintGrad(molCoords,
-                          terms.torsionConstraintTerms.idx1[i] - atomStart,
-                          terms.torsionConstraintTerms.idx2[i] - atomStart,
-                          terms.torsionConstraintTerms.idx3[i] - atomStart,
-                          terms.torsionConstraintTerms.idx4[i] - atomStart,
-                          terms.torsionConstraintTerms.minDihedralDeg[i],
-                          terms.torsionConstraintTerms.maxDihedralDeg[i],
-                          terms.torsionConstraintTerms.forceConstant[i],
+    for (int i = acStart + tid; i < acEnd; i += stride) {
+      angleConstraintGrad(molCoords,
+                          terms.angleConstraintTerms.idx1[i] - atomStart,
+                          terms.angleConstraintTerms.idx2[i] - atomStart,
+                          terms.angleConstraintTerms.idx3[i] - atomStart,
+                          terms.angleConstraintTerms.minAngleDeg[i],
+                          terms.angleConstraintTerms.maxAngleDeg[i],
+                          terms.angleConstraintTerms.forceConstant[i],
                           grad);
+    }
+
+    const int tcStart = systemIndices.torsionConstraintTermStarts[molIdx];
+    const int tcEnd   = systemIndices.torsionConstraintTermStarts[molIdx + 1];
+#pragma unroll 1
+    for (int i = tcStart + tid; i < tcEnd; i += stride) {
+      torsionConstraintGrad(molCoords,
+                            terms.torsionConstraintTerms.idx1[i] - atomStart,
+                            terms.torsionConstraintTerms.idx2[i] - atomStart,
+                            terms.torsionConstraintTerms.idx3[i] - atomStart,
+                            terms.torsionConstraintTerms.idx4[i] - atomStart,
+                            terms.torsionConstraintTerms.minDihedralDeg[i],
+                            terms.torsionConstraintTerms.maxDihedralDeg[i],
+                            terms.torsionConstraintTerms.forceConstant[i],
+                            grad);
+    }
   }
 }
 

--- a/src/minimizer/bfgs_minimize.cu
+++ b/src/minimizer/bfgs_minimize.cu
@@ -1126,6 +1126,7 @@ bool BfgsBatchMinimizer::minimizeWithMMFF(const int                            n
                                                    inverseHessian_.data(),
                                                    scratchBuffersDevice_.data(),
                                                    systemDevice.energyOuts.data(),
+                                                   MMFF::batchHasConstraints(systemDevice.contribs),
                                                    statuses_.data(),
                                                    stream_);
 

--- a/src/minimizer/bfgs_minimize_permol_kernels.cu
+++ b/src/minimizer/bfgs_minimize_permol_kernels.cu
@@ -418,7 +418,12 @@ template <> struct DataDimTraits<ForceFieldType::DG> {
 
 }  // namespace
 
-template <int MaxAtoms, bool UseSharedMem, ForceFieldType FFType, typename TermsType, typename IndicesType>
+template <int            MaxAtoms,
+          bool           UseSharedMem,
+          ForceFieldType FFType,
+          bool           HasConstraints,
+          typename TermsType,
+          typename IndicesType>
 __launch_bounds__(BLOCK_SIZE) __global__ void bfgsMinimizeKernel(const int               numIters,
                                                                  const double            gradTol,
                                                                  const bool              scaleGrads,
@@ -532,7 +537,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void bfgsMinimizeKernel(const int      
   // Compute initial energy
   double threadEnergy;
   if constexpr (FFType == ForceFieldType::MMFF) {
-    threadEnergy = MMFF::molEnergy<BLOCK_SIZE>(*terms, *systemIndices, localPos, molIdx, tid);
+    threadEnergy = MMFF::molEnergy<BLOCK_SIZE, HasConstraints>(*terms, *systemIndices, localPos, molIdx, tid);
   } else if constexpr (FFType == ForceFieldType::ETK) {
     threadEnergy = DistGeom::molEnergyETK(*terms, *systemIndices, localPos, molIdx, tid);
   } else {  // DG
@@ -553,7 +558,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void bfgsMinimizeKernel(const int      
   __syncthreads();
 
   if constexpr (FFType == ForceFieldType::MMFF) {
-    MMFF::molGrad<BLOCK_SIZE>(*terms, *systemIndices, localPos, localGrad, molIdx, tid);
+    MMFF::molGrad<BLOCK_SIZE, HasConstraints>(*terms, *systemIndices, localPos, localGrad, molIdx, tid);
   } else if constexpr (FFType == ForceFieldType::ETK) {
     DistGeom::molGradETK(*terms, *systemIndices, localPos, localGrad, molIdx, tid);
   } else {  // DG
@@ -622,7 +627,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void bfgsMinimizeKernel(const int      
       // Compute energy at perturbed position (use scratchPos which has the perturbed coordinates)
       double lsThreadEnergy;
       if constexpr (FFType == ForceFieldType::MMFF) {
-        lsThreadEnergy = MMFF::molEnergy<BLOCK_SIZE>(*terms, *systemIndices, scratchPos, molIdx, tid);
+        lsThreadEnergy = MMFF::molEnergy<BLOCK_SIZE, HasConstraints>(*terms, *systemIndices, scratchPos, molIdx, tid);
       } else if constexpr (FFType == ForceFieldType::ETK) {
         lsThreadEnergy = DistGeom::molEnergyETK(*terms, *systemIndices, scratchPos, molIdx, tid);
       } else {  // DG
@@ -677,7 +682,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void bfgsMinimizeKernel(const int      
     __syncthreads();
 
     if constexpr (FFType == ForceFieldType::MMFF) {
-      MMFF::molGrad<BLOCK_SIZE>(*terms, *systemIndices, localPos, localGrad, molIdx, tid);
+      MMFF::molGrad<BLOCK_SIZE, HasConstraints>(*terms, *systemIndices, localPos, localGrad, molIdx, tid);
     } else if constexpr (FFType == ForceFieldType::ETK) {
       DistGeom::molGradETK(*terms, *systemIndices, localPos, localGrad, molIdx, tid);
     } else {  // DG
@@ -734,7 +739,12 @@ __launch_bounds__(BLOCK_SIZE) __global__ void bfgsMinimizeKernel(const int      
 
 namespace {
 
-template <int MaxAtoms, bool UseSharedMem, ForceFieldType FFType, typename TermsType, typename IndicesType>
+template <int            MaxAtoms,
+          bool           UseSharedMem,
+          ForceFieldType FFType,
+          bool           HasConstraints,
+          typename TermsType,
+          typename IndicesType>
 cudaError_t launchKernelForSize(int                numMols,
                                 const int*         molIdList,
                                 int                numIters,
@@ -757,7 +767,7 @@ cudaError_t launchKernelForSize(int                numMols,
     return cudaSuccess;
   }
 
-  bfgsMinimizeKernel<MaxAtoms, UseSharedMem, FFType, TermsType, IndicesType>
+  bfgsMinimizeKernel<MaxAtoms, UseSharedMem, FFType, HasConstraints, TermsType, IndicesType>
     <<<numMols, BLOCK_SIZE, 0, stream>>>(numIters,
                                          gradTol,
                                          scaleGrads,
@@ -778,6 +788,144 @@ cudaError_t launchKernelForSize(int                numMols,
   return cudaGetLastError();
 }
 
+template <ForceFieldType FFType, bool HasConstraints, typename TermsType, typename IndicesType>
+cudaError_t dispatchByMaxAtoms(int                numMols,
+                               const int*         molIdList,
+                               int                maxAtoms,
+                               int                numIters,
+                               double             gradTol,
+                               bool               scaleGrads,
+                               const TermsType*   devTerms,
+                               const IndicesType* devSysIdx,
+                               const int*         atomStarts,
+                               const int*         hessianStarts,
+                               double*            positions,
+                               double*            grad,
+                               double*            inverseHessian,
+                               double**           scratchBuffers,
+                               double*            energyOuts,
+                               int16_t*           statuses,
+                               cudaStream_t       stream,
+                               double             chiralWeight,
+                               double             fourthDimWeight) {
+  // Use shared memory for <=128 atoms (in increments of 32), global memory for larger
+  if (maxAtoms <= 32) {
+    return launchKernelForSize<32, true, FFType, HasConstraints>(numMols,
+                                                                 molIdList,
+                                                                 numIters,
+                                                                 gradTol,
+                                                                 scaleGrads,
+                                                                 devTerms,
+                                                                 devSysIdx,
+                                                                 atomStarts,
+                                                                 hessianStarts,
+                                                                 positions,
+                                                                 grad,
+                                                                 inverseHessian,
+                                                                 scratchBuffers,
+                                                                 energyOuts,
+                                                                 statuses,
+                                                                 stream,
+                                                                 chiralWeight,
+                                                                 fourthDimWeight);
+  } else if (maxAtoms <= 64) {
+    return launchKernelForSize<64, true, FFType, HasConstraints>(numMols,
+                                                                 molIdList,
+                                                                 numIters,
+                                                                 gradTol,
+                                                                 scaleGrads,
+                                                                 devTerms,
+                                                                 devSysIdx,
+                                                                 atomStarts,
+                                                                 hessianStarts,
+                                                                 positions,
+                                                                 grad,
+                                                                 inverseHessian,
+                                                                 scratchBuffers,
+                                                                 energyOuts,
+                                                                 statuses,
+                                                                 stream,
+                                                                 chiralWeight,
+                                                                 fourthDimWeight);
+  } else if (maxAtoms <= 96) {
+    return launchKernelForSize<96, true, FFType, HasConstraints>(numMols,
+                                                                 molIdList,
+                                                                 numIters,
+                                                                 gradTol,
+                                                                 scaleGrads,
+                                                                 devTerms,
+                                                                 devSysIdx,
+                                                                 atomStarts,
+                                                                 hessianStarts,
+                                                                 positions,
+                                                                 grad,
+                                                                 inverseHessian,
+                                                                 scratchBuffers,
+                                                                 energyOuts,
+                                                                 statuses,
+                                                                 stream,
+                                                                 chiralWeight,
+                                                                 fourthDimWeight);
+  } else if (maxAtoms <= 128) {
+    return launchKernelForSize<128, true, FFType, HasConstraints>(numMols,
+                                                                  molIdList,
+                                                                  numIters,
+                                                                  gradTol,
+                                                                  scaleGrads,
+                                                                  devTerms,
+                                                                  devSysIdx,
+                                                                  atomStarts,
+                                                                  hessianStarts,
+                                                                  positions,
+                                                                  grad,
+                                                                  inverseHessian,
+                                                                  scratchBuffers,
+                                                                  energyOuts,
+                                                                  statuses,
+                                                                  stream,
+                                                                  chiralWeight,
+                                                                  fourthDimWeight);
+  } else if (maxAtoms <= 256) {
+    return launchKernelForSize<256, false, FFType, HasConstraints>(numMols,
+                                                                   molIdList,
+                                                                   numIters,
+                                                                   gradTol,
+                                                                   scaleGrads,
+                                                                   devTerms,
+                                                                   devSysIdx,
+                                                                   atomStarts,
+                                                                   hessianStarts,
+                                                                   positions,
+                                                                   grad,
+                                                                   inverseHessian,
+                                                                   scratchBuffers,
+                                                                   energyOuts,
+                                                                   statuses,
+                                                                   stream,
+                                                                   chiralWeight,
+                                                                   fourthDimWeight);
+  } else {
+    return launchKernelForSize<2048, false, FFType, HasConstraints>(numMols,
+                                                                    molIdList,
+                                                                    numIters,
+                                                                    gradTol,
+                                                                    scaleGrads,
+                                                                    devTerms,
+                                                                    devSysIdx,
+                                                                    atomStarts,
+                                                                    hessianStarts,
+                                                                    positions,
+                                                                    grad,
+                                                                    inverseHessian,
+                                                                    scratchBuffers,
+                                                                    energyOuts,
+                                                                    statuses,
+                                                                    stream,
+                                                                    chiralWeight,
+                                                                    fourthDimWeight);
+  }
+}
+
 }  // namespace
 
 cudaError_t launchBfgsMinimizePerMolKernel(int                                       numMols,
@@ -795,6 +943,7 @@ cudaError_t launchBfgsMinimizePerMolKernel(int                                  
                                            double*                                   inverseHessian,
                                            double**                                  scratchBuffers,
                                            double*                                   energyOuts,
+                                           bool                                      hasConstraints,
                                            int16_t*                                  statuses,
                                            cudaStream_t                              stream) {
   if (numMols == 0) {
@@ -804,123 +953,46 @@ cudaError_t launchBfgsMinimizePerMolKernel(int                                  
   const AsyncDevicePtr<MMFF::EnergyForceContribsDevicePtr> devTerms(terms, stream);
   const AsyncDevicePtr<MMFF::BatchedIndicesDevicePtr>      devSysIdx(systemIndices, stream);
 
-  // Dispatch to appropriate kernel based on max molecule size
-  // Use shared memory for <=128 atoms (in increments of 32), global memory for larger
-  if (maxAtoms <= 32) {
-    return launchKernelForSize<32, true, ForceFieldType::MMFF>(numMols,
-                                                               molIds,
-                                                               numIters,
-                                                               gradTol,
-                                                               scaleGrads,
-                                                               devTerms.data(),
-                                                               devSysIdx.data(),
-                                                               atomStarts,
-                                                               hessianStarts,
-                                                               positions,
-                                                               grad,
-                                                               inverseHessian,
-                                                               scratchBuffers,
-                                                               energyOuts,
-                                                               statuses,
-                                                               stream,
-                                                               1.0,
-                                                               1.0);
-  } else if (maxAtoms <= 64) {
-    return launchKernelForSize<64, true, ForceFieldType::MMFF>(numMols,
-                                                               molIds,
-                                                               numIters,
-                                                               gradTol,
-                                                               scaleGrads,
-                                                               devTerms.data(),
-                                                               devSysIdx.data(),
-                                                               atomStarts,
-                                                               hessianStarts,
-                                                               positions,
-                                                               grad,
-                                                               inverseHessian,
-                                                               scratchBuffers,
-                                                               energyOuts,
-                                                               statuses,
-                                                               stream,
-                                                               1.0,
-                                                               1.0);
-  } else if (maxAtoms <= 96) {
-    return launchKernelForSize<96, true, ForceFieldType::MMFF>(numMols,
-                                                               molIds,
-                                                               numIters,
-                                                               gradTol,
-                                                               scaleGrads,
-                                                               devTerms.data(),
-                                                               devSysIdx.data(),
-                                                               atomStarts,
-                                                               hessianStarts,
-                                                               positions,
-                                                               grad,
-                                                               inverseHessian,
-                                                               scratchBuffers,
-                                                               energyOuts,
-                                                               statuses,
-                                                               stream,
-                                                               1.0,
-                                                               1.0);
-  } else if (maxAtoms <= 128) {
-    return launchKernelForSize<128, true, ForceFieldType::MMFF>(numMols,
-                                                                molIds,
-                                                                numIters,
-                                                                gradTol,
-                                                                scaleGrads,
-                                                                devTerms.data(),
-                                                                devSysIdx.data(),
-                                                                atomStarts,
-                                                                hessianStarts,
-                                                                positions,
-                                                                grad,
-                                                                inverseHessian,
-                                                                scratchBuffers,
-                                                                energyOuts,
-                                                                statuses,
-                                                                stream,
-                                                                1.0,
-                                                                1.0);
-  } else if (maxAtoms <= 256) {
-    return launchKernelForSize<256, false, ForceFieldType::MMFF>(numMols,
-                                                                 molIds,
-                                                                 numIters,
-                                                                 gradTol,
-                                                                 scaleGrads,
-                                                                 devTerms.data(),
-                                                                 devSysIdx.data(),
-                                                                 atomStarts,
-                                                                 hessianStarts,
-                                                                 positions,
-                                                                 grad,
-                                                                 inverseHessian,
-                                                                 scratchBuffers,
-                                                                 energyOuts,
-                                                                 statuses,
-                                                                 stream,
-                                                                 1.0,
-                                                                 1.0);
-  } else {
-    return launchKernelForSize<2048, false, ForceFieldType::MMFF>(numMols,
-                                                                  molIds,
-                                                                  numIters,
-                                                                  gradTol,
-                                                                  scaleGrads,
-                                                                  devTerms.data(),
-                                                                  devSysIdx.data(),
-                                                                  atomStarts,
-                                                                  hessianStarts,
-                                                                  positions,
-                                                                  grad,
-                                                                  inverseHessian,
-                                                                  scratchBuffers,
-                                                                  energyOuts,
-                                                                  statuses,
-                                                                  stream,
-                                                                  1.0,
-                                                                  1.0);
+  if (hasConstraints) {
+    return dispatchByMaxAtoms<ForceFieldType::MMFF, true>(numMols,
+                                                          molIds,
+                                                          maxAtoms,
+                                                          numIters,
+                                                          gradTol,
+                                                          scaleGrads,
+                                                          devTerms.data(),
+                                                          devSysIdx.data(),
+                                                          atomStarts,
+                                                          hessianStarts,
+                                                          positions,
+                                                          grad,
+                                                          inverseHessian,
+                                                          scratchBuffers,
+                                                          energyOuts,
+                                                          statuses,
+                                                          stream,
+                                                          1.0,
+                                                          1.0);
   }
+  return dispatchByMaxAtoms<ForceFieldType::MMFF, false>(numMols,
+                                                         molIds,
+                                                         maxAtoms,
+                                                         numIters,
+                                                         gradTol,
+                                                         scaleGrads,
+                                                         devTerms.data(),
+                                                         devSysIdx.data(),
+                                                         atomStarts,
+                                                         hessianStarts,
+                                                         positions,
+                                                         grad,
+                                                         inverseHessian,
+                                                         scratchBuffers,
+                                                         energyOuts,
+                                                         statuses,
+                                                         stream,
+                                                         1.0,
+                                                         1.0);
 }
 cudaError_t launchBfgsMinimizePerMolKernelETK(int                                             numMols,
                                               const int*                                      molIds,
@@ -946,123 +1018,25 @@ cudaError_t launchBfgsMinimizePerMolKernelETK(int                               
   const AsyncDevicePtr<DistGeom::Energy3DForceContribsDevicePtr> devTerms(terms, stream);
   const AsyncDevicePtr<DistGeom::BatchedIndices3DDevicePtr>      devSysIdx(systemIndices, stream);
 
-  // Dispatch to appropriate kernel based on max molecule size
-  // Use shared memory for <=128 atoms (in increments of 32), global memory for larger
-  if (maxAtoms <= 32) {
-    return launchKernelForSize<32, true, ForceFieldType::ETK>(numMols,
-                                                              molIds,
-                                                              numIters,
-                                                              gradTol,
-                                                              scaleGrads,
-                                                              devTerms.data(),
-                                                              devSysIdx.data(),
-                                                              atomStarts,
-                                                              hessianStarts,
-                                                              positions,
-                                                              grad,
-                                                              inverseHessian,
-                                                              scratchBuffers,
-                                                              energyOuts,
-                                                              statuses,
-                                                              stream,
-                                                              1.0,
-                                                              1.0);
-  } else if (maxAtoms <= 64) {
-    return launchKernelForSize<64, true, ForceFieldType::ETK>(numMols,
-                                                              molIds,
-                                                              numIters,
-                                                              gradTol,
-                                                              scaleGrads,
-                                                              devTerms.data(),
-                                                              devSysIdx.data(),
-                                                              atomStarts,
-                                                              hessianStarts,
-                                                              positions,
-                                                              grad,
-                                                              inverseHessian,
-                                                              scratchBuffers,
-                                                              energyOuts,
-                                                              statuses,
-                                                              stream,
-                                                              1.0,
-                                                              1.0);
-  } else if (maxAtoms <= 96) {
-    return launchKernelForSize<96, true, ForceFieldType::ETK>(numMols,
-                                                              molIds,
-                                                              numIters,
-                                                              gradTol,
-                                                              scaleGrads,
-                                                              devTerms.data(),
-                                                              devSysIdx.data(),
-                                                              atomStarts,
-                                                              hessianStarts,
-                                                              positions,
-                                                              grad,
-                                                              inverseHessian,
-                                                              scratchBuffers,
-                                                              energyOuts,
-                                                              statuses,
-                                                              stream,
-                                                              1.0,
-                                                              1.0);
-  } else if (maxAtoms <= 128) {
-    return launchKernelForSize<128, true, ForceFieldType::ETK>(numMols,
-                                                               molIds,
-                                                               numIters,
-                                                               gradTol,
-                                                               scaleGrads,
-                                                               devTerms.data(),
-                                                               devSysIdx.data(),
-                                                               atomStarts,
-                                                               hessianStarts,
-                                                               positions,
-                                                               grad,
-                                                               inverseHessian,
-                                                               scratchBuffers,
-                                                               energyOuts,
-                                                               statuses,
-                                                               stream,
-                                                               1.0,
-                                                               1.0);
-  } else if (maxAtoms <= 256) {
-    return launchKernelForSize<256, false, ForceFieldType::ETK>(numMols,
-                                                                molIds,
-                                                                numIters,
-                                                                gradTol,
-                                                                scaleGrads,
-                                                                devTerms.data(),
-                                                                devSysIdx.data(),
-                                                                atomStarts,
-                                                                hessianStarts,
-                                                                positions,
-                                                                grad,
-                                                                inverseHessian,
-                                                                scratchBuffers,
-                                                                energyOuts,
-                                                                statuses,
-                                                                stream,
-                                                                1.0,
-                                                                1.0);
-  } else {
-    return launchKernelForSize<2048, false, ForceFieldType::ETK>(numMols,
-                                                                 molIds,
-                                                                 numIters,
-                                                                 gradTol,
-                                                                 scaleGrads,
-                                                                 devTerms.data(),
-                                                                 devSysIdx.data(),
-                                                                 atomStarts,
-                                                                 hessianStarts,
-                                                                 positions,
-                                                                 grad,
-                                                                 inverseHessian,
-                                                                 scratchBuffers,
-                                                                 energyOuts,
-                                                                 statuses,
-                                                                 stream,
-                                                                 1.0,
-                                                                 1.0);
-  }
+  return dispatchByMaxAtoms<ForceFieldType::ETK, false>(numMols,
+                                                        molIds,
+                                                        maxAtoms,
+                                                        numIters,
+                                                        gradTol,
+                                                        scaleGrads,
+                                                        devTerms.data(),
+                                                        devSysIdx.data(),
+                                                        atomStarts,
+                                                        hessianStarts,
+                                                        positions,
+                                                        grad,
+                                                        inverseHessian,
+                                                        scratchBuffers,
+                                                        energyOuts,
+                                                        statuses,
+                                                        stream,
+                                                        1.0,
+                                                        1.0);
 }
 
 cudaError_t launchBfgsMinimizePerMolKernelDG(int                                           numMols,
@@ -1091,123 +1065,25 @@ cudaError_t launchBfgsMinimizePerMolKernelDG(int                                
   const AsyncDevicePtr<DistGeom::EnergyForceContribsDevicePtr> devTerms(terms, stream);
   const AsyncDevicePtr<DistGeom::BatchedIndicesDevicePtr>      devSysIdx(systemIndices, stream);
 
-  // Dispatch to appropriate kernel based on max molecule size
-  // Use shared memory for <=128 atoms (in increments of 32), global memory for larger
-  if (maxAtoms <= 32) {
-    return launchKernelForSize<32, true, ForceFieldType::DG>(numMols,
-                                                             molIds,
-                                                             numIters,
-                                                             gradTol,
-                                                             scaleGrads,
-                                                             devTerms.data(),
-                                                             devSysIdx.data(),
-                                                             atomStarts,
-                                                             hessianStarts,
-                                                             positions,
-                                                             grad,
-                                                             inverseHessian,
-                                                             scratchBuffers,
-                                                             energyOuts,
-                                                             statuses,
-                                                             stream,
-                                                             chiralWeight,
-                                                             fourthDimWeight);
-  } else if (maxAtoms <= 64) {
-    return launchKernelForSize<64, true, ForceFieldType::DG>(numMols,
-                                                             molIds,
-                                                             numIters,
-                                                             gradTol,
-                                                             scaleGrads,
-                                                             devTerms.data(),
-                                                             devSysIdx.data(),
-                                                             atomStarts,
-                                                             hessianStarts,
-                                                             positions,
-                                                             grad,
-                                                             inverseHessian,
-                                                             scratchBuffers,
-                                                             energyOuts,
-                                                             statuses,
-                                                             stream,
-                                                             chiralWeight,
-                                                             fourthDimWeight);
-  } else if (maxAtoms <= 96) {
-    return launchKernelForSize<96, true, ForceFieldType::DG>(numMols,
-                                                             molIds,
-                                                             numIters,
-                                                             gradTol,
-                                                             scaleGrads,
-                                                             devTerms.data(),
-                                                             devSysIdx.data(),
-                                                             atomStarts,
-                                                             hessianStarts,
-                                                             positions,
-                                                             grad,
-                                                             inverseHessian,
-                                                             scratchBuffers,
-                                                             energyOuts,
-                                                             statuses,
-                                                             stream,
-                                                             chiralWeight,
-                                                             fourthDimWeight);
-  } else if (maxAtoms <= 128) {
-    return launchKernelForSize<128, true, ForceFieldType::DG>(numMols,
-                                                              molIds,
-                                                              numIters,
-                                                              gradTol,
-                                                              scaleGrads,
-                                                              devTerms.data(),
-                                                              devSysIdx.data(),
-                                                              atomStarts,
-                                                              hessianStarts,
-                                                              positions,
-                                                              grad,
-                                                              inverseHessian,
-                                                              scratchBuffers,
-                                                              energyOuts,
-                                                              statuses,
-                                                              stream,
-                                                              chiralWeight,
-                                                              fourthDimWeight);
-  } else if (maxAtoms <= 256) {
-    return launchKernelForSize<256, false, ForceFieldType::DG>(numMols,
-                                                               molIds,
-                                                               numIters,
-                                                               gradTol,
-                                                               scaleGrads,
-                                                               devTerms.data(),
-                                                               devSysIdx.data(),
-                                                               atomStarts,
-                                                               hessianStarts,
-                                                               positions,
-                                                               grad,
-                                                               inverseHessian,
-                                                               scratchBuffers,
-                                                               energyOuts,
-                                                               statuses,
-                                                               stream,
-                                                               chiralWeight,
-                                                               fourthDimWeight);
-  } else {
-    return launchKernelForSize<2048, false, ForceFieldType::DG>(numMols,
-                                                                molIds,
-                                                                numIters,
-                                                                gradTol,
-                                                                scaleGrads,
-                                                                devTerms.data(),
-                                                                devSysIdx.data(),
-                                                                atomStarts,
-                                                                hessianStarts,
-                                                                positions,
-                                                                grad,
-                                                                inverseHessian,
-                                                                scratchBuffers,
-                                                                energyOuts,
-                                                                statuses,
-                                                                stream,
-                                                                chiralWeight,
-                                                                fourthDimWeight);
-  }
+  return dispatchByMaxAtoms<ForceFieldType::DG, false>(numMols,
+                                                       molIds,
+                                                       maxAtoms,
+                                                       numIters,
+                                                       gradTol,
+                                                       scaleGrads,
+                                                       devTerms.data(),
+                                                       devSysIdx.data(),
+                                                       atomStarts,
+                                                       hessianStarts,
+                                                       positions,
+                                                       grad,
+                                                       inverseHessian,
+                                                       scratchBuffers,
+                                                       energyOuts,
+                                                       statuses,
+                                                       stream,
+                                                       chiralWeight,
+                                                       fourthDimWeight);
 }
 
 }  // namespace nvMolKit

--- a/src/minimizer/bfgs_minimize_permol_kernels.h
+++ b/src/minimizer/bfgs_minimize_permol_kernels.h
@@ -24,7 +24,10 @@
 
 namespace nvMolKit {
 
-/// Launch per-molecule BFGS minimization kernel - MMFF specialization
+/// Launch per-molecule BFGS minimization kernel - MMFF specialization.
+/// `hasConstraints` selects between two specializations of the kernel: when false, the
+/// distance/position/angle/torsion constraint loops are compiled out, which lowers register
+/// pressure and improves occupancy on the common no-constraint path.
 cudaError_t launchBfgsMinimizePerMolKernel(int                                       numMols,
                                            const int*                                molIds,
                                            int                                       maxAtoms,
@@ -40,6 +43,7 @@ cudaError_t launchBfgsMinimizePerMolKernel(int                                  
                                            double*                                   inverseHessian,
                                            double**                                  scratchBuffers,
                                            double*                                   energyOuts,
+                                           bool                                      hasConstraints,
                                            int16_t*                                  statuses = nullptr,
                                            cudaStream_t                              stream   = nullptr);
 


### PR DESCRIPTION
The per-molecule MMFF and UFF energy/gradient device functions iterate over four optional constraint term types (distance, position, angle, torsion). When constraints are absent the loops still bring extra register pressure into the BFGS per-mol kernel, lowering occupancy.

Add a HasConstraints template parameter to MMFF::molEnergy / molGrad, UFF::molEnergy / molGrad, and the bfgsMinimizeKernel that drives the MMFF per-mol minimize. With if constexpr the constraint loops are compiled out of the no-constraint specialization. At launch time we inspect the host-visible sizes of the constraint device vectors via a new batchHasConstraints() helper and dispatch to the matching specialization. ETK and DG keep a single specialization since they do not consume MMFF-style constraint terms.