### PR TITLE
Fix int32 overflow in substruct pair indexing

### DIFF
--- a/src/substruct/substruct_results.h
+++ b/src/substruct/substruct_results.h
@@ -66,7 +66,7 @@ struct SubstructSearchConfig {
 struct SubstructSearchResults {
   /// Sparse storage: pairIndex -> vector of matches
   /// Each match is a vector<int> of target atom indices (one per query atom)
-  std::unordered_map<int, std::vector<std::vector<int>>> matches;
+  std::unordered_map<int64_t, std::vector<std::vector<int>>> matches;
 
   int numTargets = 0;
   int numQueries = 0;
@@ -81,7 +81,9 @@ struct SubstructSearchResults {
   }
 
   /// Compute flat pair index
-  [[nodiscard]] int pairIndex(int targetIdx, int queryIdx) const { return targetIdx * numQueries + queryIdx; }
+  [[nodiscard]] int64_t pairIndex(int targetIdx, int queryIdx) const {
+    return static_cast<int64_t>(targetIdx) * numQueries + queryIdx;
+  }
 
   /// Number of matches for this pair
   [[nodiscard]] int matchCount(int targetIdx, int queryIdx) const {
@@ -120,15 +122,19 @@ struct HasSubstructMatchResults {
   }
 
   /// Compute flat pair index
-  [[nodiscard]] int pairIndex(int targetIdx, int queryIdx) const { return targetIdx * numQueries + queryIdx; }
+  [[nodiscard]] int64_t pairIndex(int targetIdx, int queryIdx) const {
+    return static_cast<int64_t>(targetIdx) * numQueries + queryIdx;
+  }
 
   /// Check if target contains query as substructure
   [[nodiscard]] bool matches(int targetIdx, int queryIdx) const {
-    return hasMatch[pairIndex(targetIdx, queryIdx)] != 0;
+    return hasMatch[static_cast<size_t>(pairIndex(targetIdx, queryIdx))] != 0;
   }
 
   /// Set match result for a pair
-  void setMatch(int targetIdx, int queryIdx, bool value) { hasMatch[pairIndex(targetIdx, queryIdx)] = value ? 1 : 0; }
+  void setMatch(int targetIdx, int queryIdx, bool value) {
+    hasMatch[static_cast<size_t>(pairIndex(targetIdx, queryIdx))] = value ? 1 : 0;
+  }
 };
 
 }  // namespace nvMolKit

--- a/src/substruct/substruct_search.cu
+++ b/src/substruct/substruct_search.cu
@@ -1165,7 +1165,7 @@ void hasSubstructMatch(const std::vector<const RDKit::ROMol*>& targets,
 
   for (auto& [pairIdx, matches] : matchResults.matches) {
     if (!matches.empty()) {
-      results.hasMatch[pairIdx] = 1;
+      results.hasMatch[static_cast<size_t>(pairIdx)] = 1;
     }
   }
 }

--- a/src/substruct/substruct_search_internal.cpp
+++ b/src/substruct/substruct_search_internal.cpp
@@ -155,8 +155,8 @@ void processWithRDKitFallback(const RDKit::ROMol*       target,
   if (boolResults) {
     boolResults->setMatch(targetIdx, queryIdx, true);
   } else if (countResults) {
-    const int pairIdx        = targetIdx * results.numQueries + queryIdx;
-    (*countResults)[pairIdx] = matchCount;
+    const int64_t pairIdx                         = static_cast<int64_t>(targetIdx) * results.numQueries + queryIdx;
+    (*countResults)[static_cast<size_t>(pairIdx)] = matchCount;
   } else {
     std::vector<std::vector<int>> convertedMatches;
     convertedMatches.reserve(rdkitMatches.size());
@@ -399,9 +399,9 @@ void accumulateMiniBatchResultsCounts(GpuExecutor&               executor,
   std::lock_guard<std::mutex> lock(resultsMutex);
 
   for (int i = 0; i < executor.plan.numPairsInMiniBatch; ++i) {
-    const auto [targetIdx, queryIdx] = resolvePairIndices(i, ctx, hostBuffer);
-    const int globalPairIdx          = targetIdx * ctx.numQueries + queryIdx;
-    counts[globalPairIdx]            = hostBuffer.matchCounts[i];
+    const auto [targetIdx, queryIdx]           = resolvePairIndices(i, ctx, hostBuffer);
+    const int64_t globalPairIdx                = static_cast<int64_t>(targetIdx) * ctx.numQueries + queryIdx;
+    counts[static_cast<size_t>(globalPairIdx)] = hostBuffer.matchCounts[i];
   }
 }
 


### PR DESCRIPTION
For batches large enough that numTargets * numQueries exceeds INT32_MAX (e.g. 10M targets x 480 queries = 4.8B pairs), the flat pair index computed as `targetIdx * numQueries + queryIdx` wrapped to a negative int. That index was then sign-extended to size_t when used to subscript HasSubstructMatchResults::hasMatch and the counts vector, causing out-of-bounds writes and segfaults in hasSubstructMatch and countSubstructMatches. The same overflow corrupted unordered_map keys in SubstructSearchResults::matches.

Widen pairIndex computations and the map key type to int64_t. Cast to size_t at indexing sites. Kernel-side pair indices are unchanged because they operate in batch-local target coordinates bounded by batchSize.