### PR TITLE
Ship sm_103 SASS and fix cross-similarity dispatch on B300

### DIFF
--- a/cmake/cuda_targets.cmake
+++ b/cmake/cuda_targets.cmake
@@ -42,10 +42,11 @@ elseif(NVMOLKIT_CUDA_TARGET_MODE STREQUAL "full")
         STATUS "CUDA < 12.8 detected, Blackwell (100-real) arch not enabled")
     endif()
     if(_cuda_version_num GREATER_EQUAL 1209)
+      list(APPEND _nvmolkit_cuda_arch_list "103-real")
       list(APPEND _nvmolkit_cuda_arch_list "120")
       message(
         STATUS
-          "CUDA >= 12.9 detected, enabling Blackwell (120 + PTX) for forward compatibility"
+          "CUDA >= 12.9 detected, enabling Blackwell (103-real) and (120 + PTX) for forward compatibility"
       )
     endif()
   endif()
@@ -121,7 +122,15 @@ if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
   else()
     message(FATAL_ERROR "Failed to build detect_cuda_arch.cu")
   endif()
-  foreach(cc IN ITEMS 80 86 89 90 100 120)
+  foreach(
+    cc IN
+    ITEMS 80
+          86
+          89
+          90
+          100
+          103
+          120)
     if(_native_cc STREQUAL "${cc}")
       target_compile_definitions(nvmolkit_cuda_caps
                                  INTERFACE NVMOLKIT_CUDA_CC_${cc}=1)
@@ -131,7 +140,15 @@ if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
     endif()
   endforeach()
 else()
-  foreach(cc IN ITEMS 80 86 89 90 100 120)
+  foreach(
+    cc IN
+    ITEMS 80
+          86
+          89
+          90
+          100
+          103
+          120)
     string(REPLACE ";" " " _cuda_arch_str "${CMAKE_CUDA_ARCHITECTURES}")
     string(REGEX MATCH "(^| )${cc}(-real)?( |$)" _match "${_cuda_arch_str}")
     if(_match)

--- a/src/similarity_kernels.cu
+++ b/src/similarity_kernels.cu
@@ -56,6 +56,9 @@ bool supportsTensorOps(const int major, const int minor) {
   if (NVMOLKIT_CUDA_CC_100 && major == 10 && minor == 0) {
     return true;
   }
+  if (NVMOLKIT_CUDA_CC_103 && major == 10 && minor == 3) {
+    return true;
+  }
   if (NVMOLKIT_CUDA_CC_120 && major == 12 && minor == 0) {
     return true;
   }


### PR DESCRIPTION
On B300 the host's supportsTensorOps fell through with no NVMOLKIT_CUDA_CC_103 macro and picked the SIMT tile shape, while the device-side __CUDA_ARCH__ >= 800 guard still selected the BMMA kernel, producing NaN outputs from the cross-similarity kernels. Adds 103-real to the CUDA >= 12.9 arch list, defines NVMOLKIT_CUDA_CC_103 in both detect paths, and teaches supportsTensorOps about sm_103.