### PR TITLE
Update most links for domain name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nvMolKit
 
 ## Documentation
-Please see the official [NVIDIA nvMolKit Documentation](https://nvidia-digital-bio.github.io/nvMolKit/) for an overview of features, examples, and a detailed API reference.
+Please see the official [NVIDIA nvMolKit Documentation](https://nvidia-bionemo.github.io/nvMolKit/) for an overview of features, examples, and a detailed API reference.
 
 ## Cursor / agent skill
 
@@ -59,7 +59,7 @@ To install nvMolKit pinned to a particular RDKit:
 RDKIT_VERSION=2025.9.6
 NVMOLKIT_VERSION=0.5.0
 pip install nvmolkit==${NVMOLKIT_VERSION}+rdkit${RDKIT_VERSION} \
-    --extra-index-url https://nvidia-digital-bio.github.io/nvMolKit/wheels/rdkit${RDKIT_VERSION}/simple/
+    --extra-index-url https://nvidia-bionemo.github.io/nvMolKit/wheels/rdkit${RDKIT_VERSION}/simple/
 ```
 
 Replace `2025.9.6` with the RDKit version you want. Variants published for nvMolKit v0.5.0 include every version between 2025.03.6 and 2026.03.1.
@@ -234,7 +234,7 @@ CIBW_MANYLINUX_X86_64_IMAGE=nvmolkit-manylinux-cuda12:test \
 
 To narrow the matrix while iterating, set `CIBW_BUILD=cp312-manylinux_x86_64` (or whichever python tag you care about) before invoking the script. Wheels land in `wheelhouse/`.
 
-The full CI pipeline is at [`.github/workflows/pip-build.yml`](.github/workflows/pip-build.yml). It runs on demand (`workflow_dispatch` only), expands the (rdkit, python) matrix from [`admin/distribute/rdkit_build_matrix.yaml`](admin/distribute/rdkit_build_matrix.yaml), and pulls the pre-built manylinux+CUDA image from the org's GHCR (`ghcr.io/nvidia-digital-bio/nvmolkit-manylinux-cuda12`). The image is rebuilt and pushed manually when the Dockerfile changes; the build script header documents the push command.
+The full CI pipeline is at [`.github/workflows/pip-build.yml`](.github/workflows/pip-build.yml). It runs on demand (`workflow_dispatch` only), expands the (rdkit, python) matrix from [`admin/distribute/rdkit_build_matrix.yaml`](admin/distribute/rdkit_build_matrix.yaml), and pulls the pre-built manylinux+CUDA image from the org's GHCR (`ghcr.io/nvidia-bionemo/nvmolkit-manylinux-cuda12`). The image is rebuilt and pushed manually when the Dockerfile changes; the build script header documents the push command.
 
 Internally, cibuildwheel's `before-build` hook (see [`admin/distribute/cibuildwheel_before_build.sh`](admin/distribute/cibuildwheel_before_build.sh)) clones rdkit-pypi at the matching tag, runs [`admin/distribute/build_rdkit_recipe.sh`](admin/distribute/build_rdkit_recipe.sh) to reproduce its build (~30-60 min on first invocation; cached afterwards), pip-installs the matching rdkit wheel for runtime SONAME-matching libs, and stages everything at stable paths under `/tmp/nvmolkit_pip_inputs/`. setup.py picks those up via `NVMOLKIT_BUILD_AGAINST_PIP_*` env vars set in pyproject.toml's `[tool.cibuildwheel.linux].environment`.
 

--- a/agent-skills/nvmolkit-usage/SKILL.md
+++ b/agent-skills/nvmolkit-usage/SKILL.md
@@ -264,6 +264,6 @@ All conformers of each input molecule are minimized in one batch. Constraints at
 
 ## Going deeper
 
-- Full feature list, API reference, and guides: <https://nvidia-digital-bio.github.io/nvMolKit/>
-- What changed in each release: <https://nvidia-digital-bio.github.io/nvMolKit/changelog.html>
+- Full feature list, API reference, and guides: <https://nvidia-bionemo.github.io/nvMolKit/>
+- What changed in each release: <https://nvidia-bionemo.github.io/nvMolKit/changelog.html>
 - Worked examples (Jupyter notebooks): the `examples/` directory in the GitHub repo

--- a/docs/agent_skill.rst
+++ b/docs/agent_skill.rst
@@ -12,7 +12,7 @@ Get the skill
 -------------
 
 The skill lives at
-`agent-skills/nvmolkit-usage/ <https://github.com/NVIDIA-Digital-Bio/nvMolKit/tree/main/agent-skills/nvmolkit-usage>`_
+`agent-skills/nvmolkit-usage/ <https://github.com/NVIDIA-BioNeMo/nvMolKit/tree/main/agent-skills/nvmolkit-usage>`_
 in the nvMolKit GitHub repo.
 
 Copy that directory into one of:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,7 +63,7 @@ For more fully-fledged examples, check out the Jupyter notebooks in the `example
 
 Source Code
 -----------
-nvMolKit is open source under the Apache License, and is available on `GitHub <https://github.com/NVIDIA-Digital-Bio/nvMolKit>`_.
+nvMolKit is open source under the Apache License, and is available on `GitHub <https://github.com/NVIDIA-BioNeMo/nvMolKit>`_.
 
 .. _installation:
 
@@ -115,7 +115,7 @@ To install nvMolKit pinned to a particular RDKit:
     RDKIT_VERSION=2025.9.6
     NVMOLKIT_VERSION=0.5.0
     pip install nvmolkit==${NVMOLKIT_VERSION}+rdkit${RDKIT_VERSION} \
-        --extra-index-url https://nvidia-digital-bio.github.io/nvMolKit/wheels/rdkit${RDKIT_VERSION}/simple/
+        --extra-index-url https://nvidia-bionemo.github.io/nvMolKit/wheels/rdkit${RDKIT_VERSION}/simple/
 
 Replace ``2025.9.6`` with the RDKit version you want. Variants published for
 nvMolKit v0.5.0 include every version between 2025.03.6 and 2026.03.1.
@@ -124,7 +124,7 @@ nvMolKit v0.5.0 include every version between 2025.03.6 and 2026.03.1.
 From Source
 ^^^^^^^^^^^
 
-nvMolKit can be installed from source using a C++ and CUDA compiler. See installation instructions in the `GitHub README <https://github.com/NVIDIA-Digital-Bio/nvMolKit>`_.
+nvMolKit can be installed from source using a C++ and CUDA compiler. See installation instructions in the `GitHub README <https://github.com/NVIDIA-BioNeMo/nvMolKit>`_.
 
 
 Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ changes in place, consistent with RDKit.
 An NVIDIA GPU with compute capability 7.0 (Volta) or newer and a Linux
 environment with CUDA 12 are required. For installation options, API reference, and
 examples, see the
-[project documentation](https://nvidia-digital-bio.github.io/nvMolKit/).
+[project documentation](https://nvidia-bionemo.github.io/nvMolKit/).
 """, content-type = "text/markdown" }
 license = "Apache-2.0"
 authors = [
@@ -62,11 +62,11 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://nvidia-digital-bio.github.io/nvMolKit/"
-Documentation = "https://nvidia-digital-bio.github.io/nvMolKit/"
-Repository = "https://github.com/NVIDIA-Digital-Bio/nvMolKit"
-Issues = "https://github.com/NVIDIA-Digital-Bio/nvMolKit/issues"
-Changelog = "https://github.com/NVIDIA-Digital-Bio/nvMolKit/releases"
+Homepage = "https://nvidia-bionemo.github.io/nvMolKit/"
+Documentation = "https://nvidia-bionemo.github.io/nvMolKit/"
+Repository = "https://github.com/NVIDIA-BioNeMo/nvMolKit"
+Issues = "https://github.com/NVIDIA-BioNeMo/nvMolKit/issues"
+Changelog = "https://github.com/NVIDIA-BioNeMo/nvMolKit/releases"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Exceptions are:

1. Changelog - those links redirect fine
2. Docker container instructions, we need to actually push to the new package registry, will do offline then follow up with a docs change