### PR TITLE
Fix fingerprinting when all molecules in the batch hit the rdkit fallback path

### DIFF
--- a/nvmolkit/tests/test_fingerprints.py
+++ b/nvmolkit/tests/test_fingerprints.py
@@ -145,3 +145,31 @@ def test_gh_issue_84():
         gen = MorganFingerprintGenerator(radius=radius, fpSize=fp_size)
         bits = unpack_fingerprint(gen.GetFingerprints([mol]).torch()).sum().item()
         assert bits > 0, f"Got empty fingerprint for BINAP on attempt {i}"
+
+
+def test_gh_issue_195():
+    """Regression test for https://github.com/NVIDIA-BioNeMo/nvMolKit/issues/195.
+
+    A batch containing only molecules larger than the 128 atom/bond GPU buckets
+    used to produce empty fingerprints.
+    """
+    radius = 3
+    fp_size = 2048
+
+    large_mol = Chem.MolFromSmiles("NCC(=O)" * 40)
+    assert large_mol is not None
+    assert large_mol.GetNumAtoms() >= 128 or large_mol.GetNumBonds() >= 128
+
+    rdkit_gen = rdFingerprintGenerator.GetMorganGenerator(radius=radius, fpSize=fp_size)
+    ref_bits = rdkit_gen.GetFingerprint(large_mol).ToList()
+    assert sum(ref_bits) > 0
+
+    nvmolkit_gen = MorganFingerprintGenerator(radius=radius, fpSize=fp_size)
+
+    for batch in ([large_mol], [large_mol, large_mol]):
+        unpacked = unpack_fingerprint(nvmolkit_gen.GetFingerprints(batch).torch())
+        torch.cuda.synchronize()
+        assert unpacked.shape == (len(batch), fp_size)
+        for row in range(len(batch)):
+            assert unpacked[row].sum().item() > 0, "Large-only batch produced an empty fingerprint"
+            torch.testing.assert_close(ref_bits, unpacked[row].to(int).tolist())

--- a/src/morgan_fingerprint_gpu.cpp
+++ b/src/morgan_fingerprint_gpu.cpp
@@ -266,10 +266,18 @@ AsyncDeviceVector<FlatBitVect<fpSize>> computeFingerprintsCuImpl(const std::vect
       workLarge.push_back(i);
     }
   }
-  const size_t                    numThreads32    = (work32.size() + dispatchChunkSize - 1) / dispatchChunkSize;
-  const size_t                    numThreads64    = (work64.size() + dispatchChunkSize - 1) / dispatchChunkSize;
-  const size_t                    numThreads128   = (work128.size() + dispatchChunkSize - 1) / dispatchChunkSize;
-  const size_t                    numThreadsTotal = numThreads32 + numThreads64 + numThreads128;
+  const size_t numThreads32    = (work32.size() + dispatchChunkSize - 1) / dispatchChunkSize;
+  const size_t numThreads64    = (work64.size() + dispatchChunkSize - 1) / dispatchChunkSize;
+  const size_t numThreads128   = (work128.size() + dispatchChunkSize - 1) / dispatchChunkSize;
+  size_t       numThreadsTotal = numThreads32 + numThreads64 + numThreads128;
+  // Large molecules are drained from the shared workLarge queue inside the worker
+  // loop below, which only runs numThreadsTotal iterations. When every molecule is
+  // large there is no small/medium work, so without dedicated iterations the queue
+  // would never be drained and those molecules would get empty fingerprints. Spread
+  // the drain across the available threads in that case.
+  if (numThreadsTotal == 0) {
+    numThreadsTotal = std::min(workLarge.size(), static_cast<size_t>(nThreadsActual));
+  }
   detail::OpenMPExceptionRegistry exceptionRegistry;
 
 #pragma omp parallel for num_threads(nThreadsActual) default(none) shared(numThreadsTotal,     \


### PR DESCRIPTION
Partial fix for #195