### PR TITLE
Fix dead RDKIT_NEW_FLAG_API gate in ETKDG chirality and bounds code

### DIFF
--- a/rdkit_extensions/CMakeLists.txt
+++ b/rdkit_extensions/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(mmff_optimize INTERFACE ${RDKit_LIBS} CUDA::cudart
 add_library(rdkit_dist_geom_flattened dist_geom_flattened_builder.cpp)
 target_link_libraries(
   rdkit_dist_geom_flattened
-  PRIVATE ${RDKit_LIBS} device_vector
+  PRIVATE ${RDKit_LIBS} device_vector nvmolkit_versions
   PUBLIC dist_geom)
 
 add_library(rdkit_bounds_matrix bounds_matrix.cpp)

--- a/rdkit_extensions/dist_geom_flattened_builder.cpp
+++ b/rdkit_extensions/dist_geom_flattened_builder.cpp
@@ -9,6 +9,8 @@
 #include <map>
 #include <sstream>
 
+#include "versions.h"
+
 // No clang-tidy for 1:1 RDKit ports.
 // NOLINTBEGIN
 
@@ -444,8 +446,8 @@ void addLongRangeDistanceConstraints(nvMolKit::DistGeom::Energy3DForceContribsHo
   for (unsigned int i = 1; i < numAtoms; ++i) {
     for (unsigned int j = 0; j < i; ++j) {
       if (!atomPairs[j * numAtoms + i]) {
-        const double l = mmat.getLowerBound(i, j);
-        const double u = mmat.getUpperBound(i, j);
+        double l = mmat.getLowerBound(i, j);
+        double u = mmat.getUpperBound(i, j);
 #if RDKIT_NEW_FLAG_API
         double fdist = etkdgDetails.boundsMatForceScaling * 10.0;
         if (!etkdgDetails.constrainedAtoms.empty() && etkdgDetails.constrainedAtoms[i] &&

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,7 @@ target_link_libraries(
           ff_kernel_utils
           dist_geom
           rdkit_dist_geom_flattened
+          nvmolkit_versions
           etkdg)
 
 add_library(etkdg etkdg.cpp)

--- a/src/etkdg_stage_stereochem_checks.cu
+++ b/src/etkdg_stage_stereochem_checks.cu
@@ -15,6 +15,7 @@
 
 #include "src/etkdg_stage_stereochem_checks.h"
 #include "src/forcefields/kernel_utils.cuh"
+#include "versions.h"
 namespace nvMolKit {
 namespace detail {
 
@@ -466,7 +467,7 @@ void ETKDGChiralCheckBase::loadChiralDataset(const ETKDGContext&           ctx,
       idx2Host.push_back(check->d_idx2 + atomIndexOffset);
       idx3Host.push_back(check->d_idx3 + atomIndexOffset);
       idx4Host.push_back(check->d_idx4 + atomIndexOffset);
-#if (RDKIT_VERSION_MAJOR > 2024 || (RDKIT_VERSION_MAJOR == 2024 && RDKIT_VERSION_MINOR >= 9))
+#if RDKIT_NEW_FLAG_API
       structureFlagsHost.push_back(check->d_structureFlags);
 #else
       structureFlagsHost.push_back(0);

--- a/src/versions.h.in
+++ b/src/versions.h.in
@@ -6,13 +6,11 @@
 #define RDKIT_VERSION_PATCH @RDKit_VERSION_PATCH@
 
 
-namespace nvMolKit {
 // Account for API break adding d_structureFlags. Our GPU codepath always includes it, but
 // for an earlier version we pass in 1.0 to not change results. The CPU API must be adapted here and in
-// chiralty ETKDG code.
-constexpr bool RDKIT_NEW_FLAG_API  = (RDKIT_VERSION_MAJOR > 2024 || (RDKIT_VERSION_MAJOR == 2024 && RDKIT_VERSION_MINOR >= 9));
-
-
-} // namespace nvMolKit
+// chiralty ETKDG code. This must be a preprocessor macro: it gates calls to the ChiralSet structureFlags
+// constructor overload, which only exists on RDKit >= 2024.09, so the branch cannot be compiled on older
+// versions. Consumers select the codepath with `#if RDKIT_NEW_FLAG_API`.
+#define RDKIT_NEW_FLAG_API (RDKIT_VERSION_MAJOR > 2024 || (RDKIT_VERSION_MAJOR == 2024 && RDKIT_VERSION_MINOR >= 9))
 
 #endif  // NVMOLKIT_VERSIONS_H


### PR DESCRIPTION
GH issue 202: a non-negligible fraction of molecules embedded to zero conformers. RDKIT_NEW_FLAG_API was a constexpr bool but consumed with #if, which the preprocessor evaluates as 0, and etkdg_stages and rdkit_dist_geom_flattened never linked nvmolkit_versions so versions.h was not even visible. The gate was therefore always off.

findChiralSets never set d_structureFlags and loadChiralDataset never read it, so fused-small-ring tetrahedral centers used volScale 1.0 instead of the 0.25 RDKit applies and were deterministically rejected at the tetrahedral check. The same gate guards the constrained tight-bounds branch in addLongRangeDistanceConstraints, which assigns to l and u; those are now non-const so the branch compiles.