### PR TITLE
Fix MMFF/UFF optimization modules failing to import standalone

### DIFF
--- a/nvmolkit/_mmffOptimization.pyi
+++ b/nvmolkit/_mmffOptimization.pyi
@@ -3,7 +3,7 @@ from rdkit.Chem import Mol
 
 def MMFFOptimizeMoleculesConfs(
     molecules: List[Mol],
-    maxIters: int = 200,
-    properties: Any = None,
-    hardwareOptions: Any = None
+    maxIters: int,
+    properties: Any,
+    hardwareOptions: Any,
 ) -> List[List[float]]: ...

--- a/nvmolkit/_uffOptimization.pyi
+++ b/nvmolkit/_uffOptimization.pyi
@@ -6,8 +6,8 @@ from nvmolkit._embedMolecules import BatchHardwareOptions
 
 def UFFOptimizeMoleculesConfs(
     molecules: List[Mol],
-    maxIters: int = 1000,
-    vdwThresholds: List[float] = ...,
-    ignoreInterfragInteractions: List[bool] = ...,
-    hardwareOptions: BatchHardwareOptions = ...,
+    maxIters: int,
+    vdwThresholds: List[float],
+    ignoreInterfragInteractions: List[bool],
+    hardwareOptions: BatchHardwareOptions,
 ) -> List[List[float]]: ...

--- a/nvmolkit/mmffOptimization.cpp
+++ b/nvmolkit/mmffOptimization.cpp
@@ -35,10 +35,7 @@ BOOST_PYTHON_MODULE(_mmffOptimization) {
         nvMolKit::MMFF::MMFFOptimizeMoleculesConfsBfgs(molsVec, maxIters, properties, hardwareOptions);
       return nvMolKit::vectorOfVectorsToList(result);
     },
-    (bp::arg("molecules"),
-     bp::arg("maxIters")        = 200,
-     bp::arg("properties")      = bp::list(),
-     bp::arg("hardwareOptions") = nvMolKit::BatchHardwareOptions()),
+    (bp::arg("molecules"), bp::arg("maxIters"), bp::arg("properties"), bp::arg("hardwareOptions")),
     "Optimize conformers for multiple molecules using MMFF force field.\n"
     "\n"
     "Args:\n"
@@ -74,10 +71,10 @@ BOOST_PYTHON_MODULE(_mmffOptimization) {
       return nvMolKit::buildOwningDevice3DResult(*result.device);
     },
     (bp::arg("molecules"),
-     bp::arg("maxIters")        = 200,
-     bp::arg("properties")      = bp::list(),
-     bp::arg("hardwareOptions") = nvMolKit::BatchHardwareOptions(),
-     bp::arg("targetGpu")       = -1),
+     bp::arg("maxIters"),
+     bp::arg("properties"),
+     bp::arg("hardwareOptions"),
+     bp::arg("targetGpu")),
     "Optimize conformers for multiple molecules using MMFF force field, returning device-resident "
     "results.\n"
     "\n"

--- a/nvmolkit/tests/test_import_order.py
+++ b/nvmolkit/tests/test_import_order.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "nvmolkit.mmffOptimization",
+        "nvmolkit.uffOptimization",
+    ],
+)
+def test_module_imports_as_first_nvmolkit_import(module_name):
+    """Importing an optimization module first must not require nvmolkit.types to be imported first.
+
+    The native extensions declare BatchHardwareOptions default arguments whose to-Python converter
+    is registered by nvmolkit._embedMolecules. Each import runs in a fresh interpreter so the
+    converter is not already registered by an earlier import in this test session.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module_name}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"Importing {module_name} as the first nvMolKit import failed:\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/nvmolkit/uffOptimization.cpp
+++ b/nvmolkit/uffOptimization.cpp
@@ -39,10 +39,10 @@ BOOST_PYTHON_MODULE(_uffOptimization) {
       return nvMolKit::vectorOfVectorsToList(result);
     },
     (bp::arg("molecules"),
-     bp::arg("maxIters") = 1000,
+     bp::arg("maxIters"),
      bp::arg("vdwThresholds"),
      bp::arg("ignoreInterfragInteractions"),
-     bp::arg("hardwareOptions") = nvMolKit::BatchHardwareOptions()),
+     bp::arg("hardwareOptions")),
     "Optimize conformers for multiple molecules using UFF force field.\n"
     "\n"
     "Args:\n"
@@ -83,11 +83,11 @@ BOOST_PYTHON_MODULE(_uffOptimization) {
       return nvMolKit::buildOwningDevice3DResult(*result.device);
     },
     (bp::arg("molecules"),
-     bp::arg("maxIters") = 1000,
+     bp::arg("maxIters"),
      bp::arg("vdwThresholds"),
      bp::arg("ignoreInterfragInteractions"),
-     bp::arg("hardwareOptions") = nvMolKit::BatchHardwareOptions(),
-     bp::arg("targetGpu")       = -1),
+     bp::arg("hardwareOptions"),
+     bp::arg("targetGpu")),
     "Optimize conformers for multiple molecules using UFF force field, returning device-resident "
     "results.\n"
     "\n"


### PR DESCRIPTION
The _mmffOptimization and _uffOptimization bindings declared BatchHardwareOptions default argument values. Boost.Python converts default values to Python when a function is registered, which needs a to-Python converter that only _embedMolecules registers, so importing either module before nvmolkit.types raised "No to_python converter found for nvMolKit::BatchHardwareOptions". The Python wrappers already supply every argument, so the native defaults are dropped, and a regression test imports each module first in a fresh interpreter.

Fixes #211 