### PR TITLE
Fix recursive SMARTS extraction with pip RDKit

### DIFF
--- a/src/substruct/molecules.cpp
+++ b/src/substruct/molecules.cpp
@@ -15,6 +15,12 @@
 
 #include "src/substruct/molecules.h"
 
+// RDConfig defines RDK_BUILD_THREADSAFE_SSS, which changes RecursiveStructureQuery layout.
+// It must be visible before QueryOps is included through QueryAtom.h.
+// clang-format off
+#include <RDGeneral/RDConfig.h>
+// clang-format on
+
 #include <GraphMol/MolOps.h>
 #include <GraphMol/QueryAtom.h>
 #include <GraphMol/QueryOps.h>

--- a/tests/test_substruct_search.cu
+++ b/tests/test_substruct_search.cu
@@ -1448,6 +1448,29 @@ TEST_P(RecursiveSubstructureSearchTest, NestedRecursiveBatchProcessing) {
   }
 }
 
+TEST_P(RecursiveSubstructureSearchTest, AmideRecursiveQueryMatchesSmallTargets) {
+  std::vector<std::unique_ptr<RDKit::ROMol>> targetMols;
+  std::vector<std::unique_ptr<RDKit::ROMol>> queryMols;
+
+  parseMolecules({"CC(=O)N", "NC=O", "CC(=O)O"}, {"[$(NC=O)]"}, targetMols, queryMols);
+
+  HasSubstructMatchResults boolResults;
+  hasSubstructMatch(getRawPtrs(targetMols), getRawPtrs(queryMols), boolResults, algorithm(), stream_.stream());
+
+  EXPECT_TRUE(boolResults.matches(0, 0));
+  EXPECT_TRUE(boolResults.matches(1, 0));
+  EXPECT_FALSE(boolResults.matches(2, 0));
+
+  std::vector<int> counts;
+  countSubstructMatches(getRawPtrs(targetMols), getRawPtrs(queryMols), counts, algorithm(), stream_.stream());
+
+  ASSERT_EQ(counts.size(), targetMols.size() * queryMols.size());
+  for (size_t t = 0; t < targetMols.size(); ++t) {
+    const auto rdkitMatches = getRDKitSubstructMatches(*targetMols[t], *queryMols[0], false);
+    EXPECT_EQ(counts[t], static_cast<int>(rdkitMatches.size())) << "target " << t;
+  }
+}
+
 TEST_P(SubstructureSearchTest, InvalidSlotsPerRunnerThrows) {
   std::vector<std::unique_ptr<RDKit::ROMol>> targetMols;
   std::vector<std::unique_ptr<RDKit::ROMol>> queryMols;


### PR DESCRIPTION
This was an ABI issue - a transitive flag is important for the structure of RDKit data that wasn't being included. It's an RDKit issue but we can fix it by manually including the flag we need to avoid the ABI mismatch. 

Was not present in conda-forge builds by luck. 

Fixes #208 