### PR TITLE
Document torch CUDA backend install fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ If you use [Cursor](https://cursor.com/) (or another agent that supports the `SK
 **IMPORTANT**: nvMolKit requires an NVIDIA GPU with compute capability 7.0 (V100) or higher to run. Check your GPU's compute capability [here](https://developer.nvidia.com/cuda-gpus).
 It also requires a CUDA Driver sufficient for CUDA 12.6 or later (driver version >=560.28), though some backwards compatibility may be supported, see the [CUDA compatibility guide](https://docs.nvidia.com/deploy/cuda-compatibility/index.html).
 
+nvMolKit uses PyTorch for CUDA tensors, so the installed PyTorch CUDA backend must also be compatible with your driver. Package managers may otherwise select a CUDA backend that is newer than your host driver supports.
+
+- **Conda**: install the conda-forge `pytorch-gpu` metapackage and pin `cuda-version` when needed.
+- **pip**: choose the CUDA backend from the [PyTorch local install selector](https://pytorch.org/get-started/locally/) or the [previous versions page](https://pytorch.org/get-started/previous-versions/), install that `torch` wheel first, then install nvMolKit.
+- **uv**: pass `--torch-backend` during install, for example `uv pip install --torch-backend=cu128 nvmolkit`.
+
 ### Conda-forge Installation (Recommended)
 
 Conda is the recommended way to install nvMolKit, matching the recommended distribution mechanism of the RDKit. First, ensure 
@@ -25,11 +31,11 @@ conda install -c conda-forge nvmolkit
 ```
 
 **Note**: If your system's CUDA driver does not support CUDA 13, the default install may
-resolve `cuda-version=13` and fall back to a CPU-only PyTorch. To ensure GPU-accelerated
-PyTorch is installed:
+resolve `cuda-version=13` and leave you with an unusable or CPU-only PyTorch. To ensure
+GPU-accelerated PyTorch is installed:
 
 ```bash
-conda install -c conda-forge nvmolkit cuda-version=12.6
+conda install -c conda-forge nvmolkit pytorch-gpu cuda-version=12.6
 ```
 Choose a `cuda-version` that is **≤** the CUDA version reported by `nvidia-smi` and that
 has a matching PyTorch build on conda-forge. See the
@@ -38,9 +44,19 @@ to find supported CUDA versions.
 
 ### Pip Installation
 
+Published binary wheels are available for CPython 3.11-3.14. The nvMolKit pip
+wheels are built with CUDA Toolkit 12.9 and depend on CUDA 12 runtime packages.
+For pip environments, install a PyTorch CUDA 12 wheel supported by your driver
+before installing nvMolKit. For example, with PyTorch's CUDA 12.8 backend:
+
 ```bash
-pip install nvmolkit
+python -m pip install torch --index-url https://download.pytorch.org/whl/cu128
+python -m pip install nvmolkit
+python -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())"
 ```
+
+Replace `cu128` with another CUDA 12 backend from the PyTorch install page if that is
+compatible with your driver.
 
 The wheel published to PyPI is built against a single RDKit release per
 nvMolKit version (RDKit 2026.03.1 for nvMolKit v0.5.0), due to versioning
@@ -237,4 +253,3 @@ To narrow the matrix while iterating, set `CIBW_BUILD=cp312-manylinux_x86_64` (o
 The full CI pipeline is at [`.github/workflows/pip-build.yml`](.github/workflows/pip-build.yml). It runs on demand (`workflow_dispatch` only), expands the (rdkit, python) matrix from [`admin/distribute/rdkit_build_matrix.yaml`](admin/distribute/rdkit_build_matrix.yaml), and pulls the pre-built manylinux+CUDA image from the org's GHCR (`ghcr.io/nvidia-bionemo/nvmolkit-manylinux-cuda12`). The image is rebuilt and pushed manually when the Dockerfile changes; the build script header documents the push command.
 
 Internally, cibuildwheel's `before-build` hook (see [`admin/distribute/cibuildwheel_before_build.sh`](admin/distribute/cibuildwheel_before_build.sh)) clones rdkit-pypi at the matching tag, runs [`admin/distribute/build_rdkit_recipe.sh`](admin/distribute/build_rdkit_recipe.sh) to reproduce its build (~30-60 min on first invocation; cached afterwards), pip-installs the matching rdkit wheel for runtime SONAME-matching libs, and stages everything at stable paths under `/tmp/nvmolkit_pip_inputs/`. setup.py picks those up via `NVMOLKIT_BUILD_AGAINST_PIP_*` env vars set in pyproject.toml's `[tool.cibuildwheel.linux].environment`.
-

--- a/agent-skills/nvmolkit-usage/SKILL.md
+++ b/agent-skills/nvmolkit-usage/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: nvmolkit-usage
-description: Write code that calls the installed nvMolKit Python API for GPU-accelerated, batched RDKit-style operations - Morgan fingerprints, Tanimoto/cosine similarity, ETKDG conformer embedding, MMFF/UFF optimization, TFD, conformer RMSD, Butina clustering, and substructure search. Use when the user is importing `nvmolkit.*`, debugging an `nvmolkit` call, choosing between nvMolKit and RDKit for a batched cheminformatics workflow, or wiring nvMolKit results into a torch/numpy pipeline. Out of scope: building nvMolKit from source.
+description: >-
+  Write code that calls the installed nvMolKit Python API for GPU-accelerated,
+  batched RDKit-style operations - Morgan fingerprints, Tanimoto/cosine
+  similarity, ETKDG conformer embedding, MMFF/UFF optimization, TFD, conformer
+  RMSD, Butina clustering, and substructure search. Use when the user is
+  importing `nvmolkit.*`, debugging an `nvmolkit` call, choosing between
+  nvMolKit and RDKit for a batched cheminformatics workflow, or wiring nvMolKit
+  results into a torch/numpy pipeline. Out of scope: building nvMolKit from
+  source.
 license: Apache-2.0
 metadata:
   owner: Kevin Boyd (@scal444)
@@ -30,6 +38,12 @@ Plain RDKit is usually the better choice for single-molecule one-offs or workflo
 - A working `torch` install with CUDA support (nvMolKit returns GPU tensors via `torch`'s CUDA array interface).
 
 If CUDA is unavailable, nvMolKit calls raise. There is no CPU fallback - if the user needs one, use RDKit directly for that path.
+
+When helping with installation, make the user choose a PyTorch CUDA backend that the host driver supports before installing nvMolKit. nvMolKit's PyPI wheels are built with CUDA Toolkit 12.9 and depend on CUDA 12 runtime packages, but pip/uv can still select a CUDA 13 PyTorch wheel unless the install command says otherwise.
+
+- Conda: prefer conda-forge `pytorch-gpu`; pin `cuda-version=12.6` or another CUDA version supported by the driver.
+- pip: send the user to the PyTorch install selector (`https://pytorch.org/get-started/locally/`) or previous-versions page (`https://pytorch.org/get-started/previous-versions/`) to install `torch` for a CUDA 12.x backend before installing nvMolKit.
+- uv: install nvMolKit with an explicit backend, e.g. `uv pip install --torch-backend=cu128 nvmolkit`.
 
 ## Verify the install before writing real code
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,6 +75,19 @@ Installation
    nvMolKit requires an NVIDIA GPU with compute capability 7.0 (V100) or higher. You can check your GPU's compute capability at the `NVIDIA CUDA GPUs page <https://developer.nvidia.com/cuda-gpus>`_.
    A CUDA Driver compatible with CUDA 12.6 or later is also required (driver version >=560.28). Some degree of backward compatibility may be available; for details, see the `CUDA compatibility guide <https://docs.nvidia.com/deploy/cuda-compatibility/index.html>`_.
 
+nvMolKit uses PyTorch for CUDA tensors, so the installed PyTorch CUDA backend
+must also be compatible with your driver. Package managers may otherwise select
+a CUDA backend that is newer than your host driver supports.
+
+* **Conda**: install the conda-forge ``pytorch-gpu`` metapackage and pin
+  ``cuda-version`` when needed.
+* **pip**: choose the CUDA backend from the `PyTorch local install selector
+  <https://pytorch.org/get-started/locally/>`_ or the `previous versions page
+  <https://pytorch.org/get-started/previous-versions/>`_, install that
+  ``torch`` wheel first, then install nvMolKit.
+* **uv**: pass ``--torch-backend`` during install, for example
+  ``uv pip install --torch-backend=cu128 nvmolkit``.
+
 Conda Forge
 ^^^^^^^^^^^
 
@@ -87,13 +100,30 @@ To install with conda, run::
 
     conda install -c conda-forge nvmolkit
 
+If your system's CUDA driver does not support CUDA 13, pin a CUDA 12 backend and
+include conda-forge's ``pytorch-gpu`` metapackage::
+
+    conda install -c conda-forge nvmolkit pytorch-gpu cuda-version=12.6
+
+Choose a ``cuda-version`` that is less than or equal to the CUDA version
+reported by ``nvidia-smi`` and that has a matching PyTorch build on conda-forge.
 
 Pip Installation
 ^^^^^^^^^^^^^^^^
 
+Published binary wheels are available for CPython 3.11-3.14. The nvMolKit pip
+wheels are built with CUDA Toolkit 12.9 and depend on CUDA 12 runtime packages.
+For pip environments, install a PyTorch CUDA 12 wheel supported by your driver
+before installing nvMolKit. For example, with PyTorch's CUDA 12.8 backend:
+
 .. code-block:: bash
 
-    pip install nvmolkit
+    python -m pip install torch --index-url https://download.pytorch.org/whl/cu128
+    python -m pip install nvmolkit
+    python -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())"
+
+Replace ``cu128`` with another CUDA 12 backend from the PyTorch install page if
+that is compatible with your driver.
 
 The wheel published to PyPI is built against a single RDKit release per
 nvMolKit version (RDKit 2026.03.1 for nvMolKit v0.5.0), due to versioning


### PR DESCRIPTION
Covers pip, uv, and conda. Minimal details as needed, we're not trying to reproduce the whole build instructions, just the most common issues. 