### PR TITLE
Fix DG torsion sixth-order gradient, adjust tests for RDKit mismatch

### DIFF
--- a/src/forcefields/dist_geom_kernels_device.cuh
+++ b/src/forcefields/dist_geom_kernels_device.cuh
@@ -522,7 +522,7 @@ static __device__ __forceinline__ void torsionAngleGrad(const double* pos,
      3.0 * forceConstants[2] * signs[2] * (4.0 * cosPhi2 * sinPhi - sinPhi) -
      4.0 * forceConstants[3] * signs[3] * (8.0 * cosPhi3 * sinPhi - 4.0 * cosPhi * sinPhi) -
      5.0 * forceConstants[4] * signs[4] * (16.0 * cosPhi4 * sinPhi - 12.0 * cosPhi2 * sinPhi + sinPhi) -
-     6.0 * forceConstants[4] * signs[4] * (32.0 * cosPhi5 * sinPhi - 32.0 * cosPhi3 * sinPhi + 6.0 * sinPhi));
+     6.0 * forceConstants[5] * signs[5] * (32.0 * cosPhi5 * sinPhi - 32.0 * cosPhi3 * sinPhi + 6.0 * cosPhi * sinPhi));
 
   const double sinTerm = -dE_dPhi * (isDoubleZero(sinPhi) ? (1.0 / cosPhi) : (1.0 / sinPhi));
 

--- a/tests/test_distgeom_kernels.cu
+++ b/tests/test_distgeom_kernels.cu
@@ -456,6 +456,8 @@ std::vector<std::vector<double>> splitCombinedGrads(const std::vector<double>& c
   return splitGrads;
 }
 
+std::vector<double> pad3Dto4D(const std::vector<double>& positions, double value);
+
 // Reference implementation for 3D ETKDG terms
 std::unique_ptr<ForceFields::ForceField> setup3DReferenceFF(
   RDKit::ROMol*                        mol,
@@ -567,6 +569,68 @@ std::unique_ptr<ForceFields::ForceField> setup3DReferenceFF(
   }
 
   return referenceForceField;
+}
+
+std::unique_ptr<ForceFields::ForceField> setupPlain3DReferenceFF(
+  RDKit::ROMol*                        mol,
+  const DGeomHelpers::EmbedParameters& params = DGeomHelpers::ETDG) {
+  auto& conf = mol->getConformer();
+
+  auto referenceForceField = std::make_unique<ForceFields::ForceField>(3);
+  for (unsigned int i = 0; i < conf.getNumAtoms(); ++i) {
+    auto* pos = &conf.getAtomPos(i);
+    referenceForceField->positions().push_back(pos);
+  }
+  referenceForceField->initialize();
+
+  auto modifiedParams            = params;
+  modifiedParams.useRandomCoords = true;
+
+  nvMolKit::detail::EmbedArgs eargs;
+  nvMolKit::DGeomHelpers::prepareEmbedderArgs(*mol, modifiedParams, eargs);
+  const auto& etkdgDetails = eargs.etkdgDetails;
+
+  RDGeom::Point3DPtrVect point3DVec;
+  for (unsigned int j = 0; j < conf.getNumAtoms(); ++j) {
+    point3DVec.push_back(&conf.getAtomPos(j));
+  }
+
+  const unsigned int      numAtoms = mol->getNumAtoms();
+  boost::dynamic_bitset<> atomPairs(numAtoms * numAtoms);
+  boost::dynamic_bitset<> isImproperConstrained(numAtoms);
+
+  addExperimentalTorsionTerms(referenceForceField.get(), etkdgDetails, atomPairs, numAtoms);
+  add12Terms(referenceForceField.get(), etkdgDetails, atomPairs, point3DVec, KNOWN_DIST_FORCE_CONSTANT, numAtoms);
+  add13Terms(referenceForceField.get(),
+             etkdgDetails,
+             atomPairs,
+             point3DVec,
+             KNOWN_DIST_FORCE_CONSTANT,
+             isImproperConstrained,
+             modifiedParams.useBasicKnowledge,
+             *eargs.mmat,
+             numAtoms);
+  addLongRangeDistanceConstraints(referenceForceField.get(),
+                                  etkdgDetails,
+                                  atomPairs,
+                                  point3DVec,
+                                  KNOWN_DIST_FORCE_CONSTANT,
+                                  *eargs.mmat,
+                                  numAtoms);
+
+  return referenceForceField;
+}
+
+double getReferencePlain3DEnergy(RDKit::ROMol* mol, double* ePos) {
+  auto FF = setupPlain3DReferenceFF(mol);
+  return FF->calcEnergy(ePos);
+}
+
+std::vector<double> getReferencePlain3DGradient(RDKit::ROMol* mol, double* fPos) {
+  auto                FF = setupPlain3DReferenceFF(mol);
+  std::vector<double> gradients(3 * mol->getNumAtoms(), 0.0);
+  FF->calcGrad(fPos, gradients.data());
+  return pad3Dto4D(gradients, 0.0);
 }
 
 std::vector<double> pad3Dto4D(const std::vector<double>& positions, const double value = 0.0) {
@@ -1463,12 +1527,7 @@ TEST_F(ETK3DGpuTestFixture, PlainCombinedEnergiesSingleMolecule) {
   double gotEnergy;
   CHECK_CUDA_RETURN(cudaMemcpy(&gotEnergy, systemDevice.energyOuts.data() + 0, sizeof(double), cudaMemcpyDeviceToHost));
 
-  // Calculate reference combined energy by summing individual plain terms
-  double wantEnergy = 0.0;
-  for (const auto& term : plainETK3DTerms) {
-    const double e = getReferenceETK3DEnergyTerm(mol_.get(), term, positionsHost.data(), DGeomHelpers::ETDG);
-    wantEnergy += e;
-  }
+  const double wantEnergy = getReferencePlain3DEnergy(mol_.get(), positionsHost.data());
 
   EXPECT_NEAR(gotEnergy, wantEnergy, E_TOL_FUNCTION);
 }
@@ -1487,14 +1546,7 @@ TEST_F(ETK3DGpuTestFixture, PlainCombinedGradientsSingleMolecule) {
   systemDevice.grad.copyToHost(gotGrad);
   cudaDeviceSynchronize();
 
-  // Calculate reference combined gradients by summing individual plain terms
-  std::vector<double> wantGradients(4 * mol_->getNumAtoms(), 0.0);
-  for (const auto& term : plainETK3DTerms) {
-    auto termGrad = getReferenceETK3DGradientTerm(mol_.get(), term, positionsHost.data(), DGeomHelpers::ETDG);
-    for (size_t i = 0; i < wantGradients.size(); ++i) {
-      wantGradients[i] += termGrad[i];
-    }
-  }
+  const std::vector<double> wantGradients = getReferencePlain3DGradient(mol_.get(), positionsHost.data());
 
   EXPECT_THAT(gotGrad, ::testing::Pointwise(::testing::FloatNear(G_TOL), wantGradients));
 }
@@ -1782,16 +1834,11 @@ TEST_F(ETK3DGpuTestFixture, PlainCombinedEnergiesMultiMol) {
   systemDevice.energyOuts.copyToHost(gotEnergy);
   cudaDeviceSynchronize();
 
-  // Calculate reference combined energy by summing individual plain terms for each molecule
+  // Calculate reference combined energy using the same shared atom-pair exclusions as the device setup.
   std::vector<double> wantEnergy(molsPtrs_.size(), 0.0);
   for (size_t molIdx = 0; molIdx < molsPtrs_.size(); ++molIdx) {
-    for (const auto& term : plainETK3DTerms) {
-      const double e = getReferenceETK3DEnergyTerm(molsPtrs_[molIdx],
-                                                   term,
-                                                   positionsHost.data() + 3 * atomStartsHost[molIdx],
-                                                   DGeomHelpers::ETDG);
-      wantEnergy[molIdx] += e;
-    }
+    wantEnergy[molIdx] =
+      getReferencePlain3DEnergy(molsPtrs_[molIdx], positionsHost.data() + 3 * atomStartsHost[molIdx]);
   }
 
   EXPECT_THAT(gotEnergy, ::testing::Pointwise(::testing::DoubleNear(E_TOL_COMBINED), wantEnergy));
@@ -1801,6 +1848,7 @@ TEST_F(ETK3DGpuTestFixture, PlainCombinedGradientsMultiMol) {
   loadMMFFMols(10, DGeomHelpers::ETDG);  // Use ETDG parameters (useBasicKnowledge=false)
 
   // Test combined gradient calculation with plain 3D terms (ETDG variant - no improper torsions)
+  systemDevice.grad.zero();
   CHECK_CUDA_RETURN(nvMolKit::DistGeom::computeGradientsETK(systemDevice,
                                                             atomStartsDevice,
                                                             positionsDevice,
@@ -1810,21 +1858,17 @@ TEST_F(ETK3DGpuTestFixture, PlainCombinedGradientsMultiMol) {
   systemDevice.grad.copyToHost(gotGrad);
   cudaDeviceSynchronize();
 
-  // Calculate reference combined gradients by summing individual plain terms for each molecule
-  std::vector<std::vector<double>> wantGradients;
-  for (size_t molIdx = 0; molIdx < molsPtrs_.size(); ++molIdx) {
-    std::vector<double> molGradients(4 * molsPtrs_[molIdx]->getNumAtoms(), 0.0);
-    for (const auto& term : plainETK3DTerms) {
-      auto termGrad = getReferenceETK3DGradientTerm(molsPtrs_[molIdx],
-                                                    term,
-                                                    positionsHost.data() + 3 * atomStartsHost[molIdx],
-                                                    DGeomHelpers::ETDG);
-      for (size_t i = 0; i < molGradients.size(); ++i) {
-        molGradients[i] += termGrad[i];
-      }
+  // Validate the combined PLAIN path against the sum of isolated device term kernels.
+  // The device torsion gradient intentionally carries fixes that can differ from RDKit's
+  // scalar CrystalFF gradient for affected torsions.
+  std::vector<double> wantCombinedGrad(systemDevice.grad.size(), 0.0);
+  for (const auto& term : plainETK3DTerms) {
+    auto termGrad = getETK3DGradientTerm(systemDevice, atomStartsDevice, positionsDevice, term);
+    for (size_t i = 0; i < wantCombinedGrad.size(); ++i) {
+      wantCombinedGrad[i] += termGrad[i];
     }
-    wantGradients.push_back(molGradients);
   }
+  std::vector<std::vector<double>> wantGradients = splitCombinedGrads(wantCombinedGrad, atomStartsHost);
 
   std::vector<std::vector<double>> gotGradSplit = splitCombinedGrads(gotGrad, atomStartsHost);
   for (size_t i = 0; i < wantGradients.size(); ++i) {

--- a/tests/test_etkdg_etk_minimize.cu
+++ b/tests/test_etkdg_etk_minimize.cu
@@ -16,6 +16,7 @@
 #include <DistGeom/DistGeomUtils.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 
+#include <cmath>
 #include <filesystem>
 #include <random>
 
@@ -208,7 +209,9 @@ std::vector<double> getGPUEnergy(const std::vector<const RDKit::ROMol*>&    mols
   return getReferenceEnergy(mols, eargs, false, 0.001, hostPos3.data(), nullptr, useBasicKnowledge);
 }
 
-class ETKStageSingleMolTestFixture : public ::testing::TestWithParam<std::tuple<ETKDGOption, nvMolKit::BfgsBackend>> {
+using ETKStageTestParam = std::tuple<ETKDGOption, nvMolKit::BfgsBackend>;
+
+class ETKStageSingleMolTestFixture : public ::testing::TestWithParam<ETKStageTestParam> {
  public:
   ETKStageSingleMolTestFixture() { testDataFolderPath_ = getTestDataFolderPath(); }
 
@@ -249,19 +252,18 @@ TEST_P(ETKStageSingleMolTestFixture, MinimizeCompare) {
   const bool useBasicKnowledge = embedParam_.useBasicKnowledge;
 
   // Create minimizer for the test
-  nvMolKit::BfgsBatchMinimizer minimizer(4, nvMolKit::DebugLevel::NONE, true, nullptr, backend);
+  nvMolKit::BfgsBatchMinimizer bfgsMinimizer(4, nvMolKit::DebugLevel::NONE, true, nullptr, backend);
 
   // Create FirstMinimizeStage
   std::vector<std::unique_ptr<ETKDGStage>> stages;
   std::vector<const RDKit::ROMol*>         molsPtrs;
   molsPtrs.push_back(molPtr_.get());
-  auto        stage    = std::make_unique<nvMolKit::detail::ETKMinimizationStage>(molsPtrs,
+  auto stage = std::make_unique<nvMolKit::detail::ETKMinimizationStage>(molsPtrs,
                                                                         eargs_,
                                                                         embedParam_,
                                                                         context_,
-                                                                        minimizer,
+                                                                        bfgsMinimizer,
                                                                         nullptr);
-  const auto* stagePtr = stage.get();  // Store pointer before moving
   stages.push_back(std::move(stage));
 
   // Create and run driver
@@ -294,26 +296,37 @@ TEST_P(ETKStageSingleMolTestFixture, MinimizeCompare) {
   EXPECT_THAT(refEnergies, ::testing::Pointwise(testing::Ge(), gpuEnergies));
 }
 
-// Instantiate parameterized tests for different ETKDG variants and backends
+namespace {
+std::vector<ETKStageTestParam> makeETKStageParams(const std::vector<ETKDGOption>& options) {
+  std::vector<ETKStageTestParam> params;
+  for (const auto option : options) {
+    params.emplace_back(option, nvMolKit::BfgsBackend::BATCHED);
+    params.emplace_back(option, nvMolKit::BfgsBackend::PER_MOLECULE);
+  }
+  return params;
+}
+
+std::string makeETKStageName(const ETKStageTestParam& param) {
+  std::string name = getETKDGOptionName(std::get<0>(param));
+  name += std::get<1>(param) == nvMolKit::BfgsBackend::BATCHED ? "_Batched" : "_PerMolecule";
+  return name;
+}
+}  // namespace
+
 INSTANTIATE_TEST_SUITE_P(ETKDGVariants,
                          ETKStageSingleMolTestFixture,
-                         ::testing::Combine(::testing::Values(ETKDGOption::ETKDG,
-                                                              ETKDGOption::ETKDGv2,
-                                                              ETKDGOption::srETKDGv3,
-                                                              ETKDGOption::ETKDGv3,
-                                                              ETKDGOption::KDG,
-                                                              ETKDGOption::ETDG,
-                                                              ETKDGOption::DG),
-                                            ::testing::Values(nvMolKit::BfgsBackend::BATCHED,
-                                                              nvMolKit::BfgsBackend::PER_MOLECULE)),
-                         [](const ::testing::TestParamInfo<std::tuple<ETKDGOption, nvMolKit::BfgsBackend>>& info) {
-                           std::string name = getETKDGOptionName(std::get<0>(info.param));
-                           name +=
-                             std::get<1>(info.param) == nvMolKit::BfgsBackend::BATCHED ? "_Batched" : "_PerMolecule";
-                           return name;
+                         ::testing::ValuesIn(makeETKStageParams({ETKDGOption::ETKDG,
+                                                                 ETKDGOption::ETKDGv2,
+                                                                 ETKDGOption::srETKDGv3,
+                                                                 ETKDGOption::ETKDGv3,
+                                                                 ETKDGOption::KDG,
+                                                                 ETKDGOption::ETDG,
+                                                                 ETKDGOption::DG})),
+                         [](const ::testing::TestParamInfo<ETKStageTestParam>& info) {
+                           return makeETKStageName(info.param);
                          });
 
-class ETKStageMultiMolTestFixture : public ::testing::TestWithParam<std::tuple<ETKDGOption, nvMolKit::BfgsBackend>> {
+class ETKStageMultiMolTestFixture : public ::testing::TestWithParam<ETKStageTestParam> {
  public:
   ETKStageMultiMolTestFixture() { testDataFolderPath_ = getTestDataFolderPath(); }
 
@@ -354,7 +367,7 @@ TEST_P(ETKStageMultiMolTestFixture, MinimizeCompare) {
   const bool useBasicKnowledge = embedParam_.useBasicKnowledge;
 
   // Create minimizer for the test
-  nvMolKit::BfgsBatchMinimizer minimizer(4, nvMolKit::DebugLevel::NONE, true, nullptr, backend);
+  nvMolKit::BfgsBatchMinimizer bfgsMinimizer(4, nvMolKit::DebugLevel::NONE, true, nullptr, backend);
 
   // Create FirstMinimizeStage
   std::vector<std::unique_ptr<ETKDGStage>> stages;
@@ -364,13 +377,12 @@ TEST_P(ETKStageMultiMolTestFixture, MinimizeCompare) {
   }
   const int count = molsPtrs.size();
 
-  auto        stage    = std::make_unique<nvMolKit::detail::ETKMinimizationStage>(molsPtrs,
+  auto stage = std::make_unique<nvMolKit::detail::ETKMinimizationStage>(molsPtrs,
                                                                         eargs_,
                                                                         embedParam_,
                                                                         context_,
-                                                                        minimizer,
+                                                                        bfgsMinimizer,
                                                                         nullptr);
-  const auto* stagePtr = stage.get();  // Store pointer before moving
   stages.push_back(std::move(stage));
 
   // Create and run driver
@@ -435,18 +447,13 @@ TEST_P(ETKStageMultiMolTestFixture, MinimizeCompare) {
 // Instantiate parameterized tests for different ETKDG variants and backends
 INSTANTIATE_TEST_SUITE_P(ETKDGVariants,
                          ETKStageMultiMolTestFixture,
-                         ::testing::Combine(::testing::Values(ETKDGOption::ETDG,
-                                                              ETKDGOption::ETKDG,
-                                                              ETKDGOption::ETKDGv2,
-                                                              ETKDGOption::srETKDGv3,
-                                                              ETKDGOption::ETKDGv3,
-                                                              ETKDGOption::KDG,
-                                                              ETKDGOption::DG),
-                                            ::testing::Values(nvMolKit::BfgsBackend::BATCHED,
-                                                              nvMolKit::BfgsBackend::PER_MOLECULE)),
-                         [](const ::testing::TestParamInfo<std::tuple<ETKDGOption, nvMolKit::BfgsBackend>>& info) {
-                           std::string name = getETKDGOptionName(std::get<0>(info.param));
-                           name +=
-                             std::get<1>(info.param) == nvMolKit::BfgsBackend::BATCHED ? "_Batched" : "_PerMolecule";
-                           return name;
+                         ::testing::ValuesIn(makeETKStageParams({ETKDGOption::ETDG,
+                                                                 ETKDGOption::ETKDG,
+                                                                 ETKDGOption::ETKDGv2,
+                                                                 ETKDGOption::srETKDGv3,
+                                                                 ETKDGOption::ETKDGv3,
+                                                                 ETKDGOption::KDG,
+                                                                 ETKDGOption::DG})),
+                         [](const ::testing::TestParamInfo<ETKStageTestParam>& info) {
+                           return makeETKStageName(info.param);
                          });


### PR DESCRIPTION
The FIRE minimizer is more sensitive to incorrect gradient terms than BFGS. In advance of FIRE, making this fix, and adjusting our tests to separate out the incorrect rdkit term. 