### PR TITLE
Primitives and device queues for MCS - MCS PR 2/N

### DIFF
--- a/src/mcs/fmcs_cuda/fmcs_seed.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_seed.cuh
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/mcs/fmcs_cuda/fmcs_seed.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_seed.cuh
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FMCS_CUDA_FMCS_SEED_CUH
+#define FMCS_CUDA_FMCS_SEED_CUH
+
+#include <cstdint>
+#include <type_traits>
+
+namespace mcs {
+
+/// Bitset word type: uint32_t for maxSize <= 32, uint64_t otherwise.
+template <int maxSize> using BitWord = std::conditional_t<(maxSize <= 32), uint32_t, uint64_t>;
+
+namespace fmcs {
+
+/// Query bond that dangles off the current seed boundary and is eligible to
+/// be added in the next grow step.  @c endAtomSeedIdx == kNotInSeed indicates
+/// the other endpoint is not yet present in the seed (an atom-adding bond);
+/// anything else is a ring-closing bond onto an existing seed atom.
+/// @c alive is cleared by the individual-bond pruning pass.
+struct NewBond {
+  static constexpr uint16_t kNotInSeed = 0xFFFFu;
+
+  uint16_t bondIdx        = 0;
+  uint16_t newAtomIdx     = 0;
+  uint16_t endAtomSeedIdx = kNotInSeed;
+  bool     alive          = true;
+};
+
+/// Connected subgraph of the query molecule, represented as bitsets over the
+/// query's atom and bond index spaces.  Per-target match state lives
+/// separately in @ref MatchResult.
+template <int maxAtoms, int maxBonds> struct Seed {
+  using atom_word_type                  = BitWord<maxAtoms>;
+  using bond_word_type                  = BitWord<maxBonds>;
+  static constexpr int kAtomBitsPerWord = sizeof(atom_word_type) * 8;
+  static constexpr int kBondBitsPerWord = sizeof(bond_word_type) * 8;
+  static constexpr int kAtomWords       = (maxAtoms + kAtomBitsPerWord - 1) / kAtomBitsPerWord;
+  static constexpr int kBondWords       = (maxBonds + kBondBitsPerWord - 1) / kBondBitsPerWord;
+
+  atom_word_type atoms[kAtomWords]          = {};
+  bond_word_type bonds[kBondWords]          = {};
+  /// Query bonds forbidden from further grows of this seed, to avoid
+  /// reaching the same seed via two different grow paths.
+  bond_word_type excludedBonds[kBondWords]  = {};
+  /// Subset of @c atoms added in the most recent grow step.  This mirrors
+  /// RDKit's LastAddedAtomsBeginIdx scan: fillNewBondsCooperative only
+  /// enumerates query bonds incident to atoms that were newly appended to the
+  /// seed, while sibling/subset coverage comes from RDKit Stage 1/Stage 2.
+  atom_word_type lastAddedAtoms[kAtomWords] = {};
+
+  uint16_t numAtoms = 0;
+  uint16_t numBonds = 0;
+
+  /// Upper bound on additional atoms/bonds reachable from this seed,
+  /// cached by @ref computeRemainingSize for incumbent-size pruning.
+  uint16_t remainingAtoms = 0;
+  uint16_t remainingBonds = 0;
+  /// RDKit Seed::GrowingStage analogue.  0 means a fresh seed that should run
+  /// the outer grow stage, 1 means resume the same parent at the inner
+  /// singleton/subset stage.
+  uint16_t growingStage   = 0;
+};
+
+constexpr uint16_t kSeedGrowStageOuter = 0;
+constexpr uint16_t kSeedGrowStageInner = 1;
+
+/// Sentinel stored in @c MatchResult::targetAtomIdx[q] /
+/// @c targetBondIdx[q] when the query atom / bond @c q has not yet been
+/// mapped to any target counterpart.  uint8 max value, distinguishable
+/// from any valid target index since tiers cap maxAtoms/maxBonds at 128.
+constexpr std::uint8_t kUnmappedTargetIdx = 0xFFu;
+
+/// Per-target incremental match cache attached to a Seed.  When non-empty,
+/// @ref matchIncrementalFast extends the recorded mapping by just the bonds
+/// added since @c matchedBondSize; the visited-atom/bond bitsets keep
+/// successive extensions from reusing a target atom or bond.
+template <int maxAtoms, int maxBonds, int maxTargetAtoms, int maxTargetBonds> struct MatchResult {
+  using target_atom_word                      = BitWord<maxTargetAtoms>;
+  using target_bond_word                      = BitWord<maxTargetBonds>;
+  static constexpr int kTargetAtomBitsPerWord = sizeof(target_atom_word) * 8;
+  static constexpr int kTargetBondBitsPerWord = sizeof(target_bond_word) * 8;
+  static constexpr int kTargetAtomWords       = (maxTargetAtoms + kTargetAtomBitsPerWord - 1) / kTargetAtomBitsPerWord;
+  static constexpr int kTargetBondWords       = (maxTargetBonds + kTargetBondBitsPerWord - 1) / kTargetBondBitsPerWord;
+
+  /// queryAtomIdx -> targetAtomIdx, 0xFF for unmapped.  Query-indexed so the
+  /// map does not have to be rebuilt when the seed's atom list grows.
+  uint8_t targetAtomIdx[maxAtoms];
+  /// queryBondIdx -> targetBondIdx, 0xFF for unmapped.
+  uint8_t targetBondIdx[maxBonds];
+
+  target_atom_word visitedTargetAtoms[kTargetAtomWords] = {};
+  target_bond_word visitedTargetBonds[kTargetBondWords] = {};
+
+  uint16_t matchedAtomSize = 0;
+  uint16_t matchedBondSize = 0;
+  bool     empty           = true;
+};
+
+/// Storage wrapper bundling a @ref Seed with its per-target @ref MatchResult.
+/// The seed queue and per-block incumbent both hold these so the recorded
+/// embedding travels with the subgraph it describes.
+///
+/// @c alignas(16) ensures every @c QueuedSeed in an array (whether in
+/// shared or global memory) starts on a 16-byte boundary, which is
+/// what the int4-granularity @c warpCopy path requires.
+/// Without this, a sequence of two @c __shared__ @c QueuedSeed
+/// declarations or @c QueuedSeed[N] arrays at non-tier-128 sizes
+/// would put the second element at a 4- or 8-byte boundary and
+/// trigger @c cudaErrorMisalignedAddress on the int4 load/store.
+template <int maxAtoms, int maxBonds, int maxTargetAtoms, int maxTargetBonds> struct alignas(16) QueuedSeed {
+  Seed<maxAtoms, maxBonds>                                        seed;
+  MatchResult<maxAtoms, maxBonds, maxTargetAtoms, maxTargetBonds> match;
+};
+
+// ---------------------------------------------------------------------------
+// Helper signatures.
+//
+// Naming convention: functions that operate within a single thread carry
+// the @c WithinThread suffix; cooperative-group helpers carry the
+// @c Cooperative suffix and take a @c GroupT.  Only the version that is
+// actually called by the kernel is provided -- a pair of within-thread
+// + cooperative variants is added only when both call sites exist.
+//
+// Concurrency contract for @c *WithinThread helpers: the caller is
+// responsible for ensuring exclusive write access to the target Seed or
+// MatchResult.  Internally these do non-atomic read-modify-writes
+// (e.g. @c numAtoms += 1, bitword OR) and would silently lose updates
+// under concurrent calls on the same target.  Today the kernel
+// guarantees exclusivity by giving each lane (Phase 1) or each group's
+// designated leader (Phase 2 Stage 0 patch) its own per-lane / per-
+// group destination slot.
+// ---------------------------------------------------------------------------
+
+/// Within-thread: sets bit @p atomIdx in both @c seed.atoms and
+/// @c seed.lastAddedAtoms, and increments @c numAtoms.  Caller is a
+/// single lane that already owns @p seed.  Callers wrap a batch of
+/// @ref seedAddAtomWithinThread calls in a
+/// @ref seedBeginGrowStepWithinThread to clear @c lastAddedAtoms
+/// first, so only THIS step's atoms appear in the boundary set used by
+/// @ref fillNewBondsCooperative.
+///
+/// Idempotent: adding an atom already in @c seed.atoms is a no-op, so the
+/// invariant @c numAtoms == popcount(atoms) always holds.  A single grow
+/// step can present the same new atom through two boundary bonds (a ring
+/// closed within one step reaches the new atom from two seed atoms); the
+/// guard keeps that from double-counting @c numAtoms.
+template <int maxAtoms, int maxBonds>
+__device__ __forceinline__ void seedAddAtomWithinThread(Seed<maxAtoms, maxBonds>& seed, const int atomIdx) {
+  using AtomWord              = typename Seed<maxAtoms, maxBonds>::atom_word_type;
+  constexpr int  kBitsPerWord = Seed<maxAtoms, maxBonds>::kAtomBitsPerWord;
+  const int      wordIdx      = atomIdx / kBitsPerWord;
+  const AtomWord mask         = static_cast<AtomWord>(1) << (atomIdx % kBitsPerWord);
+  if ((seed.atoms[wordIdx] & mask) != 0)
+    return;
+  seed.atoms[wordIdx] |= mask;
+  seed.lastAddedAtoms[wordIdx] |= mask;
+  seed.numAtoms += 1;
+}
+
+/// Within-thread: sets bit @p bondIdx in @c seed.bonds AND
+/// @c seed.excludedBonds (excludedBonds prevents the same bond being
+/// re-added through a different grow path), and increments @c numBonds.
+template <int maxAtoms, int maxBonds>
+__device__ __forceinline__ void seedAddBondWithinThread(Seed<maxAtoms, maxBonds>& seed, const int bondIdx) {
+  using BondWord              = typename Seed<maxAtoms, maxBonds>::bond_word_type;
+  constexpr int  kBitsPerWord = Seed<maxAtoms, maxBonds>::kBondBitsPerWord;
+  const int      wordIdx      = bondIdx / kBitsPerWord;
+  const BondWord mask         = static_cast<BondWord>(1) << (bondIdx % kBitsPerWord);
+  seed.bonds[wordIdx] |= mask;
+  seed.excludedBonds[wordIdx] |= mask;
+  seed.numBonds += 1;
+}
+
+/// Within-thread: marks a query bond as unavailable for future grows without
+/// adding it to the seed.  RDKit uses this while constructing initial seeds:
+/// later initial seeds exclude earlier query bonds, and a mismatched initial
+/// bond is also excluded from seeds already admitted.
+template <int maxAtoms, int maxBonds>
+__device__ __forceinline__ void seedExcludeBondWithinThread(Seed<maxAtoms, maxBonds>& seed, const int bondIdx) {
+  using BondWord              = typename Seed<maxAtoms, maxBonds>::bond_word_type;
+  constexpr int  kBitsPerWord = Seed<maxAtoms, maxBonds>::kBondBitsPerWord;
+  const int      wordIdx      = bondIdx / kBitsPerWord;
+  const BondWord mask         = static_cast<BondWord>(1) << (bondIdx % kBitsPerWord);
+  seed.excludedBonds[wordIdx] |= mask;
+}
+
+/// Within-thread: clear @c seed.lastAddedAtoms.  Subsequent
+/// @ref seedAddAtomWithinThread calls in this step then
+/// populate @c lastAddedAtoms with the atoms touched by this grow step;
+/// @ref fillNewBondsCooperative reads that bitset to decide which query
+/// bonds should be enumerated as new boundary candidates.
+template <int maxAtoms, int maxBonds>
+__device__ __forceinline__ void seedBeginGrowStepWithinThread(Seed<maxAtoms, maxBonds>& seed) {
+  for (int i = 0; i < Seed<maxAtoms, maxBonds>::kAtomWords; ++i) {
+    seed.lastAddedAtoms[i] = 0;
+  }
+}
+
+/// Within-thread: pure scalar predicate; safe for every lane to evaluate
+/// independently against a uniform @p seed reference.  Returns true iff
+/// the seed could still grow strictly larger than the
+/// (@p bestBonds, @p bestAtoms) incumbent under MaximizeBonds tie-break,
+/// using the cached @c remainingAtoms / @c remainingBonds upper bound
+/// populated by @ref seedComputeRemainingSizeRdkitCooperative.
+template <int maxAtoms, int maxBonds>
+__device__ __forceinline__ bool seedCanGrowBiggerThanWithinThread(const Seed<maxAtoms, maxBonds>& seed,
+                                                                  int                             bestBonds,
+                                                                  int                             bestAtoms) {
+  const int possibleBonds = seed.numBonds + seed.remainingBonds;
+  if (possibleBonds > bestBonds)
+    return true;
+  if (possibleBonds < bestBonds)
+    return false;
+  const int possibleAtoms = seed.numAtoms + seed.remainingAtoms;
+  return possibleAtoms > bestAtoms;
+}
+
+/// Within-thread: zeroes a Seed in-place.  Tier-128 cost is ~58 B; well
+/// under the per-lane budget of a serial clear, so cooperative variant
+/// not provided.
+template <int maxAtoms, int maxBonds>
+__device__ __forceinline__ void seedClearWithinThread(Seed<maxAtoms, maxBonds>& seed) {
+  for (int i = 0; i < Seed<maxAtoms, maxBonds>::kAtomWords; ++i) {
+    seed.atoms[i]          = 0;
+    seed.lastAddedAtoms[i] = 0;
+  }
+  for (int i = 0; i < Seed<maxAtoms, maxBonds>::kBondWords; ++i) {
+    seed.bonds[i]         = 0;
+    seed.excludedBonds[i] = 0;
+  }
+  seed.numAtoms       = 0;
+  seed.numBonds       = 0;
+  seed.remainingAtoms = 0;
+  seed.remainingBonds = 0;
+  seed.growingStage   = kSeedGrowStageOuter;
+}
+
+/// Within-thread: zeroes a MatchResult in-place.  Tier-128 cost is
+/// ~280 B (mostly the 0xFF fill of targetAtomIdx[maxAtoms] and
+/// targetBondIdx[maxBonds]).  Currently called by the lane that won
+/// a per-thread queue slot in Phase 1, so the per-lane serial cost is
+/// unavoidable without restructuring; revisit in Step 6 if profiling
+/// shows it dominant.
+template <int maxAtoms, int maxBonds, int maxTA, int maxTB>
+__device__ __forceinline__ void matchResultClearWithinThread(MatchResult<maxAtoms, maxBonds, maxTA, maxTB>& match) {
+  for (int i = 0; i < maxAtoms; ++i)
+    match.targetAtomIdx[i] = kUnmappedTargetIdx;
+  for (int i = 0; i < maxBonds; ++i)
+    match.targetBondIdx[i] = kUnmappedTargetIdx;
+  for (int i = 0; i < MatchResult<maxAtoms, maxBonds, maxTA, maxTB>::kTargetAtomWords; ++i) {
+    match.visitedTargetAtoms[i] = 0;
+  }
+  for (int i = 0; i < MatchResult<maxAtoms, maxBonds, maxTA, maxTB>::kTargetBondWords; ++i) {
+    match.visitedTargetBonds[i] = 0;
+  }
+  match.matchedAtomSize = 0;
+  match.matchedBondSize = 0;
+  match.empty           = true;
+}
+
+}  // namespace fmcs
+}  // namespace mcs
+
+#endif  // FMCS_CUDA_FMCS_SEED_CUH

--- a/src/mcs/fmcs_cuda/fmcs_seed_queue.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_seed_queue.cuh
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/mcs/fmcs_cuda/fmcs_seed_queue.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_seed_queue.cuh
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FMCS_CUDA_FMCS_SEED_QUEUE_CUH
+#define FMCS_CUDA_FMCS_SEED_QUEUE_CUH
+
+#include <cooperative_groups.h>
+
+#include <cstdint>
+
+namespace mcs {
+namespace fmcs {
+
+/// Scope tag selecting the backing store + synchronization for
+/// @ref SeedQueue.  ThreadBlockScope is the only implemented variant.
+struct ThreadBlockScope {};
+
+/// Cooperative-group-scoped seed queue.  LIFO semantics match fMCS's
+/// SEED_GROW_DEEP: grow the biggest child first, only backtrack on match
+/// failure.  @c push returns false when full; callers are expected to
+/// flag @ref MCSResult::overflowed at that point.
+///
+/// Capacity is a runtime value so the host can size the backing slab
+/// against a memory budget rather than a compile-time tier.  The backing
+/// store lives in global memory (one per-block slab handed in via
+/// @ref init); only the queue header (top index and pointer) lives in
+/// the block's shared memory, so capacity is bound by GPU RAM, not
+/// shared memory.
+///
+/// The default constructor leaves the queue empty with a null backing
+/// store so the class can be declared as a @c __shared__ variable; lane 0
+/// must call @ref init before any push/pop.
+template <class Element, class Scope> class SeedQueue {
+ public:
+  __device__ __forceinline__ SeedQueue() = default;
+
+  __device__ __forceinline__ void init(Element* storage, int capacity) {
+    storage_  = storage;
+    capacity_ = capacity;
+    top_      = 0;
+  }
+
+  /// Within-thread: single lane atomically reserves one slot and writes
+  /// @p element into it.  Returns false if the queue is full, in which
+  /// case no slot was consumed.
+  ///
+  /// Concurrency: safe under multiple concurrent pushers (each gets a
+  /// distinct slot via CAS).  The kernel's iteration structure also
+  /// guarantees pushes and pops never overlap (block.sync rendezvous
+  /// between iterations), so the slot-write after the CAS is not
+  /// racing with a popper read of the same slot.
+  __device__ __forceinline__ bool pushWithinThread(const Element& element) {
+    const int slot = adjustTopAtomic(+1);
+    if (slot < 0)
+      return false;
+    storage_[slot] = element;
+    return true;
+  }
+
+  /// Within-thread: single lane atomically claims the LIFO top and
+  /// copies it out into @p outElement.  Returns false if the queue is
+  /// empty.
+  ///
+  /// Concurrency: safe under multiple concurrent poppers (CAS gives
+  /// each successful caller a distinct slot).  Relies on the kernel's
+  /// temporal separation of pops (start of iteration) from pushes
+  /// (later in the same iteration) -- the slot read after a successful
+  /// CAS is therefore not racing with a pusher write to that slot.
+  __device__ __forceinline__ bool popWithinThread(Element& outElement) {
+    const int slot = adjustTopAtomic(-1);
+    if (slot < 0)
+      return false;
+    outElement = storage_[slot - 1];
+    return true;
+  }
+
+  /// Despite the @c Cooperative suffix, the actual reservation work is lane-0
+  /// serial: lane 0 runs the atomicCAS-loop on @c top_, and the only
+  /// group-coordinated step is broadcasting the result via
+  /// @c group.shfl.  Returns -1 to all lanes when the reservation
+  /// would overflow @ref capacity, in which case no slots were
+  /// consumed.  Successful callers write directly into @ref slot
+  /// starting at the returned offset; THOSE writes are the parallel
+  /// part (one per lane).
+  template <class GroupT> __device__ __forceinline__ int batchReserveCooperative(const GroupT& group, int count) {
+    int start = -1;
+    if (group.thread_rank() == 0)
+      start = adjustTopAtomic(count);
+    return group.shfl(start, 0);
+  }
+
+  /// Cooperative reservation for a single LIFO pop.  Returns the old top to
+  /// every lane, or -1 if the queue was empty.  Callers copy from
+  /// @c slot(oldTop - 1) after a successful reservation.
+  template <class GroupT> __device__ __forceinline__ int popReserveCooperative(const GroupT& group) {
+    int oldTop = -1;
+    if (group.thread_rank() == 0)
+      oldTop = adjustTopAtomic(-1);
+    return group.shfl(oldTop, 0);
+  }
+
+  __device__ __forceinline__ Element&       slot(int i) { return storage_[i]; }
+  __device__ __forceinline__ const Element& slot(int i) const { return storage_[i]; }
+
+  __device__ __forceinline__ int  size() const { return top_; }
+  __device__ __forceinline__ bool empty() const { return top_ == 0; }
+  __device__ __forceinline__ int  capacity() const { return capacity_; }
+
+  __device__ __forceinline__ void setSizeWithinThread(int size) { top_ = size; }
+
+ private:
+  /// Within-thread CAS-loop on @c top_ that atomically applies a signed
+  /// @p delta to the queue cursor.  Returns the @c top_ value before
+  /// the update on success, or -1 if the resulting top would fall
+  /// outside @c [0, capacity_] (no slots consumed).  All three of
+  /// @ref pushWithinThread, @ref popWithinThread, and
+  /// @ref batchReserveCooperative reduce to a single call here.
+  __device__ __forceinline__ int adjustTopAtomic(int delta) {
+    int oldTop = top_;
+    while (true) {
+      const int newTop = oldTop + delta;
+      if (newTop < 0 || newTop > capacity_)
+        return -1;
+      const int prev = atomicCAS(&top_, oldTop, newTop);
+      if (prev == oldTop)
+        return oldTop;
+      oldTop = prev;
+    }
+  }
+
+  Element* storage_  = nullptr;
+  int      capacity_ = 0;
+  int      top_      = 0;
+};
+
+}  // namespace fmcs
+}  // namespace mcs
+
+#endif  // FMCS_CUDA_FMCS_SEED_QUEUE_CUH

--- a/src/mcs/mcs_common/mcs_cooperative_copy.cuh
+++ b/src/mcs/mcs_common/mcs_cooperative_copy.cuh
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/mcs/mcs_common/mcs_cooperative_copy.cuh
+++ b/src/mcs/mcs_common/mcs_cooperative_copy.cuh
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MCS_COMMON_MCS_COOPERATIVE_COPY_CUH
+#define MCS_COMMON_MCS_COOPERATIVE_COPY_CUH
+
+namespace mcs {
+
+/// Warp-cooperative coalesced copy via int4 (16 B) loads/stores.
+/// Both dst and src should be 16-byte aligned for full throughput;
+/// any tail bytes (nbytes % 16) are handled at int (4 B) granularity.
+template <typename WarpT>
+__forceinline__ __device__ void warpCopy(const WarpT& warp,
+                                         void* __restrict__ dst,
+                                         const void* __restrict__ src,
+                                         int nbytes) {
+  const int threadRank = static_cast<int>(warp.thread_rank());
+  const int numThreads = static_cast<int>(warp.num_threads());
+
+  auto*       dst16         = static_cast<int4*>(dst);
+  const auto* src16         = static_cast<const int4*>(src);
+  const int   numWideChunks = nbytes / 16;
+  for (int i = threadRank; i < numWideChunks; i += numThreads) {
+    dst16[i] = src16[i];
+  }
+
+  const int tailBytes = nbytes - numWideChunks * 16;
+  if (tailBytes > 0) {
+    auto*       dstTail       = reinterpret_cast<int*>(dst16 + numWideChunks);
+    const auto* srcTail       = reinterpret_cast<const int*>(src16 + numWideChunks);
+    const int   numTailChunks = tailBytes / 4;
+    for (int i = threadRank; i < numTailChunks; i += numThreads) {
+      dstTail[i] = srcTail[i];
+    }
+  }
+}
+
+}  // namespace mcs
+
+#endif  // MCS_COMMON_MCS_COOPERATIVE_COPY_CUH

--- a/src/mcs/mcs_common/mcs_types.cuh
+++ b/src/mcs/mcs_common/mcs_types.cuh
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/mcs/mcs_common/mcs_types.cuh
+++ b/src/mcs/mcs_common/mcs_types.cuh
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MCS_COMMON_MCS_TYPES_CUH
+#define MCS_COMMON_MCS_TYPES_CUH
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace mcs {
+
+/**
+ * @brief CSR (Compressed Sparse Row) graph representation.
+ *
+ * Stores an undirected graph where each undirected edge (u,v) appears twice
+ * in the adjacency structure: once under u and once under v.
+ */
+struct Graph {
+  int                 numVertices = 0;
+  int                 numEdges    = 0;  ///< Count of undirected edges.
+  std::vector<size_t> rowOffsets;       ///< Size = numVertices + 1.
+  std::vector<size_t> colIndices;       ///< Size = 2 * numEdges (symmetric).
+};
+
+/**
+ * @brief Result of a maximum common substructure computation.
+ */
+struct MCSResult {
+  int  numCommonVertices = 0;
+  int  numCommonEdges    = 0;
+  bool timedOut          = false;
+  bool killed            = false;
+  bool overflowed        = false;
+
+  /// Vertex mappings: mappingA[i] <-> mappingB[i] in the common subgraph.
+  std::vector<size_t> mappingA;
+  std::vector<size_t> mappingB;
+
+  /// Edge mappings (populated for MCES mode):
+  /// edgeMappingA[i] = (u, v) in graphA, edgeMappingB[i] = (u, v) in graphB.
+  std::vector<std::pair<size_t, size_t>> edgeMappingA;
+  std::vector<std::pair<size_t, size_t>> edgeMappingB;
+};
+
+}  // namespace mcs
+
+#endif  // MCS_COMMON_MCS_TYPES_CUH

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,11 @@ target_link_libraries(test_work_splitting PRIVATE work_splitting)
 add_executable(test_thread_safe_queue test_thread_safe_queue.cpp)
 target_link_libraries(test_thread_safe_queue PRIVATE thread_safe_queue)
 
+add_executable(test_fmcs_primitives test_fmcs_primitives.cu)
+target_include_directories(test_fmcs_primitives
+                           PRIVATE ${CMAKE_SOURCE_DIR}/src/mcs)
+target_link_libraries(test_fmcs_primitives PRIVATE CUDA::cudart device_vector)
+
 add_executable(test_openmp_helpers test_openmp_helpers.cpp)
 target_link_libraries(test_openmp_helpers PRIVATE openmp_helpers
                                                   OpenMP::OpenMP_CXX)
@@ -411,6 +416,7 @@ set(TEST_LIST
     test_substruct_label_integration
     test_similarity
     test_thread_safe_queue
+    test_fmcs_primitives
     test_work_splitting
     test_fire_minimizer
     test_fire_minimizer_permol)

--- a/tests/test_fmcs_primitives.cu
+++ b/tests/test_fmcs_primitives.cu
@@ -1,0 +1,938 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for the fMCS seed / queue / cooperative-copy primitives.
+// Each test launches a tiny __global__ driver that constructs inputs,
+// calls one helper, and copies results back to host memory for assertion.
+
+#include <cooperative_groups.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <set>
+#include <vector>
+
+#include "fmcs_cuda/fmcs_seed.cuh"
+#include "fmcs_cuda/fmcs_seed_queue.cuh"
+#include "mcs_common/mcs_cooperative_copy.cuh"
+#include "src/utils/device_vector.h"
+
+namespace {
+
+namespace cg = cooperative_groups;
+
+using nvMolKit::AsyncDevicePtr;
+using nvMolKit::AsyncDeviceVector;
+
+using mcs::fmcs::MatchResult;
+using mcs::fmcs::QueuedSeed;
+using mcs::fmcs::Seed;
+using mcs::fmcs::SeedQueue;
+using mcs::fmcs::ThreadBlockScope;
+
+struct QueueResult {
+  int  first;
+  int  second;
+  bool empty;
+  bool overflowAccepted;
+};
+
+__global__ void seedMutationKernel(Seed<128, 128>* seed) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  *seed = {};
+  mcs::fmcs::seedAddAtomWithinThread(*seed, 3);
+  mcs::fmcs::seedAddAtomWithinThread(*seed, 67);
+  mcs::fmcs::seedAddBondWithinThread(*seed, 7);
+  mcs::fmcs::seedAddBondWithinThread(*seed, 71);
+}
+
+__global__ void queueKernel(int* storage, QueueResult* result) {
+  __shared__ SeedQueue<int, ThreadBlockScope> queue;
+  if (threadIdx.x == 0) {
+    queue.init(storage, 2);
+    queue.pushWithinThread(11);
+    queue.pushWithinThread(22);
+    result->overflowAccepted = queue.pushWithinThread(33);
+    queue.popWithinThread(result->first);
+    queue.popWithinThread(result->second);
+    int ignored{};
+    result->empty = !queue.popWithinThread(ignored);
+  }
+}
+
+}  // namespace
+
+TEST(FMCSPrimitives, SeedMutationCrossesBitsetWords) {
+  AsyncDevicePtr<Seed<128, 128>> d_seed;
+
+  seedMutationKernel<<<1, 1>>>(d_seed.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  Seed<128, 128> seed{};
+  d_seed.get(seed);
+  EXPECT_EQ(seed.numAtoms, 2);
+  EXPECT_EQ(seed.atoms[0], 1ULL << 3);
+  EXPECT_EQ(seed.atoms[1], 1ULL << 3);
+  EXPECT_EQ(seed.numBonds, 2);
+  EXPECT_EQ(seed.bonds[0], 1ULL << 7);
+  EXPECT_EQ(seed.bonds[1], 1ULL << 7);
+  EXPECT_EQ(seed.excludedBonds[0], seed.bonds[0]);
+  EXPECT_EQ(seed.excludedBonds[1], seed.bonds[1]);
+}
+
+TEST(FMCSPrimitives, QueueIsBoundedLifo) {
+  AsyncDeviceVector<int>      d_storage(2);
+  AsyncDevicePtr<QueueResult> d_result;
+
+  queueKernel<<<1, 1>>>(d_storage.data(), d_result.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  QueueResult result{};
+  d_result.get(result);
+  EXPECT_FALSE(result.overflowAccepted);
+  EXPECT_EQ(result.first, 22);
+  EXPECT_EQ(result.second, 11);
+  EXPECT_TRUE(result.empty);
+}
+
+// ---------------------------------------------------------------------------
+// matchResultClearWithinThread
+// ---------------------------------------------------------------------------
+
+namespace {
+
+__global__ void matchResultClearDriverKernel(MatchResult<16, 16, 16, 16>* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  MatchResult<16, 16, 16, 16> m;
+  for (int i = 0; i < 16; ++i)
+    m.targetAtomIdx[i] = 7;
+  for (int i = 0; i < 16; ++i)
+    m.targetBondIdx[i] = 7;
+  // Pre-populate visited bitsets too so we can verify they're zeroed.
+  m.visitedTargetAtoms[0] = 0xDEADBEEFu;
+  m.visitedTargetBonds[0] = 0xCAFEBABEu;
+  m.matchedAtomSize       = 13;
+  m.matchedBondSize       = 11;
+  m.empty                 = false;
+  mcs::fmcs::matchResultClearWithinThread(m);
+  *out = m;
+}
+
+}  // namespace
+
+TEST(FMCSPrimitives, MatchResultClearZeroesEverything) {
+  AsyncDevicePtr<MatchResult<16, 16, 16, 16>> d_out;
+
+  matchResultClearDriverKernel<<<1, 1>>>(d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  MatchResult<16, 16, 16, 16> out{};
+  d_out.get(out);
+  for (int i = 0; i < 16; ++i) {
+    EXPECT_EQ(out.targetAtomIdx[i], 0xFFu);
+    EXPECT_EQ(out.targetBondIdx[i], 0xFFu);
+  }
+  EXPECT_EQ(out.visitedTargetAtoms[0], 0u);
+  EXPECT_EQ(out.visitedTargetBonds[0], 0u);
+  EXPECT_TRUE(out.empty);
+  EXPECT_EQ(out.matchedAtomSize, 0);
+  EXPECT_EQ(out.matchedBondSize, 0);
+}
+
+// ---------------------------------------------------------------------------
+// seedAddAtomWithinThread
+// ---------------------------------------------------------------------------
+
+namespace {
+
+__global__ void seedAddAtomDriverKernel(Seed<16, 16>* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  Seed<16, 16> seed{};
+  mcs::fmcs::seedAddAtomWithinThread(seed, 3);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 5);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 12);
+  *out = seed;
+}
+
+// A single grow step can reach the same new atom through two boundary
+// bonds (a ring closed within one step); the double-add must be a no-op
+// so the invariant numAtoms == popcount(atoms) holds.
+__global__ void seedDoubleAddAtomDriverKernel(Seed<16, 16>* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  Seed<16, 16> seed{};
+  mcs::fmcs::seedAddAtomWithinThread(seed, 4);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 4);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 9);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 9);
+  *out = seed;
+}
+
+}  // namespace
+
+TEST(FMCSPrimitives, SeedAddAtomSetsBitsAndCount) {
+  AsyncDevicePtr<Seed<16, 16>> d_out;
+
+  seedAddAtomDriverKernel<<<1, 1>>>(d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  Seed<16, 16> out{};
+  d_out.get(out);
+  // Tier 16 packs the atom bitset into one uint32 word.
+  const std::uint32_t expected = (1u << 3) | (1u << 5) | (1u << 12);
+  EXPECT_EQ(out.atoms[0], expected);
+  EXPECT_EQ(out.numAtoms, 3);
+  // No bond / excludedBonds touched.
+  EXPECT_EQ(out.bonds[0], 0u);
+  EXPECT_EQ(out.excludedBonds[0], 0u);
+  EXPECT_EQ(out.numBonds, 0);
+}
+
+TEST(FMCSPrimitives, SeedAddAtomDoubleAddIsIdempotent) {
+  AsyncDevicePtr<Seed<16, 16>> d_out;
+
+  seedDoubleAddAtomDriverKernel<<<1, 1>>>(d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  Seed<16, 16> out{};
+  d_out.get(out);
+  const std::uint32_t expected = (1u << 4) | (1u << 9);
+  EXPECT_EQ(out.atoms[0], expected);
+  EXPECT_EQ(out.lastAddedAtoms[0], expected);
+  EXPECT_EQ(out.numAtoms, 2);  // Not 4: re-adds must not double-count.
+}
+
+// ---------------------------------------------------------------------------
+// seedAddBondWithinThread / seedExcludeBondWithinThread
+// ---------------------------------------------------------------------------
+
+namespace {
+
+__global__ void seedAddBondDriverKernel(Seed<16, 16>* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  Seed<16, 16> seed{};
+  mcs::fmcs::seedAddBondWithinThread(seed, 2);
+  mcs::fmcs::seedAddBondWithinThread(seed, 7);
+  *out = seed;
+}
+
+__global__ void seedExcludeBondDriverKernel(Seed<16, 16>* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  Seed<16, 16> seed{};
+  mcs::fmcs::seedExcludeBondWithinThread(seed, 5);
+  mcs::fmcs::seedExcludeBondWithinThread(seed, 13);
+  *out = seed;
+}
+
+}  // namespace
+
+TEST(FMCSPrimitives, SeedAddBondSetsBondsAndExcludedAndCount) {
+  AsyncDevicePtr<Seed<16, 16>> d_out;
+
+  seedAddBondDriverKernel<<<1, 1>>>(d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  Seed<16, 16> out{};
+  d_out.get(out);
+  const std::uint32_t expected = (1u << 2) | (1u << 7);
+  EXPECT_EQ(out.bonds[0], expected);
+  EXPECT_EQ(out.excludedBonds[0], expected);
+  EXPECT_EQ(out.numBonds, 2);
+  // Atom side untouched.
+  EXPECT_EQ(out.atoms[0], 0u);
+  EXPECT_EQ(out.numAtoms, 0);
+}
+
+TEST(FMCSPrimitives, SeedExcludeBondDoesNotAddToSeed) {
+  AsyncDevicePtr<Seed<16, 16>> d_out;
+
+  seedExcludeBondDriverKernel<<<1, 1>>>(d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  Seed<16, 16> out{};
+  d_out.get(out);
+  // Excluded bonds are barred from future grows without joining the seed.
+  const std::uint32_t expected = (1u << 5) | (1u << 13);
+  EXPECT_EQ(out.excludedBonds[0], expected);
+  EXPECT_EQ(out.bonds[0], 0u);
+  EXPECT_EQ(out.numBonds, 0);
+}
+
+// ---------------------------------------------------------------------------
+// seedBeginGrowStepWithinThread
+// ---------------------------------------------------------------------------
+
+namespace {
+
+__global__ void seedBeginGrowStepDriverKernel(Seed<16, 16>* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  Seed<16, 16> seed{};
+  mcs::fmcs::seedAddAtomWithinThread(seed, 0);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 1);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 2);
+  // Boundary bitset should reset here.
+  mcs::fmcs::seedBeginGrowStepWithinThread(seed);
+  // Subsequent adds advance numAtoms and repopulate the boundary.
+  mcs::fmcs::seedAddAtomWithinThread(seed, 5);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 9);
+  *out = seed;
+}
+
+}  // namespace
+
+TEST(FMCSPrimitives, SeedBeginGrowStepResetsBoundary) {
+  AsyncDevicePtr<Seed<16, 16>> d_out;
+
+  seedBeginGrowStepDriverKernel<<<1, 1>>>(d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  Seed<16, 16> out{};
+  d_out.get(out);
+  EXPECT_EQ(out.numAtoms, 5);
+  EXPECT_EQ(out.atoms[0], (1u << 0) | (1u << 1) | (1u << 2) | (1u << 5) | (1u << 9));
+  // Only this step's atoms remain in the boundary set.
+  EXPECT_EQ(out.lastAddedAtoms[0], (1u << 5) | (1u << 9));
+}
+
+// ---------------------------------------------------------------------------
+// seedCanGrowBiggerThanWithinThread
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct CanGrowResults {
+  bool moreBonds;           // possible bonds 8 vs best 5: true
+  bool fewerBonds;          // possible bonds 5 vs best 8: false
+  bool tiedBondsMoreAtoms;  // possible bonds 8 best 8, atoms tie-break: true
+  bool tiedBondsFewerAtoms;
+  bool tiedBondsTiedAtoms;
+};
+
+__global__ void seedCanGrowDriverKernel(CanGrowResults* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  Seed<16, 16> seed{};
+  seed.numBonds       = 5;
+  seed.remainingBonds = 3;  // possibleBonds = 8
+  seed.numAtoms       = 4;
+  seed.remainingAtoms = 2;  // possibleAtoms = 6
+
+  out->moreBonds           = mcs::fmcs::seedCanGrowBiggerThanWithinThread(seed, /*bestBonds=*/5, /*bestAtoms=*/0);
+  out->fewerBonds          = mcs::fmcs::seedCanGrowBiggerThanWithinThread(seed, /*bestBonds=*/9, /*bestAtoms=*/0);
+  out->tiedBondsMoreAtoms  = mcs::fmcs::seedCanGrowBiggerThanWithinThread(seed, /*bestBonds=*/8, /*bestAtoms=*/5);
+  out->tiedBondsFewerAtoms = mcs::fmcs::seedCanGrowBiggerThanWithinThread(seed, /*bestBonds=*/8, /*bestAtoms=*/7);
+  out->tiedBondsTiedAtoms  = mcs::fmcs::seedCanGrowBiggerThanWithinThread(seed, /*bestBonds=*/8, /*bestAtoms=*/6);
+}
+
+struct CanGrowFromEmptyResults {
+  bool nonEmptyVsZero;  // possibleBonds=2 vs (0,0): true
+  bool emptyVsZero;     // possibleBonds=0 vs (0,0): false (strict >)
+};
+
+__global__ void seedCanGrowFromEmptyDriverKernel(CanGrowFromEmptyResults* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  Seed<16, 16> live{};
+  live.numBonds       = 1;
+  live.remainingBonds = 1;
+  out->nonEmptyVsZero = mcs::fmcs::seedCanGrowBiggerThanWithinThread(live, 0, 0);
+  Seed<16, 16> empty{};
+  out->emptyVsZero = mcs::fmcs::seedCanGrowBiggerThanWithinThread(empty, 0, 0);
+}
+
+}  // namespace
+
+TEST(FMCSPrimitives, SeedCanGrowBiggerThanBoundCheck) {
+  AsyncDevicePtr<CanGrowResults> d_out;
+
+  seedCanGrowDriverKernel<<<1, 1>>>(d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  CanGrowResults out{};
+  d_out.get(out);
+  EXPECT_TRUE(out.moreBonds);
+  EXPECT_FALSE(out.fewerBonds);
+  EXPECT_TRUE(out.tiedBondsMoreAtoms);
+  EXPECT_FALSE(out.tiedBondsFewerAtoms);
+  EXPECT_FALSE(out.tiedBondsTiedAtoms);  // strictly bigger required
+}
+
+TEST(FMCSPrimitives, SeedCanGrowBiggerThanFromEmptyIncumbent) {
+  AsyncDevicePtr<CanGrowFromEmptyResults> d_out;
+
+  seedCanGrowFromEmptyDriverKernel<<<1, 1>>>(d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  CanGrowFromEmptyResults out{};
+  d_out.get(out);
+  EXPECT_TRUE(out.nonEmptyVsZero);
+  EXPECT_FALSE(out.emptyVsZero);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-word and boundary edge cases
+// ---------------------------------------------------------------------------
+
+namespace {
+
+__global__ void seedAddAtomMultiWordDriverKernel(Seed<128, 128>* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  Seed<128, 128> seed{};
+  // Atoms at the four corners of the 2-uint64-word atom bitset:
+  //   0 (word 0, bit 0), 63 (word 0, bit 63),
+  //  64 (word 1, bit 0), 127 (word 1, bit 63).
+  mcs::fmcs::seedAddAtomWithinThread(seed, 0);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 63);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 64);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 127);
+  *out = seed;
+}
+
+__global__ void seedAddBondMultiWordDriverKernel(Seed<128, 128>* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  Seed<128, 128> seed{};
+  mcs::fmcs::seedAddBondWithinThread(seed, 0);
+  mcs::fmcs::seedAddBondWithinThread(seed, 63);
+  mcs::fmcs::seedAddBondWithinThread(seed, 64);
+  mcs::fmcs::seedAddBondWithinThread(seed, 127);
+  *out = seed;
+}
+
+__global__ void seedAddAtomBoundaryDriverKernel(Seed<16, 16>* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  Seed<16, 16> seed{};
+  mcs::fmcs::seedAddAtomWithinThread(seed, 0);
+  mcs::fmcs::seedAddAtomWithinThread(seed, 15);  // tier-16 max valid atom idx
+  *out = seed;
+}
+
+}  // namespace
+
+TEST(FMCSPrimitives, SeedAddAtomCrossesWordBoundary) {
+  AsyncDevicePtr<Seed<128, 128>> d_out;
+
+  seedAddAtomMultiWordDriverKernel<<<1, 1>>>(d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  Seed<128, 128> out{};
+  d_out.get(out);
+  const std::uint64_t bit0  = std::uint64_t{1} << 0;
+  const std::uint64_t bit63 = std::uint64_t{1} << 63;
+  EXPECT_EQ(out.atoms[0], bit0 | bit63);
+  EXPECT_EQ(out.atoms[1], bit0 | bit63);
+  EXPECT_EQ(out.numAtoms, 4);
+}
+
+TEST(FMCSPrimitives, SeedAddBondCrossesWordBoundary) {
+  AsyncDevicePtr<Seed<128, 128>> d_out;
+
+  seedAddBondMultiWordDriverKernel<<<1, 1>>>(d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  Seed<128, 128> out{};
+  d_out.get(out);
+  const std::uint64_t bit0     = std::uint64_t{1} << 0;
+  const std::uint64_t bit63    = std::uint64_t{1} << 63;
+  const std::uint64_t expected = bit0 | bit63;
+  EXPECT_EQ(out.bonds[0], expected);
+  EXPECT_EQ(out.bonds[1], expected);
+  EXPECT_EQ(out.excludedBonds[0], expected);
+  EXPECT_EQ(out.excludedBonds[1], expected);
+  EXPECT_EQ(out.numBonds, 4);
+}
+
+TEST(FMCSPrimitives, SeedAddAtomBoundaryIndices) {
+  AsyncDevicePtr<Seed<16, 16>> d_out;
+
+  seedAddAtomBoundaryDriverKernel<<<1, 1>>>(d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  Seed<16, 16> out{};
+  d_out.get(out);
+  EXPECT_EQ(out.atoms[0], (1u << 0) | (1u << 15));
+  EXPECT_EQ(out.numAtoms, 2);
+}
+
+// ---------------------------------------------------------------------------
+// SeedQueue: pushWithinThread / popWithinThread / batchReserveCooperative /
+// popReserveCooperative
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Single-thread driver: push 5 ints, pop 5, record the popped order so
+// the host can verify LIFO.
+__global__ void queuePushPopLIFODriver(int* poppedOrder, int* outSizeAfterPushes) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  __shared__ int storage[8];
+  __shared__ SeedQueue<int, ThreadBlockScope> queue;
+  queue.init(storage, 8);
+  for (int v : {10, 20, 30, 40, 50}) {
+    bool ok = queue.pushWithinThread(v);
+    (void)ok;
+  }
+  *outSizeAfterPushes = queue.size();
+  for (int i = 0; i < 5; ++i) {
+    int  popped    = -1;
+    bool ok        = queue.popWithinThread(popped);
+    poppedOrder[i] = ok ? popped : -1;
+  }
+}
+
+__global__ void queueOverflowDriver(bool* pushOk, int* finalSize) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  __shared__ int storage[4];
+  __shared__ SeedQueue<int, ThreadBlockScope> queue;
+  queue.init(storage, 4);
+  for (int i = 0; i < 5; ++i) {
+    pushOk[i] = queue.pushWithinThread(100 + i);
+  }
+  *finalSize = queue.size();
+}
+
+__global__ void queuePopFromEmptyDriver(bool* popOk, int* outVal) {
+  if (threadIdx.x != 0 || blockIdx.x != 0)
+    return;
+  __shared__ int storage[4];
+  __shared__ SeedQueue<int, ThreadBlockScope> queue;
+  queue.init(storage, 4);
+  int v   = 12345;
+  *popOk  = queue.popWithinThread(v);
+  *outVal = v;
+}
+
+// Multi-thread (1 warp = 32 threads): each lane pushes its own payload.
+// Verifies CAS-based pushes don't lose any concurrent inserts.
+__global__ void queueConcurrentPushesDriver(int* outStorage, int* outSize) {
+  __shared__ int storage[64];
+  __shared__ SeedQueue<int, ThreadBlockScope> queue;
+  if (threadIdx.x == 0)
+    queue.init(storage, 64);
+  __syncthreads();
+
+  bool ok = queue.pushWithinThread(1000 + static_cast<int>(threadIdx.x));
+  __syncthreads();
+  (void)ok;
+
+  if (threadIdx.x == 0) {
+    *outSize = queue.size();
+    for (int i = 0; i < queue.size(); ++i)
+      outStorage[i] = storage[i];
+  }
+}
+
+// Multi-thread: each of 32 lanes pops one element concurrently.
+// Verifies CAS-based pops hand out every slot exactly once.
+__global__ void queueConcurrentPopsDriver(int* outVals, bool* outOk, int* outSize) {
+  __shared__ int storage[32];
+  __shared__ SeedQueue<int, ThreadBlockScope> queue;
+  if (threadIdx.x == 0) {
+    queue.init(storage, 32);
+    for (int i = 0; i < 32; ++i)
+      queue.pushWithinThread(3000 + i);
+  }
+  __syncthreads();
+
+  int v                = -1;
+  outOk[threadIdx.x]   = queue.popWithinThread(v);
+  outVals[threadIdx.x] = v;
+  __syncthreads();
+
+  if (threadIdx.x == 0)
+    *outSize = queue.size();
+}
+
+// Multi-thread: 32 lanes do a single batchReserveCooperative call,
+// each lane writes its own payload into the reserved slot.  Verifies
+// the cooperative reservation broadcasts correctly and all 32 slots
+// land contiguously.
+__global__ void queueBatchReserveDriver(int* outStorage, int* outStart, int* outSize) {
+  __shared__ int storage[64];
+  __shared__ SeedQueue<int, ThreadBlockScope> queue;
+  if (threadIdx.x == 0)
+    queue.init(storage, 64);
+  __syncthreads();
+
+  auto      block  = cg::this_thread_block();
+  auto      warp   = cg::tiled_partition<32>(block);
+  const int laneId = static_cast<int>(warp.thread_rank());
+  const int start  = queue.batchReserveCooperative(warp, 32);
+  if (start >= 0) {
+    queue.slot(start + laneId) = 2000 + laneId;
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    *outStart = start;
+    *outSize  = queue.size();
+    for (int i = 0; i < queue.size(); ++i)
+      outStorage[i] = storage[i];
+  }
+}
+
+__global__ void queueBatchReserveOverflowDriver(int* outStart, int* outSize) {
+  __shared__ int storage[10];
+  __shared__ SeedQueue<int, ThreadBlockScope> queue;
+  if (threadIdx.x == 0)
+    queue.init(storage, 10);
+  __syncthreads();
+
+  auto      block = cg::this_thread_block();
+  auto      warp  = cg::tiled_partition<32>(block);
+  const int start = queue.batchReserveCooperative(warp, 15);
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    *outStart = start;
+    *outSize  = queue.size();
+  }
+}
+
+// Capacity 10, pre-push 7 elements, then request 5 slots: only 3 free.
+// Reservation must fail atomically (no partial reservation, no slots
+// consumed) -- partial fit must be treated as a hard failure.
+__global__ void queueBatchReservePartialFitDriver(int* outStart, int* outSizeBefore, int* outSizeAfter) {
+  __shared__ int storage[10];
+  __shared__ SeedQueue<int, ThreadBlockScope> queue;
+  if (threadIdx.x == 0) {
+    queue.init(storage, 10);
+    for (int i = 0; i < 7; ++i)
+      queue.pushWithinThread(i);
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0)
+    *outSizeBefore = queue.size();
+  __syncthreads();
+
+  auto      block = cg::this_thread_block();
+  auto      warp  = cg::tiled_partition<32>(block);
+  const int start = queue.batchReserveCooperative(warp, 5);
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    *outStart     = start;
+    *outSizeAfter = queue.size();
+  }
+}
+
+// Multi-thread: pop reservation broadcasts the old top to every lane,
+// callers read slot(oldTop - 1), and an empty queue yields -1 to all
+// lanes without consuming anything.
+__global__ void queuePopReserveDriver(int* outPerLaneTop, int* outValue, int* outEmptyTop, int* outSizeAfter) {
+  __shared__ int storage[8];
+  __shared__ SeedQueue<int, ThreadBlockScope> queue;
+  if (threadIdx.x == 0) {
+    queue.init(storage, 8);
+    queue.pushWithinThread(111);
+    queue.pushWithinThread(222);
+    queue.pushWithinThread(333);
+  }
+  __syncthreads();
+
+  auto      block  = cg::this_thread_block();
+  auto      warp   = cg::tiled_partition<32>(block);
+  const int laneId = static_cast<int>(warp.thread_rank());
+
+  const int oldTop      = queue.popReserveCooperative(warp);
+  outPerLaneTop[laneId] = oldTop;
+  if (laneId == 0 && oldTop > 0)
+    *outValue = queue.slot(oldTop - 1);
+  __syncthreads();
+
+  // Drain the remaining two entries, then reserve on an empty queue.
+  queue.popReserveCooperative(warp);
+  queue.popReserveCooperative(warp);
+  const int emptyTop = queue.popReserveCooperative(warp);
+  __syncthreads();
+
+  if (laneId == 0) {
+    *outEmptyTop  = emptyTop;
+    *outSizeAfter = queue.size();
+  }
+}
+
+}  // namespace
+
+TEST(FMCSPrimitives, QueuePushPopLIFO) {
+  AsyncDeviceVector<int> d_order(5);
+  AsyncDevicePtr<int>    d_size;
+
+  queuePushPopLIFODriver<<<1, 1>>>(d_order.data(), d_size.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  int size = 0;
+  d_size.get(size);
+  std::vector<int> order(5);
+  d_order.copyToHost(order);
+  EXPECT_EQ(size, 5);
+  // LIFO: first popped should be the last pushed.
+  EXPECT_EQ(order[0], 50);
+  EXPECT_EQ(order[1], 40);
+  EXPECT_EQ(order[2], 30);
+  EXPECT_EQ(order[3], 20);
+  EXPECT_EQ(order[4], 10);
+}
+
+TEST(FMCSPrimitives, QueuePushOverflowReturnsFalse) {
+  AsyncDeviceVector<bool> d_ok(5);
+  AsyncDevicePtr<int>     d_size;
+
+  queueOverflowDriver<<<1, 1>>>(d_ok.data(), d_size.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  // std::vector<bool> is bit-packed; copy through a plain buffer instead.
+  bool okRaw[5] = {};
+  d_ok.copyToHost(okRaw, 5);
+  int size = 0;
+  d_size.get(size);
+
+  EXPECT_TRUE(okRaw[0]);
+  EXPECT_TRUE(okRaw[1]);
+  EXPECT_TRUE(okRaw[2]);
+  EXPECT_TRUE(okRaw[3]);
+  EXPECT_FALSE(okRaw[4]);  // 5th push should fail; capacity == 4.
+  EXPECT_EQ(size, 4);
+}
+
+TEST(FMCSPrimitives, QueuePopFromEmptyReturnsFalse) {
+  AsyncDevicePtr<bool> d_ok;
+  AsyncDevicePtr<int>  d_val;
+
+  queuePopFromEmptyDriver<<<1, 1>>>(d_ok.data(), d_val.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  bool ok  = true;
+  int  val = 0;
+  d_ok.get(ok);
+  d_val.get(val);
+  EXPECT_FALSE(ok);
+  EXPECT_EQ(val, 12345);  // Caller's outElement should be untouched.
+}
+
+TEST(FMCSPrimitives, QueueConcurrentPushesAllLand) {
+  AsyncDeviceVector<int> d_storage(64);
+  AsyncDevicePtr<int>    d_size;
+
+  queueConcurrentPushesDriver<<<1, 32>>>(d_storage.data(), d_size.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  int size = 0;
+  d_size.get(size);
+  ASSERT_EQ(size, 32);
+  std::vector<int> storage(64);
+  d_storage.copyToHost(storage);
+  // All 32 lanes' payloads should be present exactly once.  Order is
+  // non-deterministic across CAS races; check by set membership.
+  std::set<int> seen;
+  for (int i = 0; i < 32; ++i)
+    seen.insert(storage[i]);
+  EXPECT_EQ(seen.size(), 32u);
+  for (int i = 0; i < 32; ++i) {
+    EXPECT_TRUE(seen.count(1000 + i)) << "missing lane " << i;
+  }
+}
+
+TEST(FMCSPrimitives, QueueConcurrentPopsAllDistinct) {
+  AsyncDeviceVector<int>  d_vals(32);
+  AsyncDeviceVector<bool> d_ok(32);
+  AsyncDevicePtr<int>     d_size;
+
+  queueConcurrentPopsDriver<<<1, 32>>>(d_vals.data(), d_ok.data(), d_size.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  int size = -1;
+  d_size.get(size);
+  std::vector<int> vals(32);
+  d_vals.copyToHost(vals);
+  bool okRaw[32] = {};
+  d_ok.copyToHost(okRaw, 32);
+
+  EXPECT_EQ(size, 0);
+  std::set<int> seen;
+  for (int i = 0; i < 32; ++i) {
+    EXPECT_TRUE(okRaw[i]) << "lane " << i << " pop failed";
+    seen.insert(vals[i]);
+  }
+  // Every pushed payload should be handed out exactly once.
+  EXPECT_EQ(seen.size(), 32u);
+  for (int i = 0; i < 32; ++i) {
+    EXPECT_TRUE(seen.count(3000 + i)) << "missing payload " << i;
+  }
+}
+
+TEST(FMCSPrimitives, QueueBatchReserveCooperative) {
+  AsyncDeviceVector<int> d_storage(64);
+  AsyncDevicePtr<int>    d_start;
+  AsyncDevicePtr<int>    d_size;
+
+  queueBatchReserveDriver<<<1, 32>>>(d_storage.data(), d_start.data(), d_size.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  int start = -1;
+  int size  = -1;
+  d_start.get(start);
+  d_size.get(size);
+  std::vector<int> storage(64);
+  d_storage.copyToHost(storage);
+  EXPECT_EQ(start, 0);
+  EXPECT_EQ(size, 32);
+  // Each lane wrote 2000 + laneId into slot start + laneId; storage[i]
+  // should equal 2000 + i for i in [0, 32).
+  for (int i = 0; i < 32; ++i) {
+    EXPECT_EQ(storage[i], 2000 + i);
+  }
+}
+
+TEST(FMCSPrimitives, QueueBatchReserveOverflowReturnsNegativeOne) {
+  AsyncDevicePtr<int> d_start;
+  AsyncDevicePtr<int> d_size;
+
+  queueBatchReserveOverflowDriver<<<1, 32>>>(d_start.data(), d_size.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  int start = 0;
+  int size  = -1;
+  d_start.get(start);
+  d_size.get(size);
+  EXPECT_EQ(start, -1);
+  EXPECT_EQ(size, 0);  // No slots consumed on overflow.
+}
+
+TEST(FMCSPrimitives, QueueBatchReservePartialFitFails) {
+  AsyncDevicePtr<int> d_start;
+  AsyncDevicePtr<int> d_sizeBefore;
+  AsyncDevicePtr<int> d_sizeAfter;
+
+  queueBatchReservePartialFitDriver<<<1, 32>>>(d_start.data(), d_sizeBefore.data(), d_sizeAfter.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  int start      = 0;
+  int sizeBefore = -1;
+  int sizeAfter  = -1;
+  d_start.get(start);
+  d_sizeBefore.get(sizeBefore);
+  d_sizeAfter.get(sizeAfter);
+  EXPECT_EQ(sizeBefore, 7);
+  EXPECT_EQ(start, -1);     // Reservation must fail atomically.
+  EXPECT_EQ(sizeAfter, 7);  // No partial slots consumed; size unchanged.
+}
+
+TEST(FMCSPrimitives, QueuePopReserveCooperative) {
+  AsyncDeviceVector<int> d_perLaneTop(32);
+  AsyncDevicePtr<int>    d_value;
+  AsyncDevicePtr<int>    d_emptyTop;
+  AsyncDevicePtr<int>    d_sizeAfter;
+
+  queuePopReserveDriver<<<1, 32>>>(d_perLaneTop.data(), d_value.data(), d_emptyTop.data(), d_sizeAfter.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  std::vector<int> perLaneTop(32);
+  d_perLaneTop.copyToHost(perLaneTop);
+  int value     = 0;
+  int emptyTop  = 0;
+  int sizeAfter = -1;
+  d_value.get(value);
+  d_emptyTop.get(emptyTop);
+  d_sizeAfter.get(sizeAfter);
+
+  // The reservation result must be broadcast identically to all lanes.
+  for (int i = 0; i < 32; ++i) {
+    EXPECT_EQ(perLaneTop[i], 3) << "lane " << i;
+  }
+  EXPECT_EQ(value, 333);    // slot(oldTop - 1) is the LIFO top.
+  EXPECT_EQ(emptyTop, -1);  // Empty queue: -1 to every lane.
+  EXPECT_EQ(sizeAfter, 0);  // The empty-pop consumed nothing.
+}
+
+// ---------------------------------------------------------------------------
+// warpCopy
+// ---------------------------------------------------------------------------
+
+namespace {
+
+__global__ void warpCopyDriver(unsigned char* dst, const unsigned char* src, int nbytes) {
+  auto block = cg::this_thread_block();
+  auto warp  = cg::tiled_partition<32>(block);
+  mcs::warpCopy(warp, dst, src, nbytes);
+}
+
+using QueuedSeedT = QueuedSeed<32, 32, 32, 32>;
+
+__global__ void warpCopyQueuedSeedDriver(QueuedSeedT* dst, const QueuedSeedT* src) {
+  auto block = cg::this_thread_block();
+  auto warp  = cg::tiled_partition<32>(block);
+  mcs::warpCopy(warp, dst, src, sizeof(QueuedSeedT));
+}
+
+}  // namespace
+
+// Exercises the int4 wide path and every tail size (nbytes % 16 in
+// {0, 4, 8, 12}), including sub-16-byte copies that skip the wide path
+// entirely.  Also verifies warpCopy never writes past nbytes.
+TEST(FMCSPrimitives, WarpCopySizesAndTailsNoOverrun) {
+  constexpr int kMax   = 512;
+  constexpr int kSlack = 64;  // Sentinel region past the copy end.
+
+  std::vector<unsigned char> pattern(kMax + kSlack);
+  for (int i = 0; i < kMax + kSlack; ++i) {
+    pattern[i] = static_cast<unsigned char>((i * 13 + 7) & 0xFF);
+  }
+  const std::vector<unsigned char> sentinel(kMax + kSlack, 0xEE);
+
+  AsyncDeviceVector<unsigned char> d_src(kMax + kSlack);
+  AsyncDeviceVector<unsigned char> d_dst(kMax + kSlack);
+  d_src.copyFromHost(pattern);
+
+  // Multiples of 16 plus every 4-byte tail case, small and large.
+  const int sizes[] = {4, 8, 12, 16, 20, 24, 28, 32, 48, 52, 244, 512};
+  for (const int nbytes : sizes) {
+    d_dst.copyFromHost(sentinel);
+    warpCopyDriver<<<1, 32>>>(d_dst.data(), d_src.data(), nbytes);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess) << "nbytes=" << nbytes;
+
+    std::vector<unsigned char> result(kMax + kSlack);
+    d_dst.copyToHost(result);
+    for (int i = 0; i < nbytes; ++i) {
+      ASSERT_EQ(result[i], pattern[i]) << "nbytes=" << nbytes << " byte " << i;
+    }
+    for (int i = nbytes; i < nbytes + kSlack; ++i) {
+      ASSERT_EQ(result[i], 0xEE) << "nbytes=" << nbytes << " overrun at byte " << i;
+    }
+  }
+}
+
+// Copies the struct the kernel actually moves with warpCopy and checks
+// byte-exact round-trip (alignas(16) guarantees the aligned fast path).
+TEST(FMCSPrimitives, WarpCopyQueuedSeedRoundTrip) {
+  static_assert(sizeof(QueuedSeedT) % 16 == 0, "QueuedSeed must pad to an int4 multiple");
+
+  QueuedSeedT hostSrc{};
+  auto*       srcBytes = reinterpret_cast<unsigned char*>(&hostSrc);
+  for (size_t i = 0; i < sizeof(QueuedSeedT); ++i) {
+    srcBytes[i] = static_cast<unsigned char>((i * 31 + 3) & 0xFF);
+  }
+
+  AsyncDevicePtr<QueuedSeedT> d_src(hostSrc);
+  AsyncDevicePtr<QueuedSeedT> d_dst;
+  d_dst.memSet(0);
+
+  warpCopyQueuedSeedDriver<<<1, 32>>>(d_dst.data(), d_src.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  QueuedSeedT hostDst{};
+  d_dst.get(hostDst);
+  EXPECT_EQ(std::memcmp(&hostDst, &hostSrc, sizeof(QueuedSeedT)), 0);
+}


### PR DESCRIPTION
Added data structures that are MCS specific. We have a few differences from substruct search that required new graph representations.

Added a seed object, fMCS grows seeds from a pool. 

Added a queue to push/pop candidate seeds in-device.