### PR TITLE
Extract the labelled-subgraph frontend from the substructure backend

### DIFF
--- a/src/subgraph/candidate_tables.cuh
+++ b/src/subgraph/candidate_tables.cuh
@@ -1,0 +1,394 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Per-pair lookup tables and candidate sets for the warp DFS.
+//
+// This is the layer between nvMolKit::dfsFromRoots (which knows only about
+// candidate bitsets) and a concrete matching problem. It owns the parts that
+// every labelled-subgraph problem needs and none of the parts specific to one:
+//
+//   - the back-edge table: for each search depth, which earlier depths
+//     constrain it, deduplicated, with each edge's predicate key;
+//   - the bond-mask classification (Uniform / Dual / General): if the query's
+//     back edges carry at most two distinct predicate keys, the target
+//     neighbour sets those keys induce are precomputed once per pair, turning
+//     per-edge work in the inner loop into a table lookup;
+//   - buildCandidates, the candidates callback handed to dfsFromRoots.
+//
+// Everything problem-specific is behind an Adapter, which presents the query
+// *in search order*: depth d is a search position, not necessarily query atom
+// d. The substructure backend uses the identity order over all query atoms; a
+// frontend that searches a permuted order supplies the permutation in its
+// adapter. This layer never sees atom ids, only depths.
+//
+// Adapter contract (all __device__, all const):
+//
+//   using Mask = TargetMask<N>;                   // target-atom bitset
+//   static constexpr bool kCachesTargetRows;      // see below
+//
+//   int      degreeAt(int depth) const;           // edge slots at this depth;
+//                                                 // must not exceed
+//                                                 // kMaxEdgeSlotsPerAtom, or
+//                                                 // back edges are silently
+//                                                 // dropped
+//   int      neighborDepthAt(int depth, int slot) const;
+//                                                 // search depth of that
+//                                                 // neighbour
+//   uint32_t edgeKeyAt(int depth, int slot) const;
+//                                                 // opaque predicate key;
+//                                                 // equal keys must mean
+//                                                 // identical predicates
+//   Mask     neighborsMatching(int targetAtom, uint32_t edgeKey) const;
+//                                                 // target atoms reachable
+//                                                 // from targetAtom over an
+//                                                 // edge that edgeKey accepts
+//
+//   // Only when kCachesTargetRows: pack a target atom's adjacency into two
+//   // words so the General case can recompute neighbour sets from shared
+//   // memory instead of re-reading global memory on every descent.
+//   void packTargetRow(int targetAtom, uint64_t& w0, uint64_t& w1) const;
+//   Mask neighborsMatchingPacked(uint64_t w0, uint64_t w1, uint32_t edgeKey) const;
+//
+// kCachesTargetRows is a performance choice, not a semantic one: an adapter
+// whose adjacency does not fit in 128 bits (uncapped degree, wide labels)
+// sets it false and pays a global walk per General-case descent.
+//
+// The label-compatibility term (WarpSharedState::depthCandidates) is filled by
+// the frontend, not the adapter: the substructure backend transposes its
+// target-major label matrix with a ballot per depth. buildCandidates only
+// reads that table.
+
+#ifndef NVMOLKIT_SUBGRAPH_CANDIDATE_TABLES_CUH
+#define NVMOLKIT_SUBGRAPH_CANDIDATE_TABLES_CUH
+
+#include <cstddef>
+#include <cstdint>
+
+#include "src/subgraph/target_mask.cuh"
+#include "src/subgraph/warp_reduce.cuh"
+
+namespace nvMolKit {
+namespace subgraph {
+
+/// Max edge slots per atom the back-edge table reserves per depth.
+constexpr int kMaxEdgeSlotsPerAtom = 8;
+
+// Entry layout in WarpSharedState::backEdges. A back edge of depth d goes to a
+// depth smaller than d, i.e. one already mapped when d is chosen.
+constexpr unsigned char kBackEdgeDepthMask   = 63u;  ///< Low 6 bits: the earlier depth.
+constexpr unsigned char kBackEdgeAltMaskFlag = 64u;  ///< Bit 6 (Dual only): use the Alt adjacency table.
+
+/**
+ * @brief How many distinct edge predicate keys the query's back edges carry.
+ *
+ * With at most two, the target neighbour sets those keys induce can be
+ * precomputed once per pair.
+ */
+enum class BondMaskCase {
+  Uniform,  ///< One key. One adjacency table suffices.
+  Dual,     ///< Two keys. Two adjacency tables; each back edge flags which it uses.
+  General   ///< Three or more. Neighbour sets recomputed per edge during the search.
+};
+
+/// Classification of the query's edge constraints; identical in every lane.
+struct QueryBondPlan {
+  BondMaskCase maskCase       = BondMaskCase::General;
+  uint32_t     minBondMask    = 0;  ///< Smallest key on any back edge.
+  uint32_t     maxBondMask    = 0;  ///< Largest key on any back edge; equals minBondMask iff Uniform.
+  /// Bit d set iff depth d's only back edge goes to depth d-1 and resolves
+  /// through targetAdjacency. Such a depth needs no back-edge lookup, since the
+  /// caller just chose depth d-1's target atom.
+  uint64_t     chainDepths    = 0;
+  /// As chainDepths, for depths resolving through targetAdjacencyAlt.
+  uint64_t     chainDepthsAlt = 0;
+};
+
+/**
+ * @brief Per-warp lookup tables and counters, sized for a whole CTA.
+ *
+ * Warp w touches only [w][...], so no synchronisation beyond __syncwarp() is
+ * needed. Where this is a kernel's only __shared__ allocation, its size alone
+ * determines how many CTAs fit per SM (see occupancy.cuh).
+ *
+ * The adjacency tables hold different things per BondMaskCase; buildTargetAdjacency
+ * is the only place that fills them:
+ *   Uniform: targetAdjacency[a] = atoms reachable from a over an edge the
+ *            query's single key accepts. Alt unused.
+ *   Dual:    targetAdjacency[a] for minBondMask, targetAdjacencyAlt[a] for
+ *            maxBondMask; each back edge picks one via kBackEdgeAltMaskFlag.
+ *   General: with kCachesTargetRows, the tables cache the adapter's packed
+ *            adjacency row instead; without it, they are unused.
+ */
+template <std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock> struct WarpSharedState {
+  static_assert(MaxSearchDepth <= 64, "Back-edge depths pack into 6 bits and chain depths into a 64-bit mask");
+
+  /// Roots each lane owns: lane, lane + 32, ... below MaxTargetAtoms.
+  static constexpr int kRoots = static_cast<int>(MaxTargetAtoms / 32);
+  using Mask                  = TargetMask<MaxTargetAtoms>;
+
+  /**
+   * @brief One adjacency table slot, read as whichever member the case stores.
+   *
+   * A union because cached packed rows are always 64 bits wide, whereas a mask
+   * is only as wide as MaxTargetAtoms. This keeps the table exactly as large as
+   * the wider of the two, so narrowing Mask costs no shared memory here while
+   * still narrowing it in registers.
+   */
+  union AdjacencyEntry {
+    Mask     mask;
+    uint64_t packedRow;
+  };
+
+  AdjacencyEntry targetAdjacency[WarpsPerBlock][MaxTargetAtoms];
+  AdjacencyEntry targetAdjacencyAlt[WarpsPerBlock][MaxTargetAtoms];
+  /// Per depth, the label-compatible target atoms.
+  Mask           depthCandidates[WarpsPerBlock][MaxSearchDepth];
+  /// Per depth, its back edges, kBackEdge*-encoded.
+  unsigned char  backEdges[WarpsPerBlock][MaxSearchDepth][kMaxEdgeSlotsPerAtom];
+  unsigned char  backEdgeCounts[WarpsPerBlock][MaxSearchDepth];  ///< Valid entries in backEdges[w][d].
+  int            matchCount[WarpsPerBlock];                      ///< Embeddings found for the warp's pair.
+  int            reportedCount[WarpsPerBlock];                   ///< Of those, how many fit in the output buffer.
+};
+
+/**
+ * @brief Build the back-edge table and classify the query's edge keys.
+ *
+ * Three passes over the depths, striped across the warp:
+ *  1. Record each depth's deduplicated back edges, reducing the smallest and
+ *     largest key across the warp. Min and max are only a cheap fingerprint for
+ *     the number of distinct keys: all keys equal implies min == max, and if
+ *     exactly two values occur they are the min and the max.
+ *  2. If min != max, flag the max-key edges and watch for a third value, which
+ *     demotes the pair to General.
+ *  3. Uniform and Dual only: find the chain depths (see QueryBondPlan).
+ *
+ * The result depends only on the query, yet is recomputed for every pair; an
+ * adapter whose query side is fixed across a batch could compute it once at
+ * host pack time and load it instead.
+ */
+template <class Adapter, std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock>
+__device__ __forceinline__ QueryBondPlan
+analyzeQueryEdges(WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock>& shared,
+                  int                                                             warp,
+                  int                                                             lane,
+                  const Adapter&                                                  adapter,
+                  int                                                             numDepths) {
+  QueryBondPlan plan;
+
+  uint32_t laneMin = 0xFFFFFFFFu;
+  uint32_t laneMax = 0u;
+
+  for (int depth = lane; depth < numDepths; depth += 32) {
+    const int degree = adapter.degreeAt(depth);
+    int       count  = 0;
+    uint64_t  seen   = 0;
+    for (int slot = 0; slot < kMaxEdgeSlotsPerAtom && slot < degree; ++slot) {
+      const int neighborDepth = adapter.neighborDepthAt(depth, slot);
+      if (neighborDepth >= depth) {
+        continue;
+      }
+      if ((seen >> neighborDepth) & 1ULL) {
+        continue;
+      }
+      seen |= 1ULL << neighborDepth;
+      const uint32_t key                   = adapter.edgeKeyAt(depth, slot);
+      shared.backEdges[warp][depth][count] = static_cast<unsigned char>(neighborDepth);
+      laneMin                              = min(laneMin, key);
+      laneMax                              = max(laneMax, key);
+      ++count;
+    }
+    shared.backEdgeCounts[warp][depth] = static_cast<unsigned char>(count);
+  }
+
+  plan.minBondMask   = warpReduceMin(laneMin);
+  plan.maxBondMask   = warpReduceMax(laneMax);
+  const bool uniform = (plan.minBondMask == plan.maxBondMask);
+  __syncwarp();
+
+  // The walk here must mirror the first pass exactly: it re-derives the same
+  // slot ordering in order to flag the entries it wrote.
+  uint32_t sawThirdMask = 0;
+  if (!uniform) {
+    for (int depth = lane; depth < numDepths; depth += 32) {
+      const int degree = adapter.degreeAt(depth);
+      int       count  = 0;
+      uint64_t  seen   = 0;
+      for (int slot = 0; slot < kMaxEdgeSlotsPerAtom && slot < degree; ++slot) {
+        const int neighborDepth = adapter.neighborDepthAt(depth, slot);
+        if (neighborDepth >= depth) {
+          continue;
+        }
+        if ((seen >> neighborDepth) & 1ULL) {
+          continue;
+        }
+        seen |= 1ULL << neighborDepth;
+        const uint32_t key = adapter.edgeKeyAt(depth, slot);
+        if (key != plan.minBondMask && key != plan.maxBondMask) {
+          sawThirdMask = 1;
+        }
+        if (key == plan.maxBondMask) {
+          shared.backEdges[warp][depth][count] |= kBackEdgeAltMaskFlag;
+        }
+        ++count;
+      }
+    }
+  }
+  const bool dual = !uniform && (__ballot_sync(kFullWarpMask, sawThirdMask) == 0u);
+  plan.maskCase   = uniform ? BondMaskCase::Uniform : (dual ? BondMaskCase::Dual : BondMaskCase::General);
+  __syncwarp();
+
+  if (plan.maskCase != BondMaskCase::General) {
+    uint64_t lanePrimary = 0;
+    uint64_t laneAlt     = 0;
+    for (int depth = lane; depth < numDepths; depth += 32) {
+      if (depth >= 1 && shared.backEdgeCounts[warp][depth] == 1) {
+        const uint32_t edge = shared.backEdges[warp][depth][0];
+        if ((edge & kBackEdgeDepthMask) == static_cast<uint32_t>(depth - 1)) {
+          if (edge & kBackEdgeAltMaskFlag) {
+            laneAlt |= 1ULL << depth;
+          } else {
+            lanePrimary |= 1ULL << depth;
+          }
+        }
+      }
+    }
+    // Two 32-bit OR reductions per 64-bit lane mask; the reductions are 32-bit.
+    plan.chainDepths = static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(lanePrimary))) |
+                       (static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(lanePrimary >> 32))) << 32);
+    plan.chainDepthsAlt = static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(laneAlt))) |
+                          (static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(laneAlt >> 32))) << 32);
+  }
+
+  return plan;
+}
+
+/**
+ * @brief Fill the per-warp adjacency tables for the classified plan, target
+ *        atoms striped across the warp. See WarpSharedState for the contents.
+ */
+template <class Adapter, std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock>
+__device__ __forceinline__ void buildTargetAdjacency(
+  WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock>& shared,
+  int                                                             warp,
+  int                                                             lane,
+  const Adapter&                                                  adapter,
+  int                                                             numTargetAtoms,
+  const QueryBondPlan&                                            plan) {
+  for (int atom = lane; atom < numTargetAtoms; atom += 32) {
+    if (plan.maskCase == BondMaskCase::Uniform) {
+      shared.targetAdjacency[warp][atom].mask = adapter.neighborsMatching(atom, plan.maxBondMask);
+    } else if (plan.maskCase == BondMaskCase::Dual) {
+      shared.targetAdjacency[warp][atom].mask    = adapter.neighborsMatching(atom, plan.minBondMask);
+      shared.targetAdjacencyAlt[warp][atom].mask = adapter.neighborsMatching(atom, plan.maxBondMask);
+    } else if constexpr (Adapter::kCachesTargetRows) {
+      uint64_t w0;
+      uint64_t w1;
+      adapter.packTargetRow(atom, w0, w1);
+      shared.targetAdjacency[warp][atom].packedRow    = w0;
+      shared.targetAdjacencyAlt[warp][atom].packedRow = w1;
+    }
+  }
+}
+
+/**
+ * @brief The target atoms depth @p depth may still map to: the candidates
+ *        callback handed to nvMolKit::dfsFromRoots.
+ *
+ * Evaluates the intersection described in warp_dfs.cuh, in four shapes,
+ * cheapest first:
+ *   - chain depth: the only back edge goes to depth-1, whose target atom the
+ *     caller passes as @p prevTargetAtom, so the back-edge table is not read;
+ *   - Uniform: every back edge intersects targetAdjacency;
+ *   - Dual: each back edge's kBackEdgeAltMaskFlag picks its table;
+ *   - General: recompute the neighbour set per edge, from the cached packed row
+ *     if the adapter caches, otherwise from the adapter directly.
+ *
+ * The General case walks the adapter's raw edge slots, which can name the same
+ * neighbour twice, so it dedups against @p seen; the other cases read the
+ * already-deduplicated back-edge table.
+ */
+template <class Adapter, std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock>
+__device__ __forceinline__ TargetMask<MaxTargetAtoms> buildCandidates(
+  const WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock>& shared,
+  int                                                                   warp,
+  int                                                                   depth,
+  const unsigned char*                                                  mapping,
+  const TargetMask<MaxTargetAtoms>&                                     used,
+  const Adapter&                                                        adapter,
+  const QueryBondPlan&                                                  plan,
+  int                                                                   prevTargetAtom) {
+  using Mask = TargetMask<MaxTargetAtoms>;
+
+  Mask candidates = shared.depthCandidates[warp][depth];
+  candidates.andNotEq(used);
+
+  const uint64_t depthBit = 1ULL << depth;
+  if (plan.chainDepths & depthBit) {
+    candidates.andEq(shared.targetAdjacency[warp][prevTargetAtom].mask);
+    return candidates;
+  }
+  if (plan.chainDepthsAlt & depthBit) {
+    candidates.andEq(shared.targetAdjacencyAlt[warp][prevTargetAtom].mask);
+    return candidates;
+  }
+
+  const int numBackEdges = shared.backEdgeCounts[warp][depth];
+
+  if (plan.maskCase == BondMaskCase::Uniform) {
+    for (int k = 0; k < numBackEdges && !candidates.empty(); ++k) {
+      candidates.andEq(
+        shared.targetAdjacency[warp][mapping[shared.backEdges[warp][depth][k] & kBackEdgeDepthMask]].mask);
+    }
+    return candidates;
+  }
+
+  if (plan.maskCase == BondMaskCase::Dual) {
+    for (int k = 0; k < numBackEdges && !candidates.empty(); ++k) {
+      const uint32_t edge   = shared.backEdges[warp][depth][k];
+      const int      mapped = mapping[edge & kBackEdgeDepthMask];
+      candidates.andEq((edge & kBackEdgeAltMaskFlag) ? shared.targetAdjacencyAlt[warp][mapped].mask :
+                                                       shared.targetAdjacency[warp][mapped].mask);
+    }
+    return candidates;
+  }
+
+  const int degree = adapter.degreeAt(depth);
+  uint64_t  seen   = 0;
+  for (int slot = 0; slot < kMaxEdgeSlotsPerAtom && slot < degree && !candidates.empty(); ++slot) {
+    const int neighborDepth = adapter.neighborDepthAt(depth, slot);
+    if (neighborDepth >= depth) {
+      continue;
+    }
+    if ((seen >> neighborDepth) & 1ULL) {
+      continue;
+    }
+    seen |= 1ULL << neighborDepth;
+    const int      mapped = mapping[neighborDepth];
+    const uint32_t key    = adapter.edgeKeyAt(depth, slot);
+    if constexpr (Adapter::kCachesTargetRows) {
+      candidates.andEq(adapter.neighborsMatchingPacked(shared.targetAdjacency[warp][mapped].packedRow,
+                                                       shared.targetAdjacencyAlt[warp][mapped].packedRow,
+                                                       key));
+    } else {
+      candidates.andEq(adapter.neighborsMatching(mapped, key));
+    }
+  }
+  return candidates;
+}
+
+}  // namespace subgraph
+}  // namespace nvMolKit
+
+#endif  // NVMOLKIT_SUBGRAPH_CANDIDATE_TABLES_CUH

--- a/src/subgraph/warp_dfs.cuh
+++ b/src/subgraph/warp_dfs.cuh
@@ -23,9 +23,9 @@
 // most-constrained-first permutation and apply the inverse permutation to the
 // resulting mapping.
 //
-// All constraint knowledge lives behind the candidates oracle: at each descent
+// All constraint knowledge lives behind the candidates callback: at each descent
 // the core asks it for the bitset of target atoms query atom `depth` may still
-// map to given the mapping so far. The canonical oracle shape is one bitset
+// map to given the mapping so far. That callback's canonical shape is one bitset
 // intersection over target atoms:
 //
 //   candidates(d) = labelCompatible(d) & ~used
@@ -34,7 +34,7 @@
 //                         edge's bond predicate accepts }
 //
 // Forward edges need no check; they are back edges of the deeper atom. How the
-// per-edge neighbour sets are produced is the oracle's business: the
+// per-edge neighbour sets are produced is the callback's business: the
 // substructure backend precomputes them per bond-mask class (see
 // substruct_dfs.cuh), an MCS backend can walk a CSR row testing a
 // bond-compatibility bit matrix. The core only ever sees the resulting masks.
@@ -51,7 +51,7 @@
 // DfsTerminalVerdict). The abort hook is polled between roots so a frontend
 // that only needs existence can stop every lane once one lane has found an
 // embedding (e.g. by polling a warp-shared flag; a finer-grained frontend can
-// additionally poll inside its oracle, which runs on every descent).
+// additionally poll inside its candidates callback, which runs on every descent).
 
 #ifndef NVMOLKIT_SUBGRAPH_WARP_DFS_CUH
 #define NVMOLKIT_SUBGRAPH_WARP_DFS_CUH
@@ -81,7 +81,7 @@ struct DfsTerminalVerdict {
  *                      const Mask& used, int prevTargetAtom). Must already
  *                      exclude atoms in @p used. @p mapping[0..depth-1] are the
  *                      committed target atoms; @p prevTargetAtom == mapping[depth-1],
- *                      passed separately so chain-shaped oracles skip the load.
+ *                      passed separately so chain-shaped callbacks skip the load.
  * @tparam TerminalFn   DfsTerminalVerdict onTerminal(Mask terminals,
  *                      const unsigned char* mapping). Called at @p lastDepth
  *                      with the candidate set for the final query atom; every

--- a/src/substruct/substruct_dfs.cuh
+++ b/src/substruct/substruct_dfs.cuh
@@ -22,7 +22,7 @@
 //
 // The search itself is nvMolKit::dfsFromRoots (src/subgraph/warp_dfs.cuh);
 // this header is the substructure frontend: it builds the per-pair lookup
-// tables the candidates oracle reads, supplies that oracle, and implements the
+// tables the candidates callback reads, supplies that callback, and implements the
 // output modes as terminal handlers. Query atoms are matched in index order,
 // so depth d means "choose the target atom for query atom d".
 //
@@ -32,9 +32,9 @@
 // reduction. Shared memory holds the per-warp lookup tables and result counters.
 //
 // Three tables are built per pair before the search, each depending on the last:
-// tryBuildQueryAtomCandidates (the label-compatibility term of the oracle's
-// intersection), analyzeQueryBonds (the back edges), buildTargetAdjacency (the
-// per-edge neighbour sets).
+// tryBuildQueryAtomCandidates (the label-compatibility term of the candidate
+// intersection), then analyzeQueryEdges (the back edges) and
+// buildTargetAdjacency (the per-edge neighbour sets) from candidate_tables.cuh.
 //
 // Future optimization candidates:
 // - Store target adjacency as the two packed degree-8 words at construction,
@@ -43,7 +43,7 @@
 //   transpose in tryBuildQueryAtomCandidates.
 // - Have the label kernel flag pairs with an empty column and compact the DFS
 //   pair list on device.
-// - Precompute analyzeQueryBonds per query at host pack time (see its note).
+// - Precompute analyzeQueryEdges per query at host pack time (see its note).
 // - Reorder query atoms most-constrained-first at construction, with an inverse
 //   permutation on mapping download.
 // - Route size-1 queries to a popcount-over-label-column kernel.
@@ -55,6 +55,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "src/subgraph/candidate_tables.cuh"
 #include "src/subgraph/occupancy.cuh"
 #include "src/subgraph/target_mask.cuh"
 #include "src/subgraph/warp_dfs.cuh"
@@ -77,93 +78,15 @@ enum class DfsOutputMode {
   Paint   ///< Recursive SMARTS bit painted for mapping[0]; stops each root at its first embedding.
 };
 
-// =============================================================================
-// Query bond classification
-// =============================================================================
+// The per-pair table machinery, bond-mask classification, and candidates
+// callback come from src/subgraph/candidate_tables.cuh; this header supplies the
+// substructure adapter and output modes.
+using nvMolKit::subgraph::BondMaskCase;
+using nvMolKit::subgraph::QueryBondPlan;
 
-// Entry layout in WarpSharedState::backEdges. A back edge of query atom d is an
-// edge to a query atom with a smaller index, i.e. one already mapped at depth d.
-constexpr unsigned char kBackEdgeAtomMask    = 63u;  ///< Low 6 bits: the earlier query atom's index.
-constexpr unsigned char kBackEdgeAltMaskFlag = 64u;  ///< Bit 6 (Dual only): use the Alt adjacency table.
-
-/**
- * @brief How many distinct bond masks (QueryAtomBondsT::matchMask) the query's
- *        back edges carry.
- *
- * With at most two, the target neighbour sets those masks induce can be
- * precomputed once per pair, turning the per-edge work in the inner loop into a
- * table lookup.
- */
-enum class BondMaskCase {
-  Uniform,  ///< One mask. One adjacency table suffices.
-  Dual,     ///< Two masks. Two adjacency tables; each back edge flags which it uses.
-  General   ///< Three or more. Neighbour sets recomputed per edge during the search.
-};
-
-/// Classification of the query's bond constraints; identical in every lane.
-struct QueryBondPlan {
-  BondMaskCase maskCase       = BondMaskCase::General;
-  uint32_t     minBondMask    = 0;  ///< Smallest bond mask on any back edge.
-  uint32_t     maxBondMask    = 0;  ///< Largest bond mask on any back edge; equals minBondMask iff Uniform.
-  /// Bitset over query atoms: bit d set iff depth d's only back edge goes to
-  /// depth d-1 and resolves through targetAdjacency. Such a depth needs no
-  /// back-edge lookup, since the caller just chose depth d-1's target atom.
-  uint64_t     chainDepths    = 0;
-  /// As chainDepths, for depths resolving through targetAdjacencyAlt.
-  uint64_t     chainDepthsAlt = 0;
-};
-
-// =============================================================================
-// Per-warp shared state
-// =============================================================================
-
-/**
- * @brief Per-warp lookup tables and counters, sized for a whole CTA.
- *
- * Warp w touches only [w][...], so no synchronisation beyond __syncwarp() is
- * needed. This is the kernel's only __shared__ allocation, so its size alone
- * determines how many CTAs fit per SM (minBlocksPerSM).
- *
- * The adjacency tables hold different things per BondMaskCase; buildTargetAdjacency
- * is the only place that fills them:
- *   Uniform: targetAdjacency[a] = atoms bonded to a over a bond the query's
- *            single mask accepts. Alt unused.
- *   Dual:    targetAdjacency[a] for minBondMask, targetAdjacencyAlt[a] for
- *            maxBondMask; each back edge picks one via kBackEdgeAltMaskFlag.
- *   General: nothing is precomputable, so the tables cache the packed adjacency
- *            row instead -- targetAdjacency[a].lo the neighbour-index bytes,
- *            targetAdjacencyAlt[a].lo the bond-info bytes.
- */
-template <std::size_t MaxTargetAtoms, std::size_t MaxQueryAtoms> struct WarpSharedState {
-  static_assert(MaxQueryAtoms <= 64, "Back-edge indices pack into 6 bits and chain depths into a 64-bit mask");
-
-  /// Roots each lane owns: lane, lane + 32, ... below MaxTargetAtoms.
-  static constexpr int kRoots = static_cast<int>(MaxTargetAtoms / 32);
-  using Mask                  = TargetMask<MaxTargetAtoms>;
-
-  /**
-   * @brief One adjacency table slot, read as whichever member the case stores.
-   *
-   * A union because the General case caches packed adjacency rows, which are
-   * always 64 bits wide, whereas a mask is only as wide as MaxTargetAtoms. This
-   * keeps the table exactly as large as the wider of the two, so narrowing Mask
-   * costs no shared memory here while still narrowing it in registers.
-   */
-  union AdjacencyEntry {
-    Mask     mask;
-    uint64_t packedRow;
-  };
-
-  AdjacencyEntry targetAdjacency[kWarpsPerBlock][MaxTargetAtoms];
-  AdjacencyEntry targetAdjacencyAlt[kWarpsPerBlock][MaxTargetAtoms];
-  /// Transposed label matrix: the target atoms compatible with each query atom.
-  Mask           queryAtomCandidates[kWarpsPerBlock][MaxQueryAtoms];
-  /// Per query atom, its back edges, kBackEdge*-encoded.
-  unsigned char  backEdges[kWarpsPerBlock][MaxQueryAtoms][kMaxBondsPerAtom];
-  unsigned char  backEdgeCounts[kWarpsPerBlock][MaxQueryAtoms];  ///< Valid entries in backEdges[w][q].
-  int            matchCount[kWarpsPerBlock];                     ///< Embeddings found for the warp's pair.
-  int            reportedCount[kWarpsPerBlock];                  ///< Of those, how many fit in the output buffer.
-};
+/// Per-warp tables for a CTA of kWarpsPerBlock pairs.
+template <std::size_t MaxTargetAtoms, std::size_t MaxQueryAtoms>
+using WarpSharedState = nvMolKit::subgraph::WarpSharedState<MaxTargetAtoms, MaxQueryAtoms, kWarpsPerBlock>;
 
 /// Second __launch_bounds__ argument for the DFS kernels: eight resident CTAs
 /// is the occupancy the search is tuned at, clamped to what WarpSharedState --
@@ -234,88 +157,49 @@ __device__ __forceinline__ TargetMask<MaxAtoms> neighborsMatchingBondMask(uint64
 }
 
 // =============================================================================
-// Candidate construction
+// Substructure adapter
 // =============================================================================
 
 /**
- * @brief The target atoms query atom @p depth may still map to: the candidates
- *        oracle handed to nvMolKit::dfsFromRoots.
+ * @brief Presents a (query, target) molecule pair to the generic frontend.
  *
- * Evaluates the intersection described in src/subgraph/warp_dfs.cuh, in four
- * shapes, cheapest first:
- *   - chain depth: the only back edge goes to depth-1, whose target atom the
- *     caller passes as @p prevTargetAtom, so the back-edge table is not read;
- *   - Uniform: every back edge intersects targetAdjacency;
- *   - Dual: each back edge's kBackEdgeAltMaskFlag picks its table;
- *   - General: recompute the neighbour set per edge from the cached packed row.
- *
- * Only the General case needs @p seen: it walks the query atom's raw bond slots,
- * which can name the same neighbour twice, whereas analyzeQueryBonds already
- * deduplicated the table.
+ * Search order is the identity over query atoms, so depth d is query atom d and
+ * a neighbour's depth is just its atom index. Edge keys are QueryAtomBonds
+ * match masks, and target rows pack into two words, so the General case caches
+ * them in shared memory rather than re-reading global memory per descent.
  */
-template <std::size_t MaxTargetAtoms, std::size_t MaxQueryAtoms>
-__device__ __forceinline__ TargetMask<MaxTargetAtoms> buildCandidates(
-  const WarpSharedState<MaxTargetAtoms, MaxQueryAtoms>& shared,
-  int                                                   warp,
-  int                                                   depth,
-  const unsigned char*                                  mapping,
-  const TargetMask<MaxTargetAtoms>&                     used,
-  const QueryMoleculeView&                              query,
-  const QueryBondPlan&                                  plan,
-  int                                                   prevTargetAtom) {
-  using Mask = TargetMask<MaxTargetAtoms>;
+template <std::size_t MaxTargetAtoms> struct SubstructAdapter {
+  using Mask                              = TargetMask<MaxTargetAtoms>;
+  static constexpr bool kCachesTargetRows = true;
 
-  Mask candidates = shared.queryAtomCandidates[warp][depth];
-  candidates.andNotEq(used);
+  const QueryMoleculeView*  query;
+  const TargetMoleculeView* target;
 
-  const uint64_t depthBit = 1ULL << depth;
-  if (plan.chainDepths & depthBit) {
-    candidates.andEq(shared.targetAdjacency[warp][prevTargetAtom].mask);
-    return candidates;
-  }
-  if (plan.chainDepthsAlt & depthBit) {
-    candidates.andEq(shared.targetAdjacencyAlt[warp][prevTargetAtom].mask);
-    return candidates;
+  __device__ __forceinline__ int degreeAt(int depth) const { return query->getQueryBonds(depth).degree; }
+
+  __device__ __forceinline__ int neighborDepthAt(int depth, int slot) const {
+    return static_cast<int>(query->getQueryBonds(depth).neighborIdx[slot]);
   }
 
-  const int numBackEdges = shared.backEdgeCounts[warp][depth];
-
-  if (plan.maskCase == BondMaskCase::Uniform) {
-    for (int k = 0; k < numBackEdges && !candidates.empty(); ++k) {
-      candidates.andEq(
-        shared.targetAdjacency[warp][mapping[shared.backEdges[warp][depth][k] & kBackEdgeAtomMask]].mask);
-    }
-    return candidates;
+  __device__ __forceinline__ uint32_t edgeKeyAt(int depth, int slot) const {
+    return query->getQueryBonds(depth).matchMask[slot];
   }
 
-  if (plan.maskCase == BondMaskCase::Dual) {
-    for (int k = 0; k < numBackEdges && !candidates.empty(); ++k) {
-      const uint32_t edge   = shared.backEdges[warp][depth][k];
-      const int      mapped = mapping[edge & kBackEdgeAtomMask];
-      candidates.andEq((edge & kBackEdgeAltMaskFlag) ? shared.targetAdjacencyAlt[warp][mapped].mask :
-                                                       shared.targetAdjacency[warp][mapped].mask);
-    }
-    return candidates;
+  __device__ __forceinline__ Mask neighborsMatching(int targetAtom, uint32_t edgeKey) const {
+    uint64_t neighbors;
+    uint64_t bondInfo;
+    packAdjacencyRow(target->targetAtomBonds[targetAtom], neighbors, bondInfo);
+    return neighborsMatchingBondMask<MaxTargetAtoms>(neighbors, bondInfo, edgeKey);
   }
 
-  const QueryAtomBonds& queryBonds = query.getQueryBonds(depth);
-  const int             degree     = queryBonds.degree;
-  uint64_t              seen       = 0;
-  for (int slot = 0; slot < kMaxBondsPerAtom && !candidates.empty(); ++slot) {
-    if (slot >= degree) {
-      break;
-    }
-    const uint32_t neighborQueryAtom = queryBonds.neighborIdx[slot];
-    if (neighborQueryAtom < static_cast<uint32_t>(depth) && !((seen >> neighborQueryAtom) & 1ULL)) {
-      seen |= 1ULL << neighborQueryAtom;
-      const int mapped = mapping[neighborQueryAtom];
-      candidates.andEq(neighborsMatchingBondMask<MaxTargetAtoms>(shared.targetAdjacency[warp][mapped].packedRow,
-                                                                 shared.targetAdjacencyAlt[warp][mapped].packedRow,
-                                                                 queryBonds.matchMask[slot]));
-    }
+  __device__ __forceinline__ void packTargetRow(int targetAtom, uint64_t& w0, uint64_t& w1) const {
+    packAdjacencyRow(target->targetAtomBonds[targetAtom], w0, w1);
   }
-  return candidates;
-}
+
+  __device__ __forceinline__ Mask neighborsMatchingPacked(uint64_t w0, uint64_t w1, uint32_t edgeKey) const {
+    return neighborsMatchingBondMask<MaxTargetAtoms>(w0, w1, edgeKey);
+  }
+};
 
 // =============================================================================
 // Per-pair setup
@@ -340,7 +224,7 @@ __device__ __forceinline__ uint64_t readLabelRow(const uint32_t* labelWords, int
 }
 
 /**
- * @brief Transpose the pair's label matrix into shared.queryAtomCandidates.
+ * @brief Transpose the pair's label matrix into shared.depthCandidates.
  *
  * The label matrix is target-major (row t, bit q) but the search needs it
  * query-major: at depth d, the target atoms compatible with query atom d. Each
@@ -387,153 +271,11 @@ __device__ __forceinline__ bool tryBuildQueryAtomCandidates(WarpSharedState<MaxT
       for (int k = 0; k < kRoots; ++k) {
         mask.setWord32(k, ballots[k]);
       }
-      shared.queryAtomCandidates[warp][depth] = mask;
+      shared.depthCandidates[warp][depth] = mask;
     }
   }
 
   return anyEmptyColumn == 0u;
-}
-
-/**
- * @brief Build the back-edge table and classify the query's bond masks.
- *
- * Three passes over the query atoms, striped across the warp:
- *  1. Record each query atom's deduplicated back edges into
- *     shared.backEdges/backEdgeCounts, reducing the smallest and largest bond
- *     mask across the warp. Min and max are only a cheap fingerprint for the
- *     number of distinct masks: all masks equal implies min == max, and if
- *     exactly two values occur they are the min and the max.
- *  2. If min != max, flag the max-mask edges and watch for a third value, which
- *     demotes the pair to General.
- *  3. Uniform and Dual only: find the chain depths (see QueryBondPlan).
- *
- * This is a pure function of the query but runs once per pair; it could be
- * computed once per query at host pack time and loaded instead.
- */
-template <std::size_t MaxTargetAtoms, std::size_t MaxQueryAtoms>
-__device__ __forceinline__ QueryBondPlan analyzeQueryBonds(WarpSharedState<MaxTargetAtoms, MaxQueryAtoms>& shared,
-                                                           int                                             warp,
-                                                           int                                             lane,
-                                                           const QueryMoleculeView&                        query,
-                                                           int numQueryAtoms) {
-  QueryBondPlan plan;
-
-  uint32_t laneMin = 0xFFFFFFFFu;
-  uint32_t laneMax = 0u;
-
-  for (int depth = lane; depth < numQueryAtoms; depth += 32) {
-    const QueryAtomBonds& bonds  = query.getQueryBonds(depth);
-    const int             degree = bonds.degree;
-    int                   count  = 0;
-    uint64_t              seen   = 0;
-    for (int slot = 0; slot < kMaxBondsPerAtom; ++slot) {
-      if (slot >= degree) {
-        break;
-      }
-      const uint32_t neighbor = bonds.neighborIdx[slot];
-      if (neighbor < static_cast<uint32_t>(depth) && !((seen >> neighbor) & 1ULL)) {
-        seen |= 1ULL << neighbor;
-        const uint32_t mask                  = bonds.matchMask[slot];
-        shared.backEdges[warp][depth][count] = static_cast<unsigned char>(neighbor);
-        laneMin                              = min(laneMin, mask);
-        laneMax                              = max(laneMax, mask);
-        ++count;
-      }
-    }
-    shared.backEdgeCounts[warp][depth] = static_cast<unsigned char>(count);
-  }
-
-  plan.minBondMask   = warpReduceMin(laneMin);
-  plan.maxBondMask   = warpReduceMax(laneMax);
-  const bool uniform = (plan.minBondMask == plan.maxBondMask);
-  __syncwarp();
-
-  // The walk here must mirror the first pass exactly: it re-derives the same
-  // slot ordering in order to flag the entries it wrote.
-  uint32_t sawThirdMask = 0;
-  if (!uniform) {
-    for (int depth = lane; depth < numQueryAtoms; depth += 32) {
-      const QueryAtomBonds& bonds  = query.getQueryBonds(depth);
-      const int             degree = bonds.degree;
-      int                   count  = 0;
-      uint64_t              seen   = 0;
-      for (int slot = 0; slot < kMaxBondsPerAtom; ++slot) {
-        if (slot >= degree) {
-          break;
-        }
-        const uint32_t neighbor = bonds.neighborIdx[slot];
-        if (neighbor < static_cast<uint32_t>(depth) && !((seen >> neighbor) & 1ULL)) {
-          seen |= 1ULL << neighbor;
-          const uint32_t mask = bonds.matchMask[slot];
-          if (mask != plan.minBondMask && mask != plan.maxBondMask) {
-            sawThirdMask = 1;
-          }
-          if (mask == plan.maxBondMask) {
-            shared.backEdges[warp][depth][count] |= kBackEdgeAltMaskFlag;
-          }
-          ++count;
-        }
-      }
-    }
-  }
-  const bool dual = !uniform && (__ballot_sync(kFullWarpMask, sawThirdMask) == 0u);
-  plan.maskCase   = uniform ? BondMaskCase::Uniform : (dual ? BondMaskCase::Dual : BondMaskCase::General);
-  __syncwarp();
-
-  if (plan.maskCase != BondMaskCase::General) {
-    uint64_t lanePrimary = 0;
-    uint64_t laneAlt     = 0;
-    for (int depth = lane; depth < numQueryAtoms; depth += 32) {
-      if (depth >= 1 && shared.backEdgeCounts[warp][depth] == 1) {
-        const uint32_t edge = shared.backEdges[warp][depth][0];
-        if ((edge & kBackEdgeAtomMask) == static_cast<uint32_t>(depth - 1)) {
-          if (edge & kBackEdgeAltMaskFlag) {
-            laneAlt |= 1ULL << depth;
-          } else {
-            lanePrimary |= 1ULL << depth;
-          }
-        }
-      }
-    }
-    // Two 32-bit OR reductions per 64-bit lane mask; the reductions are 32-bit.
-    plan.chainDepths = static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(lanePrimary))) |
-                       (static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(lanePrimary >> 32))) << 32);
-    plan.chainDepthsAlt = static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(laneAlt))) |
-                          (static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(laneAlt >> 32))) << 32);
-  }
-
-  return plan;
-}
-
-/**
- * @brief Fill the per-warp adjacency tables for the classified plan, target
- *        atoms striped across the warp. See WarpSharedState for the contents.
- */
-template <std::size_t MaxTargetAtoms, std::size_t MaxQueryAtoms>
-__device__ __forceinline__ void buildTargetAdjacency(WarpSharedState<MaxTargetAtoms, MaxQueryAtoms>& shared,
-                                                     int                                             warp,
-                                                     int                                             lane,
-                                                     const TargetMoleculeView&                       target,
-                                                     int                                             numTargetAtoms,
-                                                     const QueryBondPlan&                            plan) {
-  for (int atom = lane; atom < numTargetAtoms; atom += 32) {
-    uint64_t neighbors;
-    uint64_t bondInfo;
-    packAdjacencyRow(target.targetAtomBonds[atom], neighbors, bondInfo);
-
-    if (plan.maskCase == BondMaskCase::Uniform) {
-      shared.targetAdjacency[warp][atom].mask =
-        neighborsMatchingBondMask<MaxTargetAtoms>(neighbors, bondInfo, plan.maxBondMask);
-    } else if (plan.maskCase == BondMaskCase::Dual) {
-      shared.targetAdjacency[warp][atom].mask =
-        neighborsMatchingBondMask<MaxTargetAtoms>(neighbors, bondInfo, plan.minBondMask);
-      shared.targetAdjacencyAlt[warp][atom].mask =
-        neighborsMatchingBondMask<MaxTargetAtoms>(neighbors, bondInfo, plan.maxBondMask);
-    } else {
-      shared.targetAdjacency[warp][atom].packedRow    = neighbors;
-      shared.targetAdjacencyAlt[warp][atom].packedRow = bondInfo;
-    }
-  }
 }
 
 // =============================================================================
@@ -660,7 +402,7 @@ __device__ void dfsSearchPair(const TargetMoleculeView&                       ta
     for (int k = 0; k < kRoots; ++k) {
       rootMask.set(lane + 32 * k);
     }
-    Mask roots = shared.queryAtomCandidates[warp][0];
+    Mask roots = shared.depthCandidates[warp][0];
     roots.andEq(rootMask);
     return roots;
   };
@@ -696,16 +438,17 @@ __device__ void dfsSearchPair(const TargetMoleculeView&                       ta
     return;
   }
 
-  const QueryBondPlan plan = analyzeQueryBonds<MaxTargetAtoms, MaxQueryAtoms>(shared, warp, lane, query, numQueryAtoms);
+  const SubstructAdapter<MaxTargetAtoms> adapter{&query, &target};
 
-  buildTargetAdjacency<MaxTargetAtoms, MaxQueryAtoms>(shared, warp, lane, target, numTargetAtoms, plan);
+  const QueryBondPlan plan = nvMolKit::subgraph::analyzeQueryEdges(shared, warp, lane, adapter, numQueryAtoms);
+
+  nvMolKit::subgraph::buildTargetAdjacency(shared, warp, lane, adapter, numTargetAtoms, plan);
   __syncwarp();
 
   uint32_t laneTotal = 0;
 
   auto candidatesAt = [&](int depth, const unsigned char* mapping, const Mask& used, int prevTargetAtom) -> Mask {
-    return buildCandidates<MaxTargetAtoms,
-                           MaxQueryAtoms>(shared, warp, depth, mapping, used, query, plan, prevTargetAtom);
+    return nvMolKit::subgraph::buildCandidates(shared, warp, depth, mapping, used, adapter, plan, prevTargetAtom);
   };
 
   // The output mode as a terminal handler; every bit of @p terminals completes


### PR DESCRIPTION
The per-pair table machinery -- back-edge extraction, edge-key classification into Uniform/Dual/General, the adjacency tables, and buildCandidates -- moves to src/subgraph/labeled_dfs.cuh, generic over an adapter that presents a query in search order.

Depth becomes a search position rather than a query atom index, so a frontend can search a subset of a query in a permuted order. The substructure backend supplies SubstructAdapter with the identity order and is otherwise unchanged.

This will allow us to drop in MCS-specific bits without major further changes to DFS