### PR TITLE
Add the fMCS exact substructure fallback over the shared candidate tables

### DIFF
--- a/src/mcs/fmcs_cuda/fmcs_match.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_match.cuh
@@ -21,9 +21,25 @@
 #include "src/mcs/fmcs_cuda/fmcs_match_tables.cuh"
 #include "src/mcs/fmcs_cuda/fmcs_seed.cuh"
 #include "src/mcs/fmcs_cuda/fmcs_topology.cuh"
+#include "src/subgraph/candidate_tables.cuh"
+#include "src/subgraph/target_mask.cuh"
+#include "src/subgraph/warp_dfs.cuh"
 
 namespace mcs {
 namespace fmcs {
+
+/// Target-atom bitset wide enough for a tier's target capacity.  Tiers 16
+/// and 32 share the 32-bit form.  Deliberately keyed on the target size
+/// alone -- the DFS stack depth is keyed on the query size -- so
+/// rectangular (query size != target size) tiers need no matcher changes.
+/// Largest seed-atom degree the degreeAtLeast buckets distinguish.  Degrees
+/// above this clamp to the last bucket, which only weakens the filter.
+constexpr int kFmcsMaxSeedDegree = 8;
+
+template <int maxTargetAtoms>
+constexpr int kFmcsMaskAtoms = (maxTargetAtoms <= 32 ? 32 : (maxTargetAtoms <= 64 ? 64 : 128));
+
+template <int maxTargetAtoms> using FmcsTargetMask = nvMolKit::TargetMask<kFmcsMaskAtoms<maxTargetAtoms>>;
 
 /// Resolved target endpoints for a successful single-(query bond, target
 /// bond, orientation) compatibility check.  Populated by
@@ -35,19 +51,33 @@ struct SingleBondMatch {
   uint8_t targetAtomV;
 };
 
+/// Scratch for the exact substructure fallback.  One instance per
+/// concurrently-searching group; all fields are written under the caller's
+/// scratch ownership rules (see matchSeedWithSubstructureFallbackCooperative).
+///
+/// The search itself keeps its stack in lane-local registers
+/// (nvMolKit::dfsFromRoots); this scratch only carries the per-seed search
+/// order, the found flag the lanes race on, and the winning atom mapping.
 template <int maxAtoms, int maxTargetAtoms> struct FmcsSubstructureScratch {
-  // Scratch for the RDKit checkIfMatchAndAppend fallback.
-  std::uint8_t seedAtomList[maxAtoms];
-  std::uint8_t seedAtoms[maxAtoms];
-  std::uint8_t seedDegree[maxAtoms];
-  std::uint8_t targetDegree[maxTargetAtoms];
-  std::uint8_t orderedQueryAtom[maxAtoms];
-  std::uint8_t queryOrderPos[maxAtoms];
-  std::uint8_t targetAtomForQuery[maxAtoms];
-  int          currentCount;
-  int          nextCount;
-  int          found;
-  int          overflowed;
+  std::uint8_t seedAtomList[maxAtoms];        ///< Seed's query atoms in index order.
+  std::uint8_t seedAtoms[maxAtoms];           ///< Search order: order position -> query atom.
+  std::uint8_t seedDegree[maxAtoms];          ///< Per query atom, its degree within the seed.
+  std::uint8_t targetDegree[maxTargetAtoms];  ///< Per target atom, its full degree.
+  std::uint8_t orderedQueryAtom[maxAtoms];    ///< 1 if the atom has been placed in the order.
+  std::uint8_t queryOrderPos[maxAtoms];       ///< Inverse of seedAtoms; kUnmappedTargetIdx if not in seed.
+  std::uint8_t targetAtomForQuery[maxAtoms];  ///< The winning embedding, indexed by query atom.
+  int          found;                         ///< Lanes race on this via atomicCAS; also the abort signal.
+
+  /// degreeAtLeast[d] = target atoms whose degree is at least d.  Indexed by a
+  /// seed atom's degree (clamped), it turns "targets this atom could occupy"
+  /// into one mask intersection instead of a scan over every target atom.
+  FmcsTargetMask<maxTargetAtoms> degreeAtLeast[kFmcsMaxSeedDegree + 1];
+
+  /// Back-edge table and per-depth candidates for the shared frontend
+  /// (src/subgraph/candidate_tables.cuh).  One group per instance, hence a single
+  /// warp slot.  No adjacency tables: MCS keys edges on query bond index, so
+  /// keys are all distinct and the plan is always General.
+  nvMolKit::subgraph::WarpSharedState<kFmcsMaskAtoms<maxTargetAtoms>, maxAtoms, 1, false> tables;
 };
 
 template <int maxAtoms, int maxBonds>
@@ -134,6 +164,12 @@ __device__ __forceinline__ bool matchSingleBondWithinThread(const int           
 /// embedding.  The caller must run the exact substructure fallback before
 /// rejecting the seed or marking a NewBond dead.  On false, @p match is left
 /// in an unspecified state and must not be reused as a valid embedding.
+///
+/// Most seeds fall through to the fallback, so the fallback dominates
+/// matcher time.  Future optimization: build the target's packed adjacency
+/// once per block into shared memory -- it is fixed for the pair and this
+/// kernel is block-per-pair -- so the fallback's candidate build reads shared
+/// memory instead of walking the global CSR on every descent.
 template <int maxAtoms, int maxBonds, int maxTA, int maxTB, class GroupT>
 __device__ __forceinline__ bool tryMatchIncrementalGreedyCooperative(
   const GroupT&                                  group,
@@ -316,6 +352,572 @@ __device__ __forceinline__ bool tryMatchIncrementalGreedyCooperative(
     }
   }
   return true;
+}
+
+__device__ __forceinline__ bool findTargetBondBetweenAtomsWithinThread(const int                    targetAtomA,
+                                                                       const int                    targetAtomB,
+                                                                       const int                    queryBondIdx,
+                                                                       const DeviceCsrView&         targetTopology,
+                                                                       const PairMatchTablesDevice& tables,
+                                                                       int&                         outTargetBondIdx) {
+  if (targetAtomA < 0 || targetAtomA >= targetTopology.numAtoms) {
+    return false;
+  }
+  const int begin = static_cast<int>(targetTopology.rowOffsets[targetAtomA]);
+  const int end   = static_cast<int>(targetTopology.rowOffsets[targetAtomA + 1]);
+  for (int adjIdx = begin; adjIdx < end; ++adjIdx) {
+    const int otherTargetAtom = static_cast<int>(targetTopology.colIndices[adjIdx]);
+    if (otherTargetAtom != targetAtomB)
+      continue;
+    const int targetBondIdx = static_cast<int>(targetTopology.bondIndices[adjIdx]);
+    if (targetBondIdx < 0 || targetBondIdx >= targetTopology.numBonds) {
+      continue;
+    }
+    if (!tables.bonds.testBit(queryBondIdx, targetBondIdx))
+      continue;
+    outTargetBondIdx = targetBondIdx;
+    return true;
+  }
+  return false;
+}
+
+template <int maxAtoms, int maxBonds, int maxTA, int maxTB>
+__device__ __forceinline__ bool rebuildMatchFromSubstructureMappingWithinThread(
+  const Seed<maxAtoms, maxBonds>&                seed,
+  const DeviceCsrView&                           queryTopology,
+  const DeviceCsrView&                           targetTopology,
+  const PairMatchTablesDevice&                   tables,
+  MatchResult<maxAtoms, maxBonds, maxTA, maxTB>& match,
+  FmcsSubstructureScratch<maxAtoms, maxTA>&      scratch) {
+  using SeedT          = Seed<maxAtoms, maxBonds>;
+  using MatchT         = MatchResult<maxAtoms, maxBonds, maxTA, maxTB>;
+  using BondWord       = typename SeedT::bond_word_type;
+  using TargetBondWord = typename MatchT::target_bond_word;
+  using TargetAtomWord = typename MatchT::target_atom_word;
+
+  constexpr int kBondBitsPerWord       = SeedT::kBondBitsPerWord;
+  constexpr int kBondWords             = SeedT::kBondWords;
+  constexpr int kTargetAtomBitsPerWord = MatchT::kTargetAtomBitsPerWord;
+  constexpr int kTargetBondBitsPerWord = MatchT::kTargetBondBitsPerWord;
+
+  matchResultClearWithinThread(match);
+  for (int i = 0; i < seed.numAtoms; ++i) {
+    const int queryAtomIdx  = scratch.seedAtomList[i];
+    const int targetAtomIdx = scratch.targetAtomForQuery[queryAtomIdx];
+    if (targetAtomIdx == kUnmappedTargetIdx)
+      return false;
+    match.targetAtomIdx[queryAtomIdx] = static_cast<std::uint8_t>(targetAtomIdx);
+    match.visitedTargetAtoms[targetAtomIdx / kTargetAtomBitsPerWord] |= static_cast<TargetAtomWord>(1)
+                                                                     << (targetAtomIdx % kTargetAtomBitsPerWord);
+  }
+  match.matchedAtomSize = seed.numAtoms;
+
+  int matchedBondCount = 0;
+  for (int wordIdx = 0; wordIdx < kBondWords; ++wordIdx) {
+    BondWord remaining = seed.bonds[wordIdx];
+    while (remaining != 0) {
+      int bitPosInWord;
+      if constexpr (sizeof(BondWord) == 4) {
+        bitPosInWord = __ffs(static_cast<unsigned int>(remaining)) - 1;
+      } else {
+        bitPosInWord = __ffsll(static_cast<unsigned long long>(remaining)) - 1;
+      }
+      const int queryBondIdx = wordIdx * kBondBitsPerWord + bitPosInWord;
+      remaining &= remaining - 1;
+
+      const std::uint32_t queryEndpoints  = queryTopology.bondEndpoints[queryBondIdx];
+      const int           queryEndpointU  = static_cast<int>(queryEndpoints >> kBondEndpointShift);
+      const int           queryEndpointV  = static_cast<int>(queryEndpoints & kBondEndpointMask);
+      const int           targetEndpointU = match.targetAtomIdx[queryEndpointU];
+      const int           targetEndpointV = match.targetAtomIdx[queryEndpointV];
+      if (targetEndpointU == kUnmappedTargetIdx || targetEndpointV == kUnmappedTargetIdx) {
+        matchResultClearWithinThread(match);
+        return false;
+      }
+
+      int targetBondIdx = -1;
+      if (!findTargetBondBetweenAtomsWithinThread(targetEndpointU,
+                                                  targetEndpointV,
+                                                  queryBondIdx,
+                                                  targetTopology,
+                                                  tables,
+                                                  targetBondIdx)) {
+        matchResultClearWithinThread(match);
+        return false;
+      }
+      const TargetBondWord visitedWord = match.visitedTargetBonds[targetBondIdx / kTargetBondBitsPerWord];
+      if ((visitedWord >> (targetBondIdx % kTargetBondBitsPerWord)) & 1) {
+        matchResultClearWithinThread(match);
+        return false;
+      }
+      match.targetBondIdx[queryBondIdx] = static_cast<std::uint8_t>(targetBondIdx);
+      match.visitedTargetBonds[targetBondIdx / kTargetBondBitsPerWord] |= static_cast<TargetBondWord>(1)
+                                                                       << (targetBondIdx % kTargetBondBitsPerWord);
+      ++matchedBondCount;
+    }
+  }
+  match.matchedBondSize = static_cast<std::uint16_t>(matchedBondCount);
+  if (matchedBondCount != seed.numBonds) {
+    matchResultClearWithinThread(match);
+    return false;
+  }
+  match.empty = false;
+  return true;
+}
+
+/// Row @p queryAtomIdx of the atom match table as a target-atom bitset.
+/// Rows are 32-bit-word-packed LSB-first, exactly TargetMask's word layout,
+/// so this is straight word loads.  Bits at or above the table's column
+/// count are never set (rows are zero-initialised on the host).
+template <int maxTA>
+__device__ __forceinline__ FmcsTargetMask<maxTA> atomRowMask(const MatchTableDevice& table, const int queryAtomIdx) {
+  FmcsTargetMask<maxTA> mask;
+  mask.clear();
+  const std::uint32_t* rowWords = table.data + static_cast<size_t>(queryAtomIdx) * table.wordsPerRow;
+#pragma unroll
+  for (int wordIdx = 0; wordIdx < static_cast<int>(sizeof(FmcsTargetMask<maxTA>) / 4); ++wordIdx) {
+    if (wordIdx < table.wordsPerRow) {
+      mask.setWord32(wordIdx, rowWords[wordIdx]);
+    }
+  }
+  return mask;
+}
+
+template <int maxAtoms, int maxTA, class GroupT>
+__device__ __forceinline__ void initializeSeedSubstructureScratchCooperative(
+  const GroupT&                             group,
+  const DeviceCsrView&                      targetTopology,
+  FmcsSubstructureScratch<maxAtoms, maxTA>& scratch) {
+  const int laneRank  = static_cast<int>(group.thread_rank());
+  const int laneCount = static_cast<int>(group.num_threads());
+
+  for (int i = laneRank; i < maxAtoms; i += laneCount) {
+    scratch.seedDegree[i]         = 0;
+    scratch.orderedQueryAtom[i]   = 0;
+    scratch.queryOrderPos[i]      = kUnmappedTargetIdx;
+    scratch.targetAtomForQuery[i] = kUnmappedTargetIdx;
+  }
+
+  for (int targetAtomIdx = laneRank; targetAtomIdx < targetTopology.numAtoms; targetAtomIdx += laneCount) {
+    scratch.targetDegree[targetAtomIdx] = static_cast<std::uint8_t>(targetTopology.rowOffsets[targetAtomIdx + 1] -
+                                                                    targetTopology.rowOffsets[targetAtomIdx]);
+  }
+
+  group.sync();
+
+  // One lane per bucket, each scanning the target atoms once.  Cheaper than a
+  // masked reduction and it keeps every bucket's build independent.
+  if (laneRank <= kFmcsMaxSeedDegree) {
+    FmcsTargetMask<maxTA> bucket;
+    bucket.clear();
+    for (int targetAtomIdx = 0; targetAtomIdx < targetTopology.numAtoms && targetAtomIdx < maxTA; ++targetAtomIdx) {
+      if (scratch.targetDegree[targetAtomIdx] >= laneRank) {
+        bucket.set(targetAtomIdx);
+      }
+    }
+    scratch.degreeAtLeast[laneRank] = bucket;
+  }
+
+  if (laneRank == 0) {
+    scratch.found = 0;
+  }
+  group.sync();
+}
+
+template <int maxAtoms, int maxBonds, int maxTA>
+__device__ __forceinline__ bool prepareSeedSubstructureSearchWithinThread(
+  const Seed<maxAtoms, maxBonds>&           seed,
+  const DeviceCsrView&                      queryTopology,
+  const DeviceCsrView&                      targetTopology,
+  const PairMatchTablesDevice&              tables,
+  FmcsSubstructureScratch<maxAtoms, maxTA>& scratch,
+  int&                                      numSeedAtoms) {
+  using SeedT    = Seed<maxAtoms, maxBonds>;
+  using AtomWord = typename SeedT::atom_word_type;
+  using BondWord = typename SeedT::bond_word_type;
+
+  constexpr int kAtomBitsPerWord = SeedT::kAtomBitsPerWord;
+  constexpr int kAtomWords       = SeedT::kAtomWords;
+  constexpr int kBondBitsPerWord = SeedT::kBondBitsPerWord;
+  constexpr int kBondWords       = SeedT::kBondWords;
+
+  if (seed.numAtoms > targetTopology.numAtoms || seed.numBonds > targetTopology.numBonds) {
+    return false;
+  }
+
+  numSeedAtoms = 0;
+  for (int wordIdx = 0; wordIdx < kAtomWords; ++wordIdx) {
+    AtomWord remaining = seed.atoms[wordIdx];
+    while (remaining != 0) {
+      int bitPosInWord;
+      if constexpr (sizeof(AtomWord) == 4) {
+        bitPosInWord = __ffs(static_cast<unsigned int>(remaining)) - 1;
+      } else {
+        bitPosInWord = __ffsll(static_cast<unsigned long long>(remaining)) - 1;
+      }
+      const int queryAtomIdx = wordIdx * kAtomBitsPerWord + bitPosInWord;
+      remaining &= remaining - 1;
+      if (queryAtomIdx < queryTopology.numAtoms) {
+        scratch.seedAtomList[numSeedAtoms++] = static_cast<std::uint8_t>(queryAtomIdx);
+      }
+    }
+  }
+  if (numSeedAtoms != seed.numAtoms)
+    return false;
+
+  for (int wordIdx = 0; wordIdx < kBondWords; ++wordIdx) {
+    BondWord remaining = seed.bonds[wordIdx];
+    while (remaining != 0) {
+      int bitPosInWord;
+      if constexpr (sizeof(BondWord) == 4) {
+        bitPosInWord = __ffs(static_cast<unsigned int>(remaining)) - 1;
+      } else {
+        bitPosInWord = __ffsll(static_cast<unsigned long long>(remaining)) - 1;
+      }
+      const int queryBondIdx = wordIdx * kBondBitsPerWord + bitPosInWord;
+      remaining &= remaining - 1;
+
+      const std::uint32_t queryEndpoints = queryTopology.bondEndpoints[queryBondIdx];
+      const int           queryEndpointU = static_cast<int>(queryEndpoints >> kBondEndpointShift);
+      const int           queryEndpointV = static_cast<int>(queryEndpoints & kBondEndpointMask);
+      ++scratch.seedDegree[queryEndpointU];
+      ++scratch.seedDegree[queryEndpointV];
+    }
+  }
+
+  for (int orderPos = 0; orderPos < numSeedAtoms; ++orderPos) {
+    int bestAtom                = -1;
+    int bestMappedNeighborCount = -1;
+    int bestDegree              = -1;
+    int bestCandidateCount      = maxTA + 1;
+
+    for (int atomListIdx = 0; atomListIdx < numSeedAtoms; ++atomListIdx) {
+      const int queryAtomIdx = scratch.seedAtomList[atomListIdx];
+      if (scratch.orderedQueryAtom[queryAtomIdx])
+        continue;
+
+      int mappedNeighborCount = 0;
+      if (orderPos > 0) {
+        const int begin = static_cast<int>(queryTopology.rowOffsets[queryAtomIdx]);
+        const int end   = static_cast<int>(queryTopology.rowOffsets[queryAtomIdx + 1]);
+        for (int adjIdx = begin; adjIdx < end; ++adjIdx) {
+          const int queryBondIdx = static_cast<int>(queryTopology.bondIndices[adjIdx]);
+          if (queryBondIdx >= queryTopology.numBonds ||
+              !seedContainsBondWithinThread<maxAtoms, maxBonds>(seed, queryBondIdx)) {
+            continue;
+          }
+          const int otherQueryAtom = static_cast<int>(queryTopology.colIndices[adjIdx]);
+          if (otherQueryAtom >= 0 && otherQueryAtom < queryTopology.numAtoms &&
+              scratch.orderedQueryAtom[otherQueryAtom]) {
+            ++mappedNeighborCount;
+          }
+        }
+      }
+      if (orderPos > 0 && mappedNeighborCount == 0)
+        continue;
+
+      FmcsTargetMask<maxTA> candidates = atomRowMask<maxTA>(tables.atoms, queryAtomIdx);
+      candidates.andEq(
+        scratch.degreeAtLeast[min(static_cast<int>(scratch.seedDegree[queryAtomIdx]), kFmcsMaxSeedDegree)]);
+      const int candidateCount = candidates.popcount();
+      if (candidateCount == 0)
+        return false;
+
+      const int  degree = scratch.seedDegree[queryAtomIdx];
+      const bool better = bestAtom < 0 || mappedNeighborCount > bestMappedNeighborCount ||
+                          (mappedNeighborCount == bestMappedNeighborCount && degree > bestDegree) ||
+                          (mappedNeighborCount == bestMappedNeighborCount && degree == bestDegree &&
+                           candidateCount < bestCandidateCount) ||
+                          (mappedNeighborCount == bestMappedNeighborCount && degree == bestDegree &&
+                           candidateCount == bestCandidateCount && queryAtomIdx < bestAtom);
+      if (better) {
+        bestAtom                = queryAtomIdx;
+        bestMappedNeighborCount = mappedNeighborCount;
+        bestDegree              = degree;
+        bestCandidateCount      = candidateCount;
+      }
+    }
+
+    if (bestAtom < 0) {
+      for (int atomListIdx = 0; atomListIdx < numSeedAtoms; ++atomListIdx) {
+        const int queryAtomIdx = scratch.seedAtomList[atomListIdx];
+        if (!scratch.orderedQueryAtom[queryAtomIdx]) {
+          bestAtom = queryAtomIdx;
+          break;
+        }
+      }
+    }
+    if (bestAtom < 0)
+      return false;
+    scratch.seedAtoms[orderPos]        = static_cast<std::uint8_t>(bestAtom);
+    scratch.orderedQueryAtom[bestAtom] = 1;
+    scratch.queryOrderPos[bestAtom]    = static_cast<std::uint8_t>(orderPos);
+  }
+  return true;
+}
+
+/// Presents a seed inside its query molecule to the shared subgraph frontend
+/// (src/subgraph/candidate_tables.cuh).
+///
+/// Depth is an order position in @c scratch.seedAtoms, the most-constrained-first
+/// permutation over the seed's atoms, so the frontend searches only the seed and
+/// in that order.  Query edges are the seed's bonds: a CSR slot whose bond is
+/// outside the seed, or whose far atom has no order position, reports
+/// @c kNoNeighborDepth and so constrains nothing.
+///
+/// The edge key is the query bond index, and @ref neighborsMatching resolves it
+/// through the (query bond, target bond) match table.  Because every bond index
+/// is distinct the plan is always General, which is why the scratch omits the
+/// adjacency tables.  Keying on the uint16 edge label instead would let
+/// Uniform/Dual precompute fire -- MCS queries carry few distinct labels -- but
+/// needs the labels uploaded to the device, which they are not today.
+///
+/// Precondition: no seed atom exceeds @c kMaxEdgeSlotsPerAtom CSR neighbours,
+/// which holds for molecular graphs (nvMolKit caps packed degree at 8).
+template <int maxAtoms, int maxBonds, int maxTA, int maxTB> struct McsSeedAdapter {
+  using Mask                              = FmcsTargetMask<maxTA>;
+  static constexpr bool kCachesTargetRows = false;
+
+  const Seed<maxAtoms, maxBonds>*                 seed;
+  const DeviceCsrView*                            queryTopology;
+  const DeviceCsrView*                            targetTopology;
+  const PairMatchTablesDevice*                    tables;
+  const FmcsSubstructureScratch<maxAtoms, maxTA>* scratch;
+
+  __device__ __forceinline__ int queryAtomAt(int depth) const { return scratch->seedAtoms[depth]; }
+
+  __device__ __forceinline__ int degreeAt(int depth) const {
+    const int queryAtomIdx = queryAtomAt(depth);
+    return static_cast<int>(queryTopology->rowOffsets[queryAtomIdx + 1]) -
+           static_cast<int>(queryTopology->rowOffsets[queryAtomIdx]);
+  }
+
+  __device__ __forceinline__ int neighborDepthAt(int depth, int slot) const {
+    const int adjIdx       = static_cast<int>(queryTopology->rowOffsets[queryAtomAt(depth)]) + slot;
+    const int queryBondIdx = static_cast<int>(queryTopology->bondIndices[adjIdx]);
+    if (queryBondIdx >= queryTopology->numBonds ||
+        !seedContainsBondWithinThread<maxAtoms, maxBonds>(*seed, queryBondIdx)) {
+      return nvMolKit::subgraph::kNoNeighborDepth;
+    }
+    const int otherQueryAtom = static_cast<int>(queryTopology->colIndices[adjIdx]);
+    if (otherQueryAtom < 0 || otherQueryAtom >= queryTopology->numAtoms) {
+      return nvMolKit::subgraph::kNoNeighborDepth;
+    }
+    const int orderPos = scratch->queryOrderPos[otherQueryAtom];
+    return orderPos == kUnmappedTargetIdx ? nvMolKit::subgraph::kNoNeighborDepth : orderPos;
+  }
+
+  __device__ __forceinline__ std::uint32_t edgeKeyAt(int depth, int slot) const {
+    return queryTopology->bondIndices[static_cast<int>(queryTopology->rowOffsets[queryAtomAt(depth)]) + slot];
+  }
+
+  __device__ __forceinline__ Mask neighborsMatching(int targetAtom, std::uint32_t queryBondIdx) const {
+    Mask mask;
+    mask.clear();
+    const int begin = static_cast<int>(targetTopology->rowOffsets[targetAtom]);
+    const int end   = static_cast<int>(targetTopology->rowOffsets[targetAtom + 1]);
+    for (int adjIdx = begin; adjIdx < end; ++adjIdx) {
+      const int targetBondIdx = static_cast<int>(targetTopology->bondIndices[adjIdx]);
+      if (targetBondIdx < 0 || targetBondIdx >= targetTopology->numBonds || targetBondIdx >= maxTB) {
+        continue;
+      }
+      if (!tables->bonds.testBit(static_cast<int>(queryBondIdx), targetBondIdx)) {
+        continue;
+      }
+      const int neighborTargetAtom = static_cast<int>(targetTopology->colIndices[adjIdx]);
+      if (neighborTargetAtom >= 0 && neighborTargetAtom < targetTopology->numAtoms && neighborTargetAtom < maxTA) {
+        mask.set(neighborTargetAtom);
+      }
+    }
+    return mask;
+  }
+};
+
+/// Exact seed-in-target substructure check: a lane-parallel DFS
+/// (nvMolKit::dfsFromRoots) racing for one embedding.
+///
+/// Lane L searches the subtrees rooted at compatible target atoms L,
+/// L+laneCount, ... for the seed atom at order position 0; the search order
+/// over seed atoms is the most-constrained-first permutation computed by
+/// @ref prepareSeedSubstructureSearchWithinThread.  The candidate set is
+/// the canonical intersection (see src/subgraph/warp_dfs.cuh): the query
+/// atom's match-table row, minus used target atoms, intersected per seed
+/// back edge with the neighbours of the mapped target atom reachable over a
+/// bond whose (query bond, target bond) match-table bit is set.
+///
+/// The first lane to complete an embedding wins @c scratch.found by
+/// atomicCAS and records the atom mapping; every other lane stops at its
+/// next abort poll.  Lane 0 then rebuilds @p match (including the bond
+/// mapping) from the recorded atoms.  The search is exhaustive within
+/// bounded memory -- the stack is O(seed atoms) of lane-local registers, with
+/// no partial-mapping buffer to overflow -- so a false return proves the seed
+/// does not embed in the target.
+///
+/// Group-uniform: all lanes of @p group must call this together.  The
+/// caller must own @p scratch for the duration of the call.
+template <int maxAtoms, int maxBonds, int maxTA, int maxTB, class GroupT>
+__device__ __forceinline__ bool matchSeedSubstructureCooperative(const GroupT&                   group,
+                                                                 const Seed<maxAtoms, maxBonds>& seed,
+                                                                 const DeviceCsrView&            queryTopology,
+                                                                 const DeviceCsrView&            targetTopology,
+                                                                 const PairMatchTablesDevice&    tables,
+                                                                 MatchResult<maxAtoms, maxBonds, maxTA, maxTB>& match,
+                                                                 FmcsSubstructureScratch<maxAtoms, maxTA>& scratch) {
+  using Mask = FmcsTargetMask<maxTA>;
+
+  const int laneRank  = static_cast<int>(group.thread_rank());
+  const int laneCount = static_cast<int>(group.num_threads());
+
+  int numSeedAtoms = 0;
+  int prepared     = 0;
+  if (laneRank == 0) {
+    matchResultClearWithinThread(match);
+  }
+  if (seed.numAtoms != 0) {
+    initializeSeedSubstructureScratchCooperative(group, targetTopology, scratch);
+  }
+  if (laneRank == 0) {
+    if (seed.numAtoms == 0) {
+      prepared = (seed.numBonds == 0) ? 2 : -1;
+    } else {
+      prepared =
+        prepareSeedSubstructureSearchWithinThread(seed, queryTopology, targetTopology, tables, scratch, numSeedAtoms) ?
+          1 :
+          -1;
+    }
+  }
+  group.sync();
+  prepared     = group.shfl(prepared, 0);
+  numSeedAtoms = group.shfl(numSeedAtoms, 0);
+  if (prepared == 2)
+    return true;
+  if (prepared < 0) {
+    return false;
+  }
+
+  // Roots: target atoms compatible with the first seed atom in search order,
+  // degree-filtered, striped across the lanes.
+  const int firstQueryAtom = scratch.seedAtoms[0];
+  Mask      laneStripe;
+  laneStripe.clear();
+  for (int targetAtomIdx = laneRank; targetAtomIdx < maxTA; targetAtomIdx += laneCount) {
+    laneStripe.set(targetAtomIdx);
+  }
+  Mask laneRoots = atomRowMask<maxTA>(tables.atoms, firstQueryAtom);
+  laneRoots.andEq(scratch.degreeAtLeast[min(static_cast<int>(scratch.seedDegree[firstQueryAtom]), kFmcsMaxSeedDegree)]);
+  laneRoots.andEq(laneStripe);
+
+  if (numSeedAtoms == 1) {
+    // No bonds to satisfy: the lowest compatible root is a complete
+    // embedding.  Reduce lane-local lowest roots to the group minimum.
+    int lowestRoot = laneRoots.empty() ? maxTA : laneRoots.lowest();
+    for (int offset = laneCount / 2; offset > 0; offset >>= 1) {
+      lowestRoot = min(lowestRoot, group.shfl_xor(lowestRoot, offset));
+    }
+    if (lowestRoot >= maxTA)
+      return false;
+    if (laneRank == 0) {
+      scratch.targetAtomForQuery[firstQueryAtom] = static_cast<std::uint8_t>(lowestRoot);
+      prepared =
+        rebuildMatchFromSubstructureMappingWithinThread(seed, queryTopology, targetTopology, tables, match, scratch) ?
+          1 :
+          -1;
+    }
+    group.sync();
+    prepared = group.shfl(prepared, 0);
+    return prepared == 1;
+  }
+
+  // Hand the seed to the shared frontend: fill the per-depth label term from
+  // the atom match table (already query-major, so no transpose), then build the
+  // back-edge table.  buildTargetAdjacency is a no-op for this adapter (always
+  // General, no row caching) but is called so the contract stays uniform.
+  const McsSeedAdapter<maxAtoms, maxBonds, maxTA, maxTB> adapter{&seed,
+                                                                 &queryTopology,
+                                                                 &targetTopology,
+                                                                 &tables,
+                                                                 &scratch};
+
+  for (int depth = laneRank; depth < numSeedAtoms; depth += laneCount) {
+    scratch.tables.depthCandidates[0][depth] = atomRowMask<maxTA>(tables.atoms, scratch.seedAtoms[depth]);
+  }
+  group.sync();
+
+  const nvMolKit::subgraph::QueryBondPlan plan =
+    nvMolKit::subgraph::analyzeQueryEdges(scratch.tables, 0, laneRank, adapter, numSeedAtoms);
+  nvMolKit::subgraph::buildTargetAdjacency(scratch.tables, 0, laneRank, adapter, targetTopology.numAtoms, plan);
+  group.sync();
+
+  auto candidatesAt = [&](int depth, const unsigned char* mapping, const Mask& used, int prevTargetAtom) -> Mask {
+    return nvMolKit::subgraph::buildCandidates(scratch.tables, 0, depth, mapping, used, adapter, plan, prevTargetAtom);
+  };
+
+  // First complete embedding wins scratch.found; the winner alone records
+  // the atom mapping, translated from order positions back to query atoms.
+  auto onTerminal = [&](Mask terminals, const unsigned char* mapping) -> nvMolKit::DfsTerminalVerdict {
+    nvMolKit::DfsTerminalVerdict verdict{false, false};
+    if (!terminals.empty()) {
+      if (atomicCAS(&scratch.found, 0, 1) == 0) {
+        for (int orderPos = 0; orderPos < numSeedAtoms - 1; ++orderPos) {
+          scratch.targetAtomForQuery[scratch.seedAtoms[orderPos]] = mapping[orderPos];
+        }
+        scratch.targetAtomForQuery[scratch.seedAtoms[numSeedAtoms - 1]] = static_cast<std::uint8_t>(terminals.lowest());
+      }
+      verdict.laneDone = true;
+    }
+    return verdict;
+  };
+
+  auto abortRequested = [&]() -> bool { return atomicAdd(&scratch.found, 0) != 0; };
+
+  nvMolKit::dfsFromRoots<maxAtoms>(laneRoots, numSeedAtoms - 1, candidatesAt, onTerminal, abortRequested);
+  group.sync();
+
+  int found = scratch.found;
+  if (found != 0) {
+    if (laneRank == 0) {
+      found =
+        rebuildMatchFromSubstructureMappingWithinThread(seed, queryTopology, targetTopology, tables, match, scratch) ?
+          1 :
+          0;
+    }
+    group.sync();
+    found = group.shfl(found, 0);
+    return found != 0;
+  }
+
+  if (laneRank == 0) {
+    matchResultClearWithinThread(match);
+  }
+  group.sync();
+  return false;
+}
+
+template <int maxAtoms, int maxBonds, int maxTA, int maxTB, class GroupT>
+__device__ __forceinline__ bool matchSeedWithSubstructureFallbackCooperative(
+  const GroupT&                                  group,
+  const Seed<maxAtoms, maxBonds>&                seed,
+  const DeviceCsrView&                           queryTopology,
+  const DeviceCsrView&                           targetTopology,
+  const PairMatchTablesDevice&                   tables,
+  MatchResult<maxAtoms, maxBonds, maxTA, maxTB>& match,
+  FmcsSubstructureScratch<maxAtoms, maxTA>&      scratch,
+  int*                                           scratchLock) {
+  if (tryMatchIncrementalGreedyCooperative(group, seed, queryTopology, targetTopology, tables, match)) {
+    return true;
+  }
+  if (group.thread_rank() == 0) {
+    while (atomicCAS(scratchLock, 0, 1) != 0) {
+    }
+  }
+  group.sync();
+  const bool ok = matchSeedSubstructureCooperative(group, seed, queryTopology, targetTopology, tables, match, scratch);
+  group.sync();
+  if (group.thread_rank() == 0) {
+    atomicExch(scratchLock, 0);
+  }
+  group.sync();
+  return ok;
 }
 
 }  // namespace fmcs

--- a/src/subgraph/candidate_tables.cuh
+++ b/src/subgraph/candidate_tables.cuh
@@ -29,9 +29,10 @@
 //
 // Everything problem-specific is behind an Adapter, which presents the query
 // *in search order*: depth d is a search position, not necessarily query atom
-// d. The substructure backend uses the identity order over all query atoms; a
-// frontend that searches a permuted order supplies the permutation in its
-// adapter. This layer never sees atom ids, only depths.
+// d. A substructure backend uses the identity order over all query atoms; an
+// MCS seed matcher uses a most-constrained-first permutation over the seed's
+// atoms only, and its adapter simply reports no edges for anything outside the
+// seed. The frontend never sees atom ids, only depths.
 //
 // Adapter contract (all __device__, all const):
 //
@@ -45,7 +46,10 @@
 //                                                 // dropped
 //   int      neighborDepthAt(int depth, int slot) const;
 //                                                 // search depth of that
-//                                                 // neighbour
+//                                                 // neighbour, or
+//                                                 // kNoNeighborDepth if the
+//                                                 // neighbour is outside the
+//                                                 // search set
 //   uint32_t edgeKeyAt(int depth, int slot) const;
 //                                                 // opaque predicate key;
 //                                                 // equal keys must mean
@@ -66,9 +70,10 @@
 // sets it false and pays a global walk per General-case descent.
 //
 // The label-compatibility term (WarpSharedState::depthCandidates) is filled by
-// the frontend, not the adapter: the substructure backend transposes its
-// target-major label matrix with a ballot per depth. buildCandidates only
-// reads that table.
+// the frontend, not the adapter: the substructure backend transposes a
+// target-major label matrix with a ballot per depth, while an MCS matcher reads
+// its already-query-major atom match table rows directly. Both write the same
+// table, and buildCandidates only reads it.
 
 #ifndef NVMOLKIT_SUBGRAPH_CANDIDATE_TABLES_CUH
 #define NVMOLKIT_SUBGRAPH_CANDIDATE_TABLES_CUH
@@ -82,13 +87,38 @@
 namespace nvMolKit {
 namespace subgraph {
 
+/// Returned by Adapter::neighborDepthAt for an edge whose far end is not in
+/// the search set (an MCS seed's boundary, for instance).
+constexpr int kNoNeighborDepth = -1;
+
 /// Max edge slots per atom the back-edge table reserves per depth.
 constexpr int kMaxEdgeSlotsPerAtom = 8;
 
 // Entry layout in WarpSharedState::backEdges. A back edge of depth d goes to a
 // depth smaller than d, i.e. one already mapped when d is chosen.
-constexpr unsigned char kBackEdgeDepthMask   = 63u;  ///< Low 6 bits: the earlier depth.
-constexpr unsigned char kBackEdgeAltMaskFlag = 64u;  ///< Bit 6 (Dual only): use the Alt adjacency table.
+constexpr unsigned char kBackEdgeDepthMask   = 127u;  ///< Low 7 bits: the earlier depth (0..127).
+constexpr unsigned char kBackEdgeAltMaskFlag = 128u;  ///< Bit 7 (Dual only): use the Alt adjacency table.
+
+/// Bitset over search depths, wide enough for the largest supported depth.
+/// Used for chain-depth flags and for deduplicating a depth's back edges.
+struct DepthBitset {
+  uint64_t words[2];
+
+  __device__ __forceinline__ void clear() { words[0] = words[1] = 0; }
+  __device__ __forceinline__ bool test(int depth) const { return ((words[depth >> 6] >> (depth & 63)) & 1ULL) != 0; }
+  __device__ __forceinline__ void set(int depth) { words[depth >> 6] |= 1ULL << (depth & 63); }
+};
+
+/// Warp-wide OR of a DepthBitset; the underlying reductions are 32-bit.
+__device__ __forceinline__ DepthBitset warpReduceOrDepths(const DepthBitset& lane) {
+  DepthBitset out;
+#pragma unroll
+  for (int w = 0; w < 2; ++w) {
+    out.words[w] = static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(lane.words[w]))) |
+                   (static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(lane.words[w] >> 32))) << 32);
+  }
+  return out;
+}
 
 /**
  * @brief How many distinct edge predicate keys the query's back edges carry.
@@ -104,15 +134,19 @@ enum class BondMaskCase {
 
 /// Classification of the query's edge constraints; identical in every lane.
 struct QueryBondPlan {
-  BondMaskCase maskCase       = BondMaskCase::General;
-  uint32_t     minBondMask    = 0;  ///< Smallest key on any back edge.
-  uint32_t     maxBondMask    = 0;  ///< Largest key on any back edge; equals minBondMask iff Uniform.
+  BondMaskCase maskCase    = BondMaskCase::General;
+  uint32_t     minBondMask = 0;  ///< Smallest key on any back edge.
+  uint32_t     maxBondMask = 0;  ///< Largest key on any back edge; equals minBondMask iff Uniform.
   /// Bit d set iff depth d's only back edge goes to depth d-1 and resolves
   /// through targetAdjacency. Such a depth needs no back-edge lookup, since the
   /// caller just chose depth d-1's target atom.
-  uint64_t     chainDepths    = 0;
+  DepthBitset  chainDepths = {
+    {0, 0}
+  };
   /// As chainDepths, for depths resolving through targetAdjacencyAlt.
-  uint64_t     chainDepthsAlt = 0;
+  DepthBitset chainDepthsAlt = {
+    {0, 0}
+  };
 };
 
 /**
@@ -131,8 +165,14 @@ struct QueryBondPlan {
  *   General: with kCachesTargetRows, the tables cache the adapter's packed
  *            adjacency row instead; without it, they are unused.
  */
-template <std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock> struct WarpSharedState {
-  static_assert(MaxSearchDepth <= 64, "Back-edge depths pack into 6 bits and chain depths into a 64-bit mask");
+template <std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock, bool WithAdjacencyTables = true>
+struct WarpSharedState {
+  static_assert(MaxSearchDepth <= 128, "Back-edge depths pack into 7 bits");
+
+  /// An adapter that neither precomputes neighbour sets (always General) nor
+  /// caches packed rows never reads the adjacency tables; sizing them to one
+  /// entry keeps the shared footprint to the back-edge table and candidates.
+  static constexpr std::size_t kAdjacencyEntries = WithAdjacencyTables ? MaxTargetAtoms : 1;
 
   /// Roots each lane owns: lane, lane + 32, ... below MaxTargetAtoms.
   static constexpr int kRoots = static_cast<int>(MaxTargetAtoms / 32);
@@ -151,8 +191,8 @@ template <std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBl
     uint64_t packedRow;
   };
 
-  AdjacencyEntry targetAdjacency[WarpsPerBlock][MaxTargetAtoms];
-  AdjacencyEntry targetAdjacencyAlt[WarpsPerBlock][MaxTargetAtoms];
+  AdjacencyEntry targetAdjacency[WarpsPerBlock][kAdjacencyEntries];
+  AdjacencyEntry targetAdjacencyAlt[WarpsPerBlock][kAdjacencyEntries];
   /// Per depth, the label-compatible target atoms.
   Mask           depthCandidates[WarpsPerBlock][MaxSearchDepth];
   /// Per depth, its back edges, kBackEdge*-encoded.
@@ -178,31 +218,32 @@ template <std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBl
  * adapter whose query side is fixed across a batch could compute it once at
  * host pack time and load it instead.
  */
-template <class Adapter, std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock>
+template <class Adapter, std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock, bool WithTables>
 __device__ __forceinline__ QueryBondPlan
-analyzeQueryEdges(WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock>& shared,
-                  int                                                             warp,
-                  int                                                             lane,
-                  const Adapter&                                                  adapter,
-                  int                                                             numDepths) {
+analyzeQueryEdges(WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock, WithTables>& shared,
+                  int                                                                         warp,
+                  int                                                                         lane,
+                  const Adapter&                                                              adapter,
+                  int                                                                         numDepths) {
   QueryBondPlan plan;
 
   uint32_t laneMin = 0xFFFFFFFFu;
   uint32_t laneMax = 0u;
 
   for (int depth = lane; depth < numDepths; depth += 32) {
-    const int degree = adapter.degreeAt(depth);
-    int       count  = 0;
-    uint64_t  seen   = 0;
+    const int   degree = adapter.degreeAt(depth);
+    int         count  = 0;
+    DepthBitset seen;
+    seen.clear();
     for (int slot = 0; slot < kMaxEdgeSlotsPerAtom && slot < degree; ++slot) {
       const int neighborDepth = adapter.neighborDepthAt(depth, slot);
-      if (neighborDepth >= depth) {
+      if (neighborDepth == kNoNeighborDepth || neighborDepth >= depth) {
         continue;
       }
-      if ((seen >> neighborDepth) & 1ULL) {
+      if (seen.test(neighborDepth)) {
         continue;
       }
-      seen |= 1ULL << neighborDepth;
+      seen.set(neighborDepth);
       const uint32_t key                   = adapter.edgeKeyAt(depth, slot);
       shared.backEdges[warp][depth][count] = static_cast<unsigned char>(neighborDepth);
       laneMin                              = min(laneMin, key);
@@ -222,18 +263,19 @@ analyzeQueryEdges(WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock>
   uint32_t sawThirdMask = 0;
   if (!uniform) {
     for (int depth = lane; depth < numDepths; depth += 32) {
-      const int degree = adapter.degreeAt(depth);
-      int       count  = 0;
-      uint64_t  seen   = 0;
+      const int   degree = adapter.degreeAt(depth);
+      int         count  = 0;
+      DepthBitset seen;
+      seen.clear();
       for (int slot = 0; slot < kMaxEdgeSlotsPerAtom && slot < degree; ++slot) {
         const int neighborDepth = adapter.neighborDepthAt(depth, slot);
-        if (neighborDepth >= depth) {
+        if (neighborDepth == kNoNeighborDepth || neighborDepth >= depth) {
           continue;
         }
-        if ((seen >> neighborDepth) & 1ULL) {
+        if (seen.test(neighborDepth)) {
           continue;
         }
-        seen |= 1ULL << neighborDepth;
+        seen.set(neighborDepth);
         const uint32_t key = adapter.edgeKeyAt(depth, slot);
         if (key != plan.minBondMask && key != plan.maxBondMask) {
           sawThirdMask = 1;
@@ -246,29 +288,32 @@ analyzeQueryEdges(WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock>
     }
   }
   const bool dual = !uniform && (__ballot_sync(kFullWarpMask, sawThirdMask) == 0u);
-  plan.maskCase   = uniform ? BondMaskCase::Uniform : (dual ? BondMaskCase::Dual : BondMaskCase::General);
+  // Without adjacency tables there is nowhere to precompute neighbour sets, so
+  // the plan must stay General however few distinct keys the query carries --
+  // Uniform/Dual would index tables sized for a single entry.
+  plan.maskCase   = !WithTables ? BondMaskCase::General :
+                                  (uniform ? BondMaskCase::Uniform : (dual ? BondMaskCase::Dual : BondMaskCase::General));
   __syncwarp();
 
   if (plan.maskCase != BondMaskCase::General) {
-    uint64_t lanePrimary = 0;
-    uint64_t laneAlt     = 0;
+    DepthBitset lanePrimary;
+    DepthBitset laneAlt;
+    lanePrimary.clear();
+    laneAlt.clear();
     for (int depth = lane; depth < numDepths; depth += 32) {
       if (depth >= 1 && shared.backEdgeCounts[warp][depth] == 1) {
         const uint32_t edge = shared.backEdges[warp][depth][0];
         if ((edge & kBackEdgeDepthMask) == static_cast<uint32_t>(depth - 1)) {
           if (edge & kBackEdgeAltMaskFlag) {
-            laneAlt |= 1ULL << depth;
+            laneAlt.set(depth);
           } else {
-            lanePrimary |= 1ULL << depth;
+            lanePrimary.set(depth);
           }
         }
       }
     }
-    // Two 32-bit OR reductions per 64-bit lane mask; the reductions are 32-bit.
-    plan.chainDepths = static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(lanePrimary))) |
-                       (static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(lanePrimary >> 32))) << 32);
-    plan.chainDepthsAlt = static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(laneAlt))) |
-                          (static_cast<uint64_t>(warpReduceOr(static_cast<uint32_t>(laneAlt >> 32))) << 32);
+    plan.chainDepths    = warpReduceOrDepths(lanePrimary);
+    plan.chainDepthsAlt = warpReduceOrDepths(laneAlt);
   }
 
   return plan;
@@ -278,14 +323,14 @@ analyzeQueryEdges(WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock>
  * @brief Fill the per-warp adjacency tables for the classified plan, target
  *        atoms striped across the warp. See WarpSharedState for the contents.
  */
-template <class Adapter, std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock>
+template <class Adapter, std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock, bool WithTables>
 __device__ __forceinline__ void buildTargetAdjacency(
-  WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock>& shared,
-  int                                                             warp,
-  int                                                             lane,
-  const Adapter&                                                  adapter,
-  int                                                             numTargetAtoms,
-  const QueryBondPlan&                                            plan) {
+  WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock, WithTables>& shared,
+  int                                                                         warp,
+  int                                                                         lane,
+  const Adapter&                                                              adapter,
+  int                                                                         numTargetAtoms,
+  const QueryBondPlan&                                                        plan) {
   for (int atom = lane; atom < numTargetAtoms; atom += 32) {
     if (plan.maskCase == BondMaskCase::Uniform) {
       shared.targetAdjacency[warp][atom].mask = adapter.neighborsMatching(atom, plan.maxBondMask);
@@ -304,7 +349,7 @@ __device__ __forceinline__ void buildTargetAdjacency(
 
 /**
  * @brief The target atoms depth @p depth may still map to: the candidates
- *        callback handed to nvMolKit::dfsFromRoots.
+ *        candidates callback handed to nvMolKit::dfsFromRoots.
  *
  * Evaluates the intersection described in warp_dfs.cuh, in four shapes,
  * cheapest first:
@@ -319,27 +364,26 @@ __device__ __forceinline__ void buildTargetAdjacency(
  * neighbour twice, so it dedups against @p seen; the other cases read the
  * already-deduplicated back-edge table.
  */
-template <class Adapter, std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock>
+template <class Adapter, std::size_t MaxTargetAtoms, std::size_t MaxSearchDepth, int WarpsPerBlock, bool WithTables>
 __device__ __forceinline__ TargetMask<MaxTargetAtoms> buildCandidates(
-  const WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock>& shared,
-  int                                                                   warp,
-  int                                                                   depth,
-  const unsigned char*                                                  mapping,
-  const TargetMask<MaxTargetAtoms>&                                     used,
-  const Adapter&                                                        adapter,
-  const QueryBondPlan&                                                  plan,
-  int                                                                   prevTargetAtom) {
+  const WarpSharedState<MaxTargetAtoms, MaxSearchDepth, WarpsPerBlock, WithTables>& shared,
+  int                                                                               warp,
+  int                                                                               depth,
+  const unsigned char*                                                              mapping,
+  const TargetMask<MaxTargetAtoms>&                                                 used,
+  const Adapter&                                                                    adapter,
+  const QueryBondPlan&                                                              plan,
+  int                                                                               prevTargetAtom) {
   using Mask = TargetMask<MaxTargetAtoms>;
 
   Mask candidates = shared.depthCandidates[warp][depth];
   candidates.andNotEq(used);
 
-  const uint64_t depthBit = 1ULL << depth;
-  if (plan.chainDepths & depthBit) {
+  if (plan.chainDepths.test(depth)) {
     candidates.andEq(shared.targetAdjacency[warp][prevTargetAtom].mask);
     return candidates;
   }
-  if (plan.chainDepthsAlt & depthBit) {
+  if (plan.chainDepthsAlt.test(depth)) {
     candidates.andEq(shared.targetAdjacencyAlt[warp][prevTargetAtom].mask);
     return candidates;
   }
@@ -364,17 +408,18 @@ __device__ __forceinline__ TargetMask<MaxTargetAtoms> buildCandidates(
     return candidates;
   }
 
-  const int degree = adapter.degreeAt(depth);
-  uint64_t  seen   = 0;
+  const int   degree = adapter.degreeAt(depth);
+  DepthBitset seen;
+  seen.clear();
   for (int slot = 0; slot < kMaxEdgeSlotsPerAtom && slot < degree && !candidates.empty(); ++slot) {
     const int neighborDepth = adapter.neighborDepthAt(depth, slot);
-    if (neighborDepth >= depth) {
+    if (neighborDepth == kNoNeighborDepth || neighborDepth >= depth) {
       continue;
     }
-    if ((seen >> neighborDepth) & 1ULL) {
+    if (seen.test(neighborDepth)) {
       continue;
     }
-    seen |= 1ULL << neighborDepth;
+    seen.set(neighborDepth);
     const int      mapped = mapping[neighborDepth];
     const uint32_t key    = adapter.edgeKeyAt(depth, slot);
     if constexpr (Adapter::kCachesTargetRows) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,12 @@ target_include_directories(test_fmcs_match PRIVATE ${CMAKE_SOURCE_DIR}/src/mcs)
 target_link_libraries(test_fmcs_match PRIVATE mcs_fmcs_foundations
                                               device_vector)
 
+add_executable(test_fmcs_substructure test_fmcs_substructure.cu)
+target_include_directories(test_fmcs_substructure
+                           PRIVATE ${CMAKE_SOURCE_DIR}/src/mcs)
+target_link_libraries(test_fmcs_substructure PRIVATE mcs_fmcs_foundations
+                                                     device_vector)
+
 add_executable(test_openmp_helpers test_openmp_helpers.cpp)
 target_link_libraries(test_openmp_helpers PRIVATE openmp_helpers
                                                   OpenMP::OpenMP_CXX)
@@ -442,6 +448,7 @@ set(TEST_LIST
     test_fmcs_grow
     test_fmcs_match
     test_fmcs_policy
+    test_fmcs_substructure
     test_work_splitting
     test_fire_minimizer
     test_fire_minimizer_permol)

--- a/tests/test_fmcs_substructure.cu
+++ b/tests/test_fmcs_substructure.cu
@@ -1,0 +1,549 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Unit tests for the per-helper device functions in fmcs_cuda/.  Each test
+// launches a tiny __global__ driver that constructs inputs, calls one
+// helper, and copies results back to host memory for assertion.  This
+// file is populated incrementally as Steps 1-5 land real implementations.
+
+#include <cooperative_groups.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <set>
+#include <vector>
+
+#include "src/mcs/fmcs_cuda/fmcs_match.cuh"
+#include "src/mcs/fmcs_cuda/fmcs_match_tables.cuh"
+#include "src/mcs/fmcs_cuda/fmcs_seed.cuh"
+#include "src/utils/device_vector.h"
+
+namespace {
+
+using nvMolKit::AsyncDevicePtr;
+using nvMolKit::AsyncDeviceVector;
+
+using mcs::fmcs::MatchResult;
+using mcs::fmcs::Seed;
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// matchSingleBondWithinThread / tryMatchIncrementalGreedyCooperative
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using mcs::fmcs::MatchTableDevice;
+using mcs::fmcs::PairMatchTablesDevice;
+using mcs::fmcs::SingleBondMatch;
+
+using mcs::fmcs::DeviceCsrView;
+
+// Match tables staged on the host and uploaded to device memory on
+// demand.  Both atom and bond tables are 32-bit row-packed bitmasks
+// (one bit per (q, t) pair).  Tests mutate the host staging vectors
+// via the set*Bit helpers; device() uploads (if dirty) and returns the
+// device view to pass to kernels.
+struct ManagedMatchTables {
+  std::vector<std::uint32_t>       atomHost;
+  std::vector<std::uint32_t>       bondHost;
+  AsyncDeviceVector<std::uint32_t> atomData;
+  AsyncDeviceVector<std::uint32_t> bondData;
+  int                              qNumAtoms = 0;
+  int                              qNumBonds = 0;
+
+  void allocate(int qAtoms, int tAtoms, int qBonds, int tBonds) {
+    qNumAtoms                 = qAtoms;
+    qNumBonds                 = qBonds;
+    const int atomWordsPerRow = (tAtoms + 31) / 32;
+    const int bondWordsPerRow = (tBonds + 31) / 32;
+    atomHost.assign(qAtoms * atomWordsPerRow, 0);
+    bondHost.assign(qBonds * bondWordsPerRow, 0);
+    dev_.atoms = MatchTableDevice{nullptr, qAtoms, tAtoms, atomWordsPerRow};
+    dev_.bonds = MatchTableDevice{nullptr, qBonds, tBonds, bondWordsPerRow};
+    dirty_     = true;
+  }
+
+  void setAtomBit(int qAtom, int tAtom) {
+    atomHost[qAtom * dev_.atoms.wordsPerRow + tAtom / 32] |= (1u << (tAtom % 32));
+    dirty_ = true;
+  }
+  void setBondBit(int qBond, int tBond) {
+    bondHost[qBond * dev_.bonds.wordsPerRow + tBond / 32] |= (1u << (tBond % 32));
+    dirty_ = true;
+  }
+  void setAllAtomBits() {
+    for (int q = 0; q < dev_.atoms.nRows; ++q)
+      for (int t = 0; t < dev_.atoms.nCols; ++t)
+        setAtomBit(q, t);
+  }
+  void setAllBondBits() {
+    for (int q = 0; q < dev_.bonds.nRows; ++q)
+      for (int t = 0; t < dev_.bonds.nCols; ++t)
+        setBondBit(q, t);
+  }
+
+  PairMatchTablesDevice device() {
+    if (dirty_) {
+      atomData.setFromVector(atomHost);
+      bondData.setFromVector(bondHost);
+      dev_.atoms.data = atomData.data();
+      dev_.bonds.data = bondData.data();
+      dirty_          = false;
+    }
+    return dev_;
+  }
+
+ private:
+  PairMatchTablesDevice dev_{};
+  bool                  dirty_ = true;
+};
+
+// Owns the device buffers behind a DeviceCsrView.  Built from an
+// undirected edge list: bond i is edges[i], and the CSR is the symmetric
+// expansion of that list (each edge contributes one entry to each
+// endpoint's row), matching what the host-side graph builder uploads for
+// real molecules.
+class TestGraph {
+ public:
+  TestGraph(int numAtoms, const std::vector<std::pair<int, int>>& edges) {
+    const int numBonds = static_cast<int>(edges.size());
+
+    std::vector<std::uint32_t> bondEndpointsHost(numBonds);
+    for (int i = 0; i < numBonds; ++i) {
+      bondEndpointsHost[i] =
+        (static_cast<std::uint32_t>(edges[i].first) << 16) | static_cast<std::uint32_t>(edges[i].second);
+    }
+
+    // Counting sort into CSR: degree pass, prefix sum, then scatter.
+    std::vector<std::uint32_t> rowOffsetsHost(numAtoms + 1, 0);
+    for (const auto& edge : edges) {
+      ++rowOffsetsHost[edge.first + 1];
+      ++rowOffsetsHost[edge.second + 1];
+    }
+    for (int atom = 0; atom < numAtoms; ++atom) {
+      rowOffsetsHost[atom + 1] += rowOffsetsHost[atom];
+    }
+
+    std::vector<std::uint32_t> colIndicesHost(2 * numBonds);
+    std::vector<std::uint32_t> bondIndicesHost(2 * numBonds);
+    std::vector<std::uint32_t> cursor(rowOffsetsHost.begin(), rowOffsetsHost.end() - 1);
+    for (int bond = 0; bond < numBonds; ++bond) {
+      const int u                = edges[bond].first;
+      const int v                = edges[bond].second;
+      colIndicesHost[cursor[u]]  = static_cast<std::uint32_t>(v);
+      bondIndicesHost[cursor[u]] = static_cast<std::uint32_t>(bond);
+      ++cursor[u];
+      colIndicesHost[cursor[v]]  = static_cast<std::uint32_t>(u);
+      bondIndicesHost[cursor[v]] = static_cast<std::uint32_t>(bond);
+      ++cursor[v];
+    }
+
+    bondEndpoints_.setFromVector(bondEndpointsHost);
+    rowOffsets_.setFromVector(rowOffsetsHost);
+    colIndices_.setFromVector(colIndicesHost);
+    bondIndices_.setFromVector(bondIndicesHost);
+
+    view_.bondEndpoints = bondEndpoints_.data();
+    view_.rowOffsets    = rowOffsets_.data();
+    view_.colIndices    = colIndices_.data();
+    view_.bondIndices   = bondIndices_.data();
+    view_.numAtoms      = numAtoms;
+    view_.numBonds      = numBonds;
+  }
+
+  DeviceCsrView view() const { return view_; }
+
+ private:
+  AsyncDeviceVector<std::uint32_t> bondEndpoints_;
+  AsyncDeviceVector<std::uint32_t> rowOffsets_;
+  AsyncDeviceVector<std::uint32_t> colIndices_;
+  AsyncDeviceVector<std::uint32_t> bondIndices_;
+  DeviceCsrView                    view_{};
+};
+
+}  // namespace
+
+namespace {
+
+// Helper: build a parent MatchResult that records the mapping
+// {qAtom[i] -> tAtom[i]} and {qBond[i] -> tBond[i]} from caller-supplied
+// parallel arrays.  Used by the incremental tests to set up "what the
+// parent already had matched" before adding new bonds.
+template <int maxA, int maxB, int maxTA, int maxTB>
+__device__ __forceinline__ void buildParentMatch(mcs::fmcs::MatchResult<maxA, maxB, maxTA, maxTB>& match,
+                                                 const int*                                        qAtoms,
+                                                 const int*                                        tAtoms,
+                                                 int                                               nAtomMaps,
+                                                 const int*                                        qBonds,
+                                                 const int*                                        tBonds,
+                                                 int                                               nBondMaps) {
+  using MatchT = mcs::fmcs::MatchResult<maxA, maxB, maxTA, maxTB>;
+  mcs::fmcs::matchResultClearWithinThread(match);
+  for (int i = 0; i < nAtomMaps; ++i) {
+    match.targetAtomIdx[qAtoms[i]] = static_cast<std::uint8_t>(tAtoms[i]);
+    const int t                    = tAtoms[i];
+    match.visitedTargetAtoms[t / MatchT::kTargetAtomBitsPerWord] |= (typename MatchT::target_atom_word{1})
+                                                                 << (t % MatchT::kTargetAtomBitsPerWord);
+  }
+  for (int i = 0; i < nBondMaps; ++i) {
+    match.targetBondIdx[qBonds[i]] = static_cast<std::uint8_t>(tBonds[i]);
+    const int t                    = tBonds[i];
+    match.visitedTargetBonds[t / MatchT::kTargetBondBitsPerWord] |= (typename MatchT::target_bond_word{1})
+                                                                 << (t % MatchT::kTargetBondBitsPerWord);
+  }
+  match.matchedAtomSize = static_cast<std::uint16_t>(nAtomMaps);
+  match.matchedBondSize = static_cast<std::uint16_t>(nBondMaps);
+  match.empty           = (nAtomMaps == 0 && nBondMaps == 0);
+}
+
+}  // namespace
+namespace mcs_fmcs_substructure_test {
+
+using QueuedT16 = mcs::fmcs::QueuedSeed<16, 16, 16, 16>;
+
+struct SubstructureTestOut {
+  bool      ok;
+  QueuedT16 child;
+};
+
+__device__ __forceinline__ void addMaskSeed(QueuedT16& child, std::uint32_t atomMask, std::uint32_t bondMask) {
+  mcs::fmcs::seedClearWithinThread(child.seed);
+  mcs::fmcs::matchResultClearWithinThread(child.match);
+  for (int a = 0; a < 16; ++a) {
+    if ((atomMask >> a) & 1u) {
+      mcs::fmcs::seedAddAtomWithinThread(child.seed, a);
+    }
+  }
+  for (int b = 0; b < 16; ++b) {
+    if ((bondMask >> b) & 1u) {
+      mcs::fmcs::seedAddBondWithinThread(child.seed, b);
+    }
+  }
+}
+
+__global__ void matchSubstructureMaskDriver(DeviceCsrView         qView,
+                                            DeviceCsrView         tView,
+                                            PairMatchTablesDevice tables,
+                                            std::uint32_t         atomMask,
+                                            std::uint32_t         bondMask,
+                                            SubstructureTestOut*  out) {
+  __shared__ QueuedT16 child;
+  __shared__ mcs::fmcs::FmcsSubstructureScratch<16, 16> scratch;
+  if (threadIdx.x == 0) {
+    addMaskSeed(child, atomMask, bondMask);
+  }
+  __syncthreads();
+
+  auto block = cooperative_groups::this_thread_block();
+  auto warp  = cooperative_groups::tiled_partition<32>(block);
+  bool ok = mcs::fmcs::matchSeedSubstructureCooperative(warp, child.seed, qView, tView, tables, child.match, scratch);
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    out->ok    = ok;
+    out->child = child;
+  }
+}
+
+__global__ void matchFallbackBadParentDriver(DeviceCsrView         qView,
+                                             DeviceCsrView         tView,
+                                             PairMatchTablesDevice tables,
+                                             SubstructureTestOut*  out) {
+  __shared__ QueuedT16 child;
+  __shared__ mcs::fmcs::FmcsSubstructureScratch<16, 16> scratch;
+  __shared__ int                                        scratchLock;
+  if (threadIdx.x == 0) {
+    // Query seed is the 4-edge path inside the triangle-with-leaves
+    // repro: query bonds 1,2,3,4 and all five atoms.  The stored parent
+    // match maps q bond 1 = (0,2) onto target bond 0 = (0,3), which is
+    // locally valid but blocks q bond 2 = (0,4) in the fast extender.
+    addMaskSeed(child, /*atomMask=*/0x1Fu, /*bondMask=*/0x1Eu);
+    mcs::fmcs::matchResultClearWithinThread(child.match);
+    using MatchT                 = decltype(child.match);
+    child.match.targetAtomIdx[0] = 0;
+    child.match.targetAtomIdx[2] = 3;
+    child.match.visitedTargetAtoms[0 / MatchT::kTargetAtomBitsPerWord] |= typename MatchT::target_atom_word{1}
+                                                                       << (0 % MatchT::kTargetAtomBitsPerWord);
+    child.match.visitedTargetAtoms[3 / MatchT::kTargetAtomBitsPerWord] |= typename MatchT::target_atom_word{1}
+                                                                       << (3 % MatchT::kTargetAtomBitsPerWord);
+    child.match.targetBondIdx[1] = 0;
+    child.match.visitedTargetBonds[0 / MatchT::kTargetBondBitsPerWord] |= typename MatchT::target_bond_word{1}
+                                                                       << (0 % MatchT::kTargetBondBitsPerWord);
+    child.match.matchedAtomSize = 2;
+    child.match.matchedBondSize = 1;
+    child.match.empty           = false;
+    scratchLock                 = 0;
+  }
+  __syncthreads();
+
+  auto block = cooperative_groups::this_thread_block();
+  auto warp  = cooperative_groups::tiled_partition<32>(block);
+  bool ok    = mcs::fmcs::matchSeedWithSubstructureFallbackCooperative(warp,
+                                                                    child.seed,
+                                                                    qView,
+                                                                    tView,
+                                                                    tables,
+                                                                    child.match,
+                                                                    scratch,
+                                                                    &scratchLock);
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    out->ok    = ok;
+    out->child = child;
+  }
+}
+
+}  // namespace mcs_fmcs_substructure_test
+
+TEST(FMCSUnit, MatchSeedSubstructurePath) {
+  using namespace mcs_fmcs_substructure_test;
+
+  TestGraph          query(4,
+                           {
+                    {0, 1},
+                    {1, 2},
+                    {2, 3}
+  });
+  TestGraph          target(5,
+                            {
+                     {0, 1},
+                     {1, 2},
+                     {2, 3},
+                     {3, 4}
+  });
+  ManagedMatchTables tables;
+  tables.allocate(4, 5, 3, 4);
+  tables.setAllAtomBits();
+  tables.setAllBondBits();
+
+  AsyncDevicePtr<SubstructureTestOut> d_out;
+  matchSubstructureMaskDriver<<<1, 32>>>(query.view(),
+                                         target.view(),
+                                         tables.device(),
+                                         /*atomMask=*/0xFu,
+                                         /*bondMask=*/0x7u,
+                                         d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  SubstructureTestOut out{};
+  d_out.get(out);
+
+  EXPECT_TRUE(out.ok);
+  EXPECT_EQ(out.child.match.matchedAtomSize, 4);
+  EXPECT_EQ(out.child.match.matchedBondSize, 3);
+  for (int q = 0; q < 4; ++q) {
+    EXPECT_NE(out.child.match.targetAtomIdx[q], mcs::fmcs::kUnmappedTargetIdx);
+  }
+  for (int q = 0; q < 3; ++q) {
+    EXPECT_NE(out.child.match.targetBondIdx[q], mcs::fmcs::kUnmappedTargetIdx);
+  }
+}
+
+TEST(FMCSUnit, MatchSeedSubstructureRejectsNoMatch) {
+  using namespace mcs_fmcs_substructure_test;
+
+  TestGraph          query(3,
+                           {
+                    {0, 1},
+                    {1, 2},
+                    {0, 2}
+  });
+  TestGraph          target(3,
+                            {
+                     {0, 1},
+                     {1, 2}
+  });
+  ManagedMatchTables tables;
+  tables.allocate(3, 3, 3, 2);
+  tables.setAllAtomBits();
+  tables.setAllBondBits();
+
+  AsyncDevicePtr<SubstructureTestOut> d_out;
+  matchSubstructureMaskDriver<<<1, 32>>>(query.view(),
+                                         target.view(),
+                                         tables.device(),
+                                         /*atomMask=*/0x7u,
+                                         /*bondMask=*/0x7u,
+                                         d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  SubstructureTestOut out{};
+  d_out.get(out);
+
+  EXPECT_FALSE(out.ok);
+  EXPECT_TRUE(out.child.match.empty);
+}
+
+TEST(FMCSUnit, MatchSeedSubstructureRespectsAtomTable) {
+  using namespace mcs_fmcs_substructure_test;
+
+  TestGraph          query(3,
+                           {
+                    {0, 1},
+                    {1, 2}
+  });
+  TestGraph          target(3,
+                            {
+                     {0, 1},
+                     {1, 2}
+  });
+  ManagedMatchTables tables;
+  tables.allocate(3, 3, 2, 2);
+  tables.setAtomBit(0, 0);
+  tables.setAtomBit(1, 1);
+  tables.setAtomBit(2, 2);
+  tables.setAllBondBits();
+
+  AsyncDevicePtr<SubstructureTestOut> d_out;
+  matchSubstructureMaskDriver<<<1, 32>>>(query.view(),
+                                         target.view(),
+                                         tables.device(),
+                                         /*atomMask=*/0x7u,
+                                         /*bondMask=*/0x3u,
+                                         d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  SubstructureTestOut out{};
+  d_out.get(out);
+
+  EXPECT_TRUE(out.ok);
+  EXPECT_EQ(out.child.match.targetAtomIdx[0], 0u);
+  EXPECT_EQ(out.child.match.targetAtomIdx[1], 1u);
+  EXPECT_EQ(out.child.match.targetAtomIdx[2], 2u);
+  EXPECT_EQ(out.child.match.matchedAtomSize, 3);
+  EXPECT_EQ(out.child.match.matchedBondSize, 2);
+}
+
+TEST(FMCSUnit, MatchSeedSubstructureRespectsBondTable) {
+  using namespace mcs_fmcs_substructure_test;
+
+  TestGraph          query(3,
+                           {
+                    {0, 1},
+                    {1, 2}
+  });
+  TestGraph          target(3,
+                            {
+                     {0, 1},
+                     {1, 2},
+                     {0, 2}
+  });
+  ManagedMatchTables tables;
+  tables.allocate(3, 3, 2, 3);
+  tables.setAllAtomBits();
+  tables.setBondBit(0, 0);
+  tables.setBondBit(1, 1);
+
+  AsyncDevicePtr<SubstructureTestOut> d_out;
+  matchSubstructureMaskDriver<<<1, 32>>>(query.view(),
+                                         target.view(),
+                                         tables.device(),
+                                         /*atomMask=*/0x7u,
+                                         /*bondMask=*/0x3u,
+                                         d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  SubstructureTestOut out{};
+  d_out.get(out);
+
+  EXPECT_TRUE(out.ok);
+  EXPECT_EQ(out.child.match.targetBondIdx[0], 0u);
+  EXPECT_EQ(out.child.match.targetBondIdx[1], 1u);
+  EXPECT_EQ(out.child.match.matchedAtomSize, 3);
+  EXPECT_EQ(out.child.match.matchedBondSize, 2);
+}
+
+TEST(FMCSUnit, MatchSeedSubstructureFindsPathInsideTriangleWithLeaves) {
+  using namespace mcs_fmcs_substructure_test;
+
+  TestGraph          query(5,
+                           {
+                    {0, 1},
+                    {0, 2},
+                    {0, 4},
+                    {1, 2},
+                    {1, 3}
+  });
+  TestGraph          target(5,
+                            {
+                     {0, 3},
+                     {1, 2},
+                     {1, 4},
+                     {2, 3}
+  });
+  ManagedMatchTables tables;
+  tables.allocate(5, 5, 5, 4);
+  tables.setAllAtomBits();
+  tables.setAllBondBits();
+
+  AsyncDevicePtr<SubstructureTestOut> d_out;
+  matchSubstructureMaskDriver<<<1, 32>>>(query.view(),
+                                         target.view(),
+                                         tables.device(),
+                                         /*atomMask=*/0x1Fu,
+                                         /*bondMask=*/0x1Eu,
+                                         d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  SubstructureTestOut out{};
+  d_out.get(out);
+
+  EXPECT_TRUE(out.ok);
+  EXPECT_EQ(out.child.match.matchedAtomSize, 5);
+  EXPECT_EQ(out.child.match.matchedBondSize, 4);
+  EXPECT_EQ(out.child.match.targetBondIdx[0], mcs::fmcs::kUnmappedTargetIdx);
+  for (int q : {1, 2, 3, 4}) {
+    EXPECT_NE(out.child.match.targetBondIdx[q], mcs::fmcs::kUnmappedTargetIdx);
+  }
+}
+
+TEST(FMCSUnit, MatchSeedFallbackRebuildsAfterGreedyFailure) {
+  using namespace mcs_fmcs_substructure_test;
+
+  TestGraph          query(5,
+                           {
+                    {0, 1},
+                    {0, 2},
+                    {0, 4},
+                    {1, 2},
+                    {1, 3}
+  });
+  TestGraph          target(5,
+                            {
+                     {0, 3},
+                     {1, 2},
+                     {1, 4},
+                     {2, 3}
+  });
+  ManagedMatchTables tables;
+  tables.allocate(5, 5, 5, 4);
+  tables.setAllAtomBits();
+  tables.setAllBondBits();
+
+  AsyncDevicePtr<SubstructureTestOut> d_out;
+  matchFallbackBadParentDriver<<<1, 32>>>(query.view(), target.view(), tables.device(), d_out.data());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  SubstructureTestOut out{};
+  d_out.get(out);
+
+  EXPECT_TRUE(out.ok);
+  EXPECT_EQ(out.child.match.matchedAtomSize, 5);
+  EXPECT_EQ(out.child.match.matchedBondSize, 4);
+  for (int q = 0; q < 5; ++q) {
+    EXPECT_NE(out.child.match.targetAtomIdx[q], mcs::fmcs::kUnmappedTargetIdx);
+  }
+  for (int q : {1, 2, 3, 4}) {
+    EXPECT_NE(out.child.match.targetBondIdx[q], mcs::fmcs::kUnmappedTargetIdx);
+  }
+}


### PR DESCRIPTION
The greedy incremental extender proves a seed embeds only when its choices
happen to work out; when it fails the seed still needs an exact answer.
matchSeedSubstructureCooperative supplies one by adapting the seed to the
shared per-pair candidate tables rather than implementing a search.

McsSeedAdapter presents the seed in most-constrained-first order, reports
kNoNeighborDepth for CSR slots whose bond is outside the seed, keys edges on
query bond index, and resolves them through the (query bond, target bond)
match table. Lanes race for the first embedding via an atomicCAS found flag
polled in the DFS abort hook; the winner records the atom mapping and lane 0
rebuilds the bond mapping from it. The search is exhaustive in bounded memory
-- a lane-local register stack, no partial-mapping buffer -- so a false return
proves the seed does not embed.

Widens the shared tables to carry this frontend: back-edge depths pack into 7
bits and chain flags become a 128-bit DepthBitset so the 128-atom tier fits;
WarpSharedState gains WithAdjacencyTables so a frontend that never reads the
adjacency tables does not allocate them, and a table-less state forces the
General case rather than indexing a one-entry table.

Seed ordering picks its most-constrained atom by intersecting the atom match
table row with a degree bucket and taking a popcount, instead of scanning
every target atom per candidate; root selection reuses the same two masks.