### PR TITLE
Add CUDA fMCS engine

### DIFF
--- a/src/mcs/CMakeLists.txt
+++ b/src/mcs/CMakeLists.txt
@@ -17,3 +17,11 @@ add_library(mcs_fmcs_foundations fmcs_cuda/fmcs_match_tables.cu mcs_graph.cpp)
 target_include_directories(mcs_fmcs_foundations
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(mcs_fmcs_foundations PUBLIC device_vector)
+
+add_library(mcs_fmcs_core fmcs_cuda/fmcs.cu)
+target_include_directories(mcs_fmcs_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+                                                ${CMAKE_SOURCE_DIR})
+target_link_libraries(mcs_fmcs_core PUBLIC mcs_fmcs_foundations device nvtx)
+target_compile_options(
+  mcs_fmcs_core
+  PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--ptxas-options=-v;--extended-lambda>)

--- a/src/mcs/fmcs_cuda/fmcs.cu
+++ b/src/mcs/fmcs_cuda/fmcs.cu
@@ -1,0 +1,629 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cooperative_groups.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "src/mcs/fmcs_cuda/fmcs.cuh"
+#include "src/mcs/fmcs_cuda/fmcs_kernel.cuh"
+#include "src/mcs/fmcs_cuda/fmcs_match_tables.cuh"
+#include "src/mcs/fmcs_cuda/fmcs_policy.cuh"
+#include "src/utils/device.h"
+#include "src/utils/gpu_executor_ring.h"
+
+namespace mcs {
+namespace fmcs {
+
+namespace {
+
+void checkCuda(cudaError_t err, const char* context) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string("fMCS dispatch CUDA error at ") + context + ": " + cudaGetErrorString(err));
+  }
+}
+
+/// uint32 host-side mirror of a CSR @ref Graph plus packed bond metadata
+/// matching @ref enumerateBonds ordering.
+struct PackedGraphHost {
+  std::vector<uint32_t> rowOffsets;
+  std::vector<uint32_t> colIndices;
+  /// Per-adjacency entry bond id, parallel to @c colIndices.
+  std::vector<uint32_t> bondIndices;
+  std::vector<uint32_t> bondEndpoints;  // (u << 16) | v, u < v
+};
+
+PackedGraphHost packGraph(const Graph& g) {
+  constexpr uint32_t kUnsetBondIndex = 0xFFFFFFFFu;
+  PackedGraphHost    out;
+  out.rowOffsets.reserve(g.rowOffsets.size());
+  for (size_t v : g.rowOffsets)
+    out.rowOffsets.push_back(static_cast<uint32_t>(v));
+  out.colIndices.reserve(g.colIndices.size());
+  for (size_t v : g.colIndices)
+    out.colIndices.push_back(static_cast<uint32_t>(v));
+  out.bondIndices.assign(g.colIndices.size(), kUnsetBondIndex);
+  out.bondEndpoints.reserve(static_cast<size_t>(g.numEdges));
+  for (int u = 0; u < g.numVertices; ++u) {
+    const size_t begin  = g.rowOffsets[u];
+    const size_t end    = g.rowOffsets[u + 1];
+    const size_t degree = end - begin;
+    if (degree > static_cast<size_t>(kMaxNeighborsPerAtom)) {
+      throw std::invalid_argument("fMCS graph vertex " + std::to_string(u) + " has degree " + std::to_string(degree) +
+                                  "; maximum supported degree is " + std::to_string(kMaxNeighborsPerAtom));
+    }
+    for (size_t k = begin; k < end; ++k) {
+      const int v = static_cast<int>(g.colIndices[k]);
+      if (u < v) {
+        const auto bondIdx = static_cast<uint32_t>(out.bondEndpoints.size());
+        out.bondEndpoints.push_back((static_cast<uint32_t>(u) << 16) | static_cast<uint32_t>(v));
+        out.bondIndices[k] = bondIdx;
+
+        bool foundReverse = false;
+        for (size_t rk = g.rowOffsets[v]; rk < g.rowOffsets[v + 1]; ++rk) {
+          if (static_cast<int>(g.colIndices[rk]) == u && out.bondIndices[rk] == kUnsetBondIndex) {
+            out.bondIndices[rk] = bondIdx;
+            foundReverse        = true;
+            break;
+          }
+        }
+        if (!foundReverse) {
+          throw std::runtime_error("fMCS CSR graph is missing reverse edge");
+        }
+      }
+    }
+  }
+  if (out.bondEndpoints.size() != static_cast<size_t>(g.numEdges)) {
+    throw std::runtime_error("fMCS CSR graph edge count is inconsistent");
+  }
+  return out;
+}
+
+/// Host-side descriptor assembled per pair.  @c queryGraph points at the
+/// smaller input (fMCS enumerates subgraphs of the query), and
+/// @c swapped records whether sides were flipped so host-side expansion
+/// can un-swap the result mappings.
+struct HostPairDescriptor {
+  bool swapped    = false;
+  bool overflowed = false;
+
+  const Graph* queryGraph  = nullptr;
+  const Graph* targetGraph = nullptr;
+
+  PackedGraphHost     packedQuery;
+  PackedGraphHost     packedTarget;
+  PairMatchTablesHost tables;
+
+  /// Maps to @ref pickMaxSizeTier: 0=16, 1=32, 2=64, 3=128; -1 on overflow.
+  int tier = -1;
+};
+
+template <class Policy, class InputT>
+HostPairDescriptor buildPairDescriptor(const InputT& sideA, const InputT& sideB, const Parameters& params) {
+  HostPairDescriptor desc;
+  const Graph&       gA = [&]() -> const Graph& {
+    if constexpr (std::is_same_v<InputT, Graph>) {
+      return sideA;
+    } else {
+      return sideA.graph;
+    }
+  }();
+  const Graph& gB = [&]() -> const Graph& {
+    if constexpr (std::is_same_v<InputT, Graph>) {
+      return sideB;
+    } else {
+      return sideB.graph;
+    }
+  }();
+
+  const bool pickA = gA.numEdges <= gB.numEdges;
+  desc.swapped     = !pickA;
+  const InputT& q  = pickA ? sideA : sideB;
+  const InputT& t  = pickA ? sideB : sideA;
+  const Graph&  qG = pickA ? gA : gB;
+  const Graph&  tG = pickA ? gB : gA;
+
+  desc.queryGraph   = &qG;
+  desc.targetGraph  = &tG;
+  desc.packedQuery  = packGraph(qG);
+  desc.packedTarget = packGraph(tG);
+
+  Policy::buildAtomMatchTable(q, t, desc.tables.atoms, params.matchVertexLabels);
+  Policy::buildBondMatchTable(q, t, desc.tables.bonds, params.matchEdgeLabels);
+
+  const int tier  = pickMaxSizeTier(std::max(qG.numVertices, tG.numVertices), std::max(qG.numEdges, tG.numEdges));
+  desc.tier       = tier;
+  desc.overflowed = (tier < 0);
+  return desc;
+}
+
+/// Owning device allocations for one tier sub-batch.  @c dResultsBuffer
+/// and @c dQueueStorage are typed at launch time (per @c maxAtoms /
+/// @c maxBonds), so they are held as opaque pointers here.  The queue
+/// storage is one contiguous global-memory slab of
+/// @c kFmcsQueueCapacity * numPairs QueuedSeed entries; per-block slices
+/// are taken inside the kernel via @c blockIdx.x.
+struct BatchDeviceBuffers {
+  void*               csrBuffer       = nullptr;
+  size_t              csrBufferBytes  = 0;
+  DevicePerPairInput* dPairInputs     = nullptr;
+  void*               dResultsBuffer  = nullptr;
+  void*               dQueueStorage   = nullptr;
+  void*               dScratchStorage = nullptr;
+};
+
+constexpr int kMaxFmcsExecutorsPerRunner = 8;
+
+struct FmcsExecutor {
+  std::unique_ptr<nvMolKit::ScopedStream> ownedStream;
+  cudaStream_t                            stream = nullptr;
+  nvMolKit::ScopedCudaEvent               copyDoneEvent;
+  BatchDeviceBuffers                      bufs;
+
+  FmcsExecutor(int executorIdx, cudaStream_t externalStream, bool useExternalStream) {
+    if (useExternalStream) {
+      stream = externalStream;
+      return;
+    }
+
+    const std::string streamName = "fmcs_executor_" + std::to_string(executorIdx);
+    ownedStream                  = std::make_unique<nvMolKit::ScopedStream>(streamName.c_str());
+    stream                       = ownedStream->stream();
+  }
+};
+
+int validateRequestedExecutorCount(const Parameters& params) {
+  if (params.executorsPerRunner < 1 || params.executorsPerRunner > kMaxFmcsExecutorsPerRunner) {
+    throw std::invalid_argument("fMCS executorsPerRunner must be between 1 and " +
+                                std::to_string(kMaxFmcsExecutorsPerRunner));
+  }
+  return params.executorsPerRunner;
+}
+
+int validateRequestedBlockSize(const Parameters& params) {
+  if (params.blockSize == 64 || params.blockSize == 128 || params.blockSize == 256 || params.blockSize == 512) {
+    return params.blockSize;
+  }
+  throw std::invalid_argument("fMCS blockSize must be one of 64, 128, 256, or 512");
+}
+
+void freeBatchBuffers(BatchDeviceBuffers& bufs, cudaStream_t stream) {
+  if (bufs.csrBuffer) {
+    cudaFreeAsync(bufs.csrBuffer, stream);
+    bufs.csrBuffer = nullptr;
+  }
+  if (bufs.dPairInputs) {
+    cudaFreeAsync(bufs.dPairInputs, stream);
+    bufs.dPairInputs = nullptr;
+  }
+  if (bufs.dResultsBuffer) {
+    cudaFreeAsync(bufs.dResultsBuffer, stream);
+    bufs.dResultsBuffer = nullptr;
+  }
+  if (bufs.dQueueStorage) {
+    cudaFreeAsync(bufs.dQueueStorage, stream);
+    bufs.dQueueStorage = nullptr;
+  }
+  if (bufs.dScratchStorage) {
+    cudaFreeAsync(bufs.dScratchStorage, stream);
+    bufs.dScratchStorage = nullptr;
+  }
+}
+
+/// Upload every pair's CSR and bond-endpoint arrays into one contiguous
+/// device buffer, returning per-pair descriptors whose pointers refer into
+/// that buffer.
+std::vector<DevicePerPairInput> uploadCsrAndAssemblePairInputs(const std::vector<HostPairDescriptor*>&   descs,
+                                                               const std::vector<PairMatchTablesDevice>& tablesDev,
+                                                               cudaStream_t                              stream,
+                                                               void**                                    outBuf,
+                                                               size_t*                                   outBufBytes) {
+  size_t totalWords = 0;
+  for (auto* d : descs) {
+    totalWords += d->packedQuery.rowOffsets.size();
+    totalWords += d->packedQuery.colIndices.size();
+    totalWords += d->packedQuery.bondIndices.size();
+    totalWords += d->packedQuery.bondEndpoints.size();
+    totalWords += d->packedTarget.rowOffsets.size();
+    totalWords += d->packedTarget.colIndices.size();
+    totalWords += d->packedTarget.bondIndices.size();
+    totalWords += d->packedTarget.bondEndpoints.size();
+  }
+
+  void* buf = nullptr;
+  if (totalWords > 0) {
+    checkCuda(cudaMallocAsync(&buf, totalWords * sizeof(uint32_t), stream), "cudaMallocAsync (CSR)");
+  }
+  uint32_t* base = reinterpret_cast<uint32_t*>(buf);
+
+  std::vector<DevicePerPairInput> out(descs.size());
+  size_t                          cursor    = 0;
+  auto                            uploadVec = [&](const std::vector<uint32_t>& v) -> uint32_t* {
+    if (v.empty())
+      return nullptr;
+    uint32_t* dst = base + cursor;
+    checkCuda(cudaMemcpyAsync(dst, v.data(), v.size() * sizeof(uint32_t), cudaMemcpyHostToDevice, stream),
+              "cudaMemcpyAsync (CSR)");
+    cursor += v.size();
+    return dst;
+  };
+
+  for (size_t i = 0; i < descs.size(); ++i) {
+    const auto&         d = *descs[i];
+    DevicePerPairInput& p = out[i];
+    p.queryNumAtoms       = d.queryGraph->numVertices;
+    p.queryNumBonds       = d.queryGraph->numEdges;
+    p.targetNumAtoms      = d.targetGraph->numVertices;
+    p.targetNumBonds      = d.targetGraph->numEdges;
+    p.queryRowOffsets     = uploadVec(d.packedQuery.rowOffsets);
+    p.queryColIndices     = uploadVec(d.packedQuery.colIndices);
+    p.queryBondIndices    = uploadVec(d.packedQuery.bondIndices);
+    p.queryBondEndpoints  = uploadVec(d.packedQuery.bondEndpoints);
+    p.targetRowOffsets    = uploadVec(d.packedTarget.rowOffsets);
+    p.targetColIndices    = uploadVec(d.packedTarget.colIndices);
+    p.targetBondIndices   = uploadVec(d.packedTarget.bondIndices);
+    p.targetBondEndpoints = uploadVec(d.packedTarget.bondEndpoints);
+    p.tables              = tablesDev[i];
+    p.swapped             = d.swapped;
+  }
+
+  if (outBuf)
+    *outBuf = buf;
+  if (outBufBytes)
+    *outBufBytes = totalWords * sizeof(uint32_t);
+  return out;
+}
+
+template <int blockThreads, int maxAtoms, int maxBonds, class Policy>
+void launchTierAsync(const std::vector<DevicePerPairInput>&            hostPairInputs,
+                     const Parameters&                                 params,
+                     cudaStream_t                                      stream,
+                     BatchDeviceBuffers&                               bufs,
+                     std::vector<DeviceMCSResult<maxAtoms, maxBonds>>& hostResults) {
+  const int numPairs = static_cast<int>(hostPairInputs.size());
+  if (numPairs == 0)
+    return;
+
+  checkCuda(cudaMallocAsync(reinterpret_cast<void**>(&bufs.dPairInputs), numPairs * sizeof(DevicePerPairInput), stream),
+            "cudaMallocAsync (pair inputs)");
+  checkCuda(cudaMemcpyAsync(bufs.dPairInputs,
+                            hostPairInputs.data(),
+                            numPairs * sizeof(DevicePerPairInput),
+                            cudaMemcpyHostToDevice,
+                            stream),
+            "cudaMemcpyAsync (pair inputs)");
+
+  DeviceMCSResult<maxAtoms, maxBonds>* dResults = nullptr;
+  const size_t resultsBytes = static_cast<size_t>(numPairs) * sizeof(DeviceMCSResult<maxAtoms, maxBonds>);
+  checkCuda(cudaMallocAsync(reinterpret_cast<void**>(&dResults), resultsBytes, stream), "cudaMallocAsync (results)");
+  bufs.dResultsBuffer = dResults;
+
+  using QueuedT           = QueuedSeed<maxAtoms, maxBonds, maxAtoms, maxBonds>;
+  QueuedT*     dQueue     = nullptr;
+  const size_t queueBytes = static_cast<size_t>(numPairs) * kFmcsQueueCapacity * sizeof(QueuedT);
+  checkCuda(cudaMallocAsync(reinterpret_cast<void**>(&dQueue), queueBytes, stream), "cudaMallocAsync (queue storage)");
+  bufs.dQueueStorage = dQueue;
+
+  using ScratchT     = FmcsSubstructureScratch<maxAtoms, maxAtoms>;
+  ScratchT* dScratch = nullptr;
+  if constexpr (kUseGlobalSubstructureScratch<blockThreads, maxAtoms>) {
+    const size_t scratchBytes =
+      static_cast<size_t>(numPairs) * static_cast<size_t>(FmcsBlockConfig<blockThreads>::numGroups) * sizeof(ScratchT);
+    checkCuda(cudaMallocAsync(reinterpret_cast<void**>(&dScratch), scratchBytes, stream),
+              "cudaMallocAsync (global substructure scratch)");
+    bufs.dScratchStorage = dScratch;
+  }
+
+  unsigned long long timeoutClocks = 0;
+  if (params.timeoutMs > 0.0f) {
+    int device = 0;
+    checkCuda(cudaGetDevice(&device), "cudaGetDevice (timeout)");
+    int clockRateKHz = 0;
+    checkCuda(cudaDeviceGetAttribute(&clockRateKHz, cudaDevAttrClockRate, device),
+              "cudaDeviceGetAttribute (clock rate)");
+    timeoutClocks = static_cast<unsigned long long>(
+      std::max(1.0, static_cast<double>(params.timeoutMs) * static_cast<double>(clockRateKHz)));
+  }
+
+  // Block size is selected from compile-time kernel specializations so the
+  // kernel's per-group state arrays stay statically sized.
+  dim3 grid(static_cast<unsigned>(numPairs));
+  dim3 block(static_cast<unsigned>(blockThreads));
+  fmcsKernel<maxAtoms, maxBonds, blockThreads, Policy, kUseGlobalSubstructureScratch<blockThreads, maxAtoms>>
+    <<<grid, block, 0, stream>>>(bufs.dPairInputs,
+                                 dResults,
+                                 dQueue,
+                                 dScratch,
+                                 kFmcsQueueCapacity,
+                                 numPairs,
+                                 timeoutClocks);
+  checkCuda(cudaGetLastError(), "fmcsKernel launch");
+
+  hostResults.resize(static_cast<size_t>(numPairs));
+  checkCuda(cudaMemcpyAsync(hostResults.data(), dResults, resultsBytes, cudaMemcpyDeviceToHost, stream),
+            "cudaMemcpyAsync (results)");
+}
+
+/// Translate fixed-size DeviceMCSResult into MCSResult, un-swapping the
+/// mappings if @p swapped is set.  The device result stores edges as
+/// (queryBondIdx, targetBondIdx) pairs; we recover (u, v) endpoints
+/// here by indexing the per-pair @c bondEndpoints arrays the host
+/// already has.
+template <int maxAtoms, int maxBonds>
+MCSResult expandDeviceResult(const DeviceMCSResult<maxAtoms, maxBonds>& dr,
+                             const std::vector<std::uint32_t>&          queryBondEndpoints,
+                             const std::vector<std::uint32_t>&          targetBondEndpoints,
+                             bool                                       swapped) {
+  MCSResult r;
+  r.numCommonVertices = dr.numCommonVertices;
+  r.numCommonEdges    = dr.numCommonEdges;
+  r.timedOut          = dr.timedOut;
+  r.overflowed        = dr.overflowed;
+  r.mappingA.reserve(static_cast<size_t>(dr.numCommonVertices));
+  r.mappingB.reserve(static_cast<size_t>(dr.numCommonVertices));
+  for (int i = 0; i < dr.numCommonVertices; ++i) {
+    const size_t a = dr.mappingA[i];
+    const size_t b = dr.mappingB[i];
+    if (swapped) {
+      r.mappingA.push_back(b);
+      r.mappingB.push_back(a);
+    } else {
+      r.mappingA.push_back(a);
+      r.mappingB.push_back(b);
+    }
+  }
+  r.edgeMappingA.reserve(static_cast<size_t>(dr.numCommonEdges));
+  r.edgeMappingB.reserve(static_cast<size_t>(dr.numCommonEdges));
+  for (int i = 0; i < dr.numCommonEdges; ++i) {
+    const std::uint32_t       qPacked = queryBondEndpoints[dr.bondMapA[i]];
+    const std::uint32_t       tPacked = targetBondEndpoints[dr.bondMapB[i]];
+    std::pair<size_t, size_t> eA{static_cast<size_t>(qPacked >> 16), static_cast<size_t>(qPacked & 0xFFFFu)};
+    std::pair<size_t, size_t> eB{static_cast<size_t>(tPacked >> 16), static_cast<size_t>(tPacked & 0xFFFFu)};
+    if (swapped)
+      std::swap(eA, eB);
+    r.edgeMappingA.push_back(eA);
+    r.edgeMappingB.push_back(eB);
+  }
+  return r;
+}
+
+template <int maxAtoms, int maxBonds, class Policy> struct TierChunk {
+  std::vector<int>                                 resultIndices;
+  std::vector<HostPairDescriptor*>                 tierDescs;
+  std::vector<PairMatchTablesHost>                 hostTables;
+  UploadedPairMatchTables                          deviceTables;
+  std::vector<DevicePerPairInput>                  hostPairInputs;
+  std::vector<DeviceMCSResult<maxAtoms, maxBonds>> hostResults;
+};
+
+template <class Policy>
+using TierChunkVariant = std::variant<std::unique_ptr<TierChunk<16, 16, Policy>>,
+                                      std::unique_ptr<TierChunk<32, 32, Policy>>,
+                                      std::unique_ptr<TierChunk<64, 64, Policy>>,
+                                      std::unique_ptr<TierChunk<128, 128, Policy>>>;
+
+template <int maxAtoms, int maxBonds, class Policy>
+std::unique_ptr<TierChunk<maxAtoms, maxBonds, Policy>> makeTierChunk(const std::vector<HostPairDescriptor*>& descs,
+                                                                     const std::vector<int>&                 indices,
+                                                                     size_t                                  begin,
+                                                                     size_t                                  end) {
+  auto chunk = std::make_unique<TierChunk<maxAtoms, maxBonds, Policy>>();
+  chunk->resultIndices.reserve(end - begin);
+  chunk->tierDescs.reserve(end - begin);
+  chunk->hostTables.reserve(end - begin);
+  for (size_t pos = begin; pos < end; ++pos) {
+    const int idx = indices[pos];
+    chunk->resultIndices.push_back(idx);
+    chunk->tierDescs.push_back(descs[idx]);
+    chunk->hostTables.push_back(descs[idx]->tables);
+  }
+  return chunk;
+}
+
+template <int maxAtoms, int maxBonds, class Policy>
+void enqueueTierChunks(const std::vector<HostPairDescriptor*>&              descs,
+                       const std::vector<int>&                              indices,
+                       size_t                                               chunkSize,
+                       nvMolKit::ThreadSafeQueue<TierChunkVariant<Policy>>& chunkQueue) {
+  if (indices.empty())
+    return;
+
+  for (size_t begin = 0; begin < indices.size(); begin += chunkSize) {
+    const size_t             end  = std::min(begin + chunkSize, indices.size());
+    TierChunkVariant<Policy> item = makeTierChunk<maxAtoms, maxBonds, Policy>(descs, indices, begin, end);
+    chunkQueue.push(std::move(item));
+  }
+}
+
+template <int blockThreads, int maxAtoms, int maxBonds, class Policy>
+void launchTierChunk(FmcsExecutor&                                           executor,
+                     std::unique_ptr<TierChunk<maxAtoms, maxBonds, Policy>>& chunk,
+                     const Parameters&                                       params) {
+  cudaStream_t executorStream = executor.stream;
+  try {
+    chunk->deviceTables = uploadPairMatchTables(chunk->hostTables, executorStream);
+
+    chunk->hostPairInputs = uploadCsrAndAssemblePairInputs(chunk->tierDescs,
+                                                           chunk->deviceTables.tables,
+                                                           executorStream,
+                                                           &executor.bufs.csrBuffer,
+                                                           &executor.bufs.csrBufferBytes);
+
+    launchTierAsync<blockThreads, maxAtoms, maxBonds, Policy>(chunk->hostPairInputs,
+                                                              params,
+                                                              executorStream,
+                                                              executor.bufs,
+                                                              chunk->hostResults);
+
+    checkCuda(cudaEventRecord(executor.copyDoneEvent.event(), executorStream),
+              "cudaEventRecord (fMCS chunk copy done)");
+  } catch (...) {
+    freeBatchBuffers(executor.bufs, executorStream);
+    throw;
+  }
+}
+
+template <int maxAtoms, int maxBonds, class Policy>
+void drainTierChunk(FmcsExecutor&                                           executor,
+                    std::unique_ptr<TierChunk<maxAtoms, maxBonds, Policy>>& chunk,
+                    std::vector<MCSResult>&                                 outResults) {
+  checkCuda(cudaEventSynchronize(executor.copyDoneEvent.event()), "cudaEventSynchronize (fMCS chunk copy done)");
+  for (size_t k = 0; k < chunk->hostResults.size(); ++k) {
+    outResults[chunk->resultIndices[k]] =
+      expandDeviceResult<maxAtoms, maxBonds>(chunk->hostResults[k],
+                                             chunk->tierDescs[k]->packedQuery.bondEndpoints,
+                                             chunk->tierDescs[k]->packedTarget.bondEndpoints,
+                                             chunk->tierDescs[k]->swapped);
+  }
+  freeBatchBuffers(executor.bufs, executor.stream);
+}
+
+template <int blockThreads, class Policy>
+void runTierChunks(nvMolKit::ThreadSafeQueue<TierChunkVariant<Policy>>& chunkQueue,
+                   size_t                                               numChunks,
+                   const Parameters&                                    params,
+                   cudaStream_t                                         stream,
+                   std::vector<MCSResult>&                              outResults) {
+  if (numChunks == 0)
+    return;
+
+  const int executorCount =
+    static_cast<int>(std::min<size_t>(static_cast<size_t>(validateRequestedExecutorCount(params)), numChunks));
+  if (executorCount > 1 && stream != nullptr) {
+    throw std::invalid_argument("fMCS multi-executor dispatch does not support an external CUDA stream");
+  }
+
+  std::vector<std::unique_ptr<FmcsExecutor>> executorStorage;
+  executorStorage.reserve(static_cast<size_t>(executorCount));
+  std::vector<FmcsExecutor*> executors;
+  executors.reserve(static_cast<size_t>(executorCount));
+  const bool useExternalStream = executorCount == 1;
+  for (int i = 0; i < executorCount; ++i) {
+    auto executor = std::make_unique<FmcsExecutor>(i, stream, useExternalStream);
+    executors.push_back(executor.get());
+    executorStorage.push_back(std::move(executor));
+  }
+
+  auto launchChunk = [&](FmcsExecutor& executor, TierChunkVariant<Policy>& chunk) {
+    std::visit(
+      [&](auto& typedChunk) {
+        if (typedChunk) {
+          launchTierChunk<blockThreads>(executor, typedChunk, params);
+        }
+      },
+      chunk);
+  };
+
+  auto drainChunk = [&](FmcsExecutor& executor, TierChunkVariant<Policy>& chunk) {
+    std::visit(
+      [&](auto& typedChunk) {
+        if (typedChunk) {
+          drainTierChunk(executor, typedChunk, outResults);
+        }
+      },
+      chunk);
+  };
+
+  nvMolKit::runQueuedExecutorRing(executors, chunkQueue, launchChunk, drainChunk);
+}
+
+template <int blockThreads, class Policy, class InputT>
+std::vector<MCSResult> runBatchWithBlockSize(const std::vector<InputT>& a,
+                                             const std::vector<InputT>& b,
+                                             Parameters                 params,
+                                             cudaStream_t               stream) {
+  if (a.size() != b.size()) {
+    throw std::runtime_error("fMCS batch: graphsA and graphsB must have equal length");
+  }
+  const size_t           N = a.size();
+  std::vector<MCSResult> results(N);
+  if (N == 0)
+    return results;
+
+  std::vector<HostPairDescriptor> descs(N);
+  std::array<std::vector<int>, 4> tierIndices;
+  for (size_t i = 0; i < N; ++i) {
+    descs[i] = buildPairDescriptor<Policy, InputT>(a[i], b[i], params);
+    if (descs[i].overflowed) {
+      MCSResult r;
+      r.overflowed = true;
+      results[i]   = r;
+      continue;
+    }
+    tierIndices[descs[i].tier].push_back(static_cast<int>(i));
+  }
+
+  std::vector<HostPairDescriptor*> descPtrs(N);
+  for (size_t i = 0; i < N; ++i)
+    descPtrs[i] = &descs[i];
+
+  const size_t chunkSize = params.batchSize > 0 ? static_cast<size_t>(params.batchSize) : N;
+  size_t       numChunks = 0;
+  for (const auto& indices : tierIndices) {
+    if (!indices.empty()) {
+      numChunks += (indices.size() + chunkSize - 1) / chunkSize;
+    }
+  }
+
+  nvMolKit::ThreadSafeQueue<TierChunkVariant<Policy>> chunkQueue;
+  enqueueTierChunks<16, 16, Policy>(descPtrs, tierIndices[0], chunkSize, chunkQueue);
+  enqueueTierChunks<32, 32, Policy>(descPtrs, tierIndices[1], chunkSize, chunkQueue);
+  enqueueTierChunks<64, 64, Policy>(descPtrs, tierIndices[2], chunkSize, chunkQueue);
+  enqueueTierChunks<128, 128, Policy>(descPtrs, tierIndices[3], chunkSize, chunkQueue);
+  chunkQueue.close();
+  runTierChunks<blockThreads, Policy>(chunkQueue, numChunks, params, stream, results);
+
+  return results;
+}
+
+template <class Policy, class InputT>
+std::vector<MCSResult> runBatch(const std::vector<InputT>& a,
+                                const std::vector<InputT>& b,
+                                Parameters                 params,
+                                cudaStream_t               stream) {
+  switch (validateRequestedBlockSize(params)) {
+    case 64:
+      return runBatchWithBlockSize<64, Policy, InputT>(a, b, params, stream);
+    case 128:
+      return runBatchWithBlockSize<128, Policy, InputT>(a, b, params, stream);
+    case 256:
+      return runBatchWithBlockSize<256, Policy, InputT>(a, b, params, stream);
+    case 512:
+      return runBatchWithBlockSize<512, Policy, InputT>(a, b, params, stream);
+  }
+  throw std::logic_error("unreachable fMCS blockSize dispatch");
+}
+
+}  // namespace
+
+std::vector<MCSResult> findMCESfMCSBatch(const std::vector<Graph>& graphsA,
+                                         const std::vector<Graph>& graphsB,
+                                         Parameters                params,
+                                         cudaStream_t              stream) {
+  return runBatch<NullFMCSPolicy, Graph>(graphsA, graphsB, params, stream);
+}
+
+}  // namespace fmcs
+}  // namespace mcs

--- a/src/mcs/fmcs_cuda/fmcs.cu
+++ b/src/mcs/fmcs_cuda/fmcs.cu
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <stdexcept>
@@ -32,6 +33,7 @@
 #include "src/mcs/fmcs_cuda/fmcs_match_tables.cuh"
 #include "src/mcs/fmcs_cuda/fmcs_policy.cuh"
 #include "src/utils/device.h"
+#include "src/utils/device_vector.h"
 #include "src/utils/gpu_executor_ring.h"
 
 namespace mcs {
@@ -159,19 +161,17 @@ HostPairDescriptor buildPairDescriptor(const InputT& sideA, const InputT& sideB,
   return desc;
 }
 
-/// Owning device allocations for one tier sub-batch.  @c dResultsBuffer
-/// and @c dQueueStorage are typed at launch time (per @c maxAtoms /
-/// @c maxBonds), so they are held as opaque pointers here.  The queue
-/// storage is one contiguous global-memory slab of
+/// Owning device allocations for one tier sub-batch. Results, queue, and
+/// scratch element types depend on the selected tier, so their storage is
+/// type-erased as bytes. The queue storage is one contiguous global-memory slab of
 /// @c kFmcsQueueCapacity * numPairs QueuedSeed entries; per-block slices
 /// are taken inside the kernel via @c blockIdx.x.
 struct BatchDeviceBuffers {
-  void*               csrBuffer       = nullptr;
-  size_t              csrBufferBytes  = 0;
-  DevicePerPairInput* dPairInputs     = nullptr;
-  void*               dResultsBuffer  = nullptr;
-  void*               dQueueStorage   = nullptr;
-  void*               dScratchStorage = nullptr;
+  nvMolKit::AsyncDeviceVector<uint32_t>           csrStorage;
+  nvMolKit::AsyncDeviceVector<DevicePerPairInput> pairInputs;
+  nvMolKit::AsyncDeviceVector<std::byte>          resultsStorage;
+  nvMolKit::AsyncDeviceVector<std::byte>          queueStorage;
+  nvMolKit::AsyncDeviceVector<std::byte>          scratchStorage;
 };
 
 constexpr int kMaxFmcsExecutorsPerRunner = 8;
@@ -180,7 +180,6 @@ struct FmcsExecutor {
   std::unique_ptr<nvMolKit::ScopedStream> ownedStream;
   cudaStream_t                            stream = nullptr;
   nvMolKit::ScopedCudaEvent               copyDoneEvent;
-  BatchDeviceBuffers                      bufs;
 
   FmcsExecutor(int executorIdx, cudaStream_t externalStream, bool useExternalStream) {
     if (useExternalStream) {
@@ -209,37 +208,13 @@ int validateRequestedBlockSize(const Parameters& params) {
   throw std::invalid_argument("fMCS blockSize must be one of 64, 128, 256, or 512");
 }
 
-void freeBatchBuffers(BatchDeviceBuffers& bufs, cudaStream_t stream) {
-  if (bufs.csrBuffer) {
-    cudaFreeAsync(bufs.csrBuffer, stream);
-    bufs.csrBuffer = nullptr;
-  }
-  if (bufs.dPairInputs) {
-    cudaFreeAsync(bufs.dPairInputs, stream);
-    bufs.dPairInputs = nullptr;
-  }
-  if (bufs.dResultsBuffer) {
-    cudaFreeAsync(bufs.dResultsBuffer, stream);
-    bufs.dResultsBuffer = nullptr;
-  }
-  if (bufs.dQueueStorage) {
-    cudaFreeAsync(bufs.dQueueStorage, stream);
-    bufs.dQueueStorage = nullptr;
-  }
-  if (bufs.dScratchStorage) {
-    cudaFreeAsync(bufs.dScratchStorage, stream);
-    bufs.dScratchStorage = nullptr;
-  }
-}
-
 /// Upload every pair's CSR and bond-endpoint arrays into one contiguous
 /// device buffer, returning per-pair descriptors whose pointers refer into
 /// that buffer.
 std::vector<DevicePerPairInput> uploadCsrAndAssemblePairInputs(const std::vector<HostPairDescriptor*>&   descs,
                                                                const std::vector<PairMatchTablesDevice>& tablesDev,
                                                                cudaStream_t                              stream,
-                                                               void**                                    outBuf,
-                                                               size_t*                                   outBufBytes) {
+                                                               nvMolKit::AsyncDeviceVector<uint32_t>&    storage) {
   size_t totalWords = 0;
   for (auto* d : descs) {
     totalWords += d->packedQuery.rowOffsets.size();
@@ -252,11 +227,8 @@ std::vector<DevicePerPairInput> uploadCsrAndAssemblePairInputs(const std::vector
     totalWords += d->packedTarget.bondEndpoints.size();
   }
 
-  void* buf = nullptr;
-  if (totalWords > 0) {
-    checkCuda(cudaMallocAsync(&buf, totalWords * sizeof(uint32_t), stream), "cudaMallocAsync (CSR)");
-  }
-  uint32_t* base = reinterpret_cast<uint32_t*>(buf);
+  storage        = nvMolKit::AsyncDeviceVector<uint32_t>(totalWords, stream);
+  uint32_t* base = storage.data();
 
   std::vector<DevicePerPairInput> out(descs.size());
   size_t                          cursor    = 0;
@@ -289,10 +261,6 @@ std::vector<DevicePerPairInput> uploadCsrAndAssemblePairInputs(const std::vector
     p.swapped             = d.swapped;
   }
 
-  if (outBuf)
-    *outBuf = buf;
-  if (outBufBytes)
-    *outBufBytes = totalWords * sizeof(uint32_t);
   return out;
 }
 
@@ -306,34 +274,30 @@ void launchTierAsync(const std::vector<DevicePerPairInput>&            hostPairI
   if (numPairs == 0)
     return;
 
-  checkCuda(cudaMallocAsync(reinterpret_cast<void**>(&bufs.dPairInputs), numPairs * sizeof(DevicePerPairInput), stream),
-            "cudaMallocAsync (pair inputs)");
-  checkCuda(cudaMemcpyAsync(bufs.dPairInputs,
+  bufs.pairInputs = nvMolKit::AsyncDeviceVector<DevicePerPairInput>(static_cast<size_t>(numPairs), stream);
+  checkCuda(cudaMemcpyAsync(bufs.pairInputs.data(),
                             hostPairInputs.data(),
                             numPairs * sizeof(DevicePerPairInput),
                             cudaMemcpyHostToDevice,
                             stream),
             "cudaMemcpyAsync (pair inputs)");
 
-  DeviceMCSResult<maxAtoms, maxBonds>* dResults = nullptr;
   const size_t resultsBytes = static_cast<size_t>(numPairs) * sizeof(DeviceMCSResult<maxAtoms, maxBonds>);
-  checkCuda(cudaMallocAsync(reinterpret_cast<void**>(&dResults), resultsBytes, stream), "cudaMallocAsync (results)");
-  bufs.dResultsBuffer = dResults;
+  bufs.resultsStorage       = nvMolKit::AsyncDeviceVector<std::byte>(resultsBytes, stream);
+  auto* dResults            = reinterpret_cast<DeviceMCSResult<maxAtoms, maxBonds>*>(bufs.resultsStorage.data());
 
   using QueuedT           = QueuedSeed<maxAtoms, maxBonds, maxAtoms, maxBonds>;
-  QueuedT*     dQueue     = nullptr;
   const size_t queueBytes = static_cast<size_t>(numPairs) * kFmcsQueueCapacity * sizeof(QueuedT);
-  checkCuda(cudaMallocAsync(reinterpret_cast<void**>(&dQueue), queueBytes, stream), "cudaMallocAsync (queue storage)");
-  bufs.dQueueStorage = dQueue;
+  bufs.queueStorage       = nvMolKit::AsyncDeviceVector<std::byte>(queueBytes, stream);
+  auto* dQueue            = reinterpret_cast<QueuedT*>(bufs.queueStorage.data());
 
   using ScratchT     = FmcsSubstructureScratch<maxAtoms, maxAtoms>;
   ScratchT* dScratch = nullptr;
   if constexpr (kUseGlobalSubstructureScratch<blockThreads, maxAtoms>) {
     const size_t scratchBytes =
       static_cast<size_t>(numPairs) * static_cast<size_t>(FmcsBlockConfig<blockThreads>::numGroups) * sizeof(ScratchT);
-    checkCuda(cudaMallocAsync(reinterpret_cast<void**>(&dScratch), scratchBytes, stream),
-              "cudaMallocAsync (global substructure scratch)");
-    bufs.dScratchStorage = dScratch;
+    bufs.scratchStorage = nvMolKit::AsyncDeviceVector<std::byte>(scratchBytes, stream);
+    dScratch            = reinterpret_cast<ScratchT*>(bufs.scratchStorage.data());
   }
 
   unsigned long long timeoutClocks = 0;
@@ -352,7 +316,7 @@ void launchTierAsync(const std::vector<DevicePerPairInput>&            hostPairI
   dim3 grid(static_cast<unsigned>(numPairs));
   dim3 block(static_cast<unsigned>(blockThreads));
   fmcsKernel<maxAtoms, maxBonds, blockThreads, Policy, kUseGlobalSubstructureScratch<blockThreads, maxAtoms>>
-    <<<grid, block, 0, stream>>>(bufs.dPairInputs,
+    <<<grid, block, 0, stream>>>(bufs.pairInputs.data(),
                                  dResults,
                                  dQueue,
                                  dScratch,
@@ -414,6 +378,7 @@ template <int maxAtoms, int maxBonds, class Policy> struct TierChunk {
   std::vector<HostPairDescriptor*>                 tierDescs;
   std::vector<PairMatchTablesHost>                 hostTables;
   UploadedPairMatchTables                          deviceTables;
+  BatchDeviceBuffers                               deviceBuffers;
   std::vector<DevicePerPairInput>                  hostPairInputs;
   std::vector<DeviceMCSResult<maxAtoms, maxBonds>> hostResults;
 };
@@ -462,27 +427,19 @@ void launchTierChunk(FmcsExecutor&                                           exe
                      std::unique_ptr<TierChunk<maxAtoms, maxBonds, Policy>>& chunk,
                      const Parameters&                                       params) {
   cudaStream_t executorStream = executor.stream;
-  try {
-    chunk->deviceTables = uploadPairMatchTables(chunk->hostTables, executorStream);
+  chunk->deviceTables         = uploadPairMatchTables(chunk->hostTables, executorStream);
+  chunk->hostPairInputs       = uploadCsrAndAssemblePairInputs(chunk->tierDescs,
+                                                         chunk->deviceTables.tables,
+                                                         executorStream,
+                                                         chunk->deviceBuffers.csrStorage);
 
-    chunk->hostPairInputs = uploadCsrAndAssemblePairInputs(chunk->tierDescs,
-                                                           chunk->deviceTables.tables,
-                                                           executorStream,
-                                                           &executor.bufs.csrBuffer,
-                                                           &executor.bufs.csrBufferBytes);
+  launchTierAsync<blockThreads, maxAtoms, maxBonds, Policy>(chunk->hostPairInputs,
+                                                            params,
+                                                            executorStream,
+                                                            chunk->deviceBuffers,
+                                                            chunk->hostResults);
 
-    launchTierAsync<blockThreads, maxAtoms, maxBonds, Policy>(chunk->hostPairInputs,
-                                                              params,
-                                                              executorStream,
-                                                              executor.bufs,
-                                                              chunk->hostResults);
-
-    checkCuda(cudaEventRecord(executor.copyDoneEvent.event(), executorStream),
-              "cudaEventRecord (fMCS chunk copy done)");
-  } catch (...) {
-    freeBatchBuffers(executor.bufs, executorStream);
-    throw;
-  }
+  checkCuda(cudaEventRecord(executor.copyDoneEvent.event(), executorStream), "cudaEventRecord (fMCS chunk copy done)");
 }
 
 template <int maxAtoms, int maxBonds, class Policy>
@@ -497,7 +454,6 @@ void drainTierChunk(FmcsExecutor&                                           exec
                                              chunk->tierDescs[k]->packedTarget.bondEndpoints,
                                              chunk->tierDescs[k]->swapped);
   }
-  freeBatchBuffers(executor.bufs, executor.stream);
 }
 
 template <int blockThreads, class Policy>

--- a/src/mcs/fmcs_cuda/fmcs.cuh
+++ b/src/mcs/fmcs_cuda/fmcs.cuh
@@ -58,7 +58,8 @@ struct Parameters {
   int   blockSize          = 128;
   /// Per-pair wall timeout in milliseconds.  0 = no timeout.
   float timeoutMs          = 0;
-  /// Max pairs per kernel launch in the batch API.  0 = auto from GPU memory.
+  /// Max pairs per kernel launch in the batch API.  0 = no explicit limit;
+  /// process each nonempty size tier as one chunk.
   int   batchSize          = 0;
   /// Number of asynchronous executor streams for tier sub-batches. 1 = serial.
   int   executorsPerRunner = 1;

--- a/src/mcs/fmcs_cuda/fmcs.cuh
+++ b/src/mcs/fmcs_cuda/fmcs.cuh
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FMCS_CUDA_FMCS_CUH
+#define FMCS_CUDA_FMCS_CUH
+
+// Public API for the fMCS (seed-grow connected-MCES) CUDA solver.
+//
+// Algorithm reference: RDKit's rdFMCS (Novartis, 2014), re-implemented
+// here as a GPU-native grow-and-verify search that enumerates the
+// connected-subgraph lattice of the smaller input and matches each
+// candidate against the larger input on the device.
+//
+// Feature surface: unlabeled topology, optional exact vertex/edge-label
+// matching, MaximizeBonds objective, Threshold=1.0, connected-only result.
+// RDKit atomCompare/bondCompare modes map to caller-provided labels: CompareAny
+// disables the corresponding table, while CompareElements/CompareIsotopes
+// and CompareOrder/CompareOrderExact require the caller to encode those
+// semantics as uint16 labels. RingMatchesRingOnly is likewise supported when
+// ring membership is encoded in atom/bond labels. Chirality, fused-ring
+// strictness, and Threshold < 1.0 are out of scope.
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "src/mcs/mcs_common/mcs_types.cuh"
+
+namespace mcs {
+
+namespace fmcs {
+
+/// Maximum CSR degree supported by the device substructure matcher.
+inline constexpr int kMaxNeighborsPerAtom = 8;
+
+/// Algorithm-level parameters for the fMCS solver.
+///
+/// The objective (connected MCES, MaximizeBonds, Threshold=1) is baked
+/// into the algorithm itself and is not exposed as a knob.
+struct Parameters {
+  /// CUDA block size for the per-pair kernel. Supported: 64, 128, 256, 512.
+  /// Tier-128 searches at 512 threads place substructure scratch in global
+  /// memory; smaller tiers retain shared-memory scratch.
+  int   blockSize          = 128;
+  /// Per-pair wall timeout in milliseconds.  0 = no timeout.
+  float timeoutMs          = 0;
+  /// Max pairs per kernel launch in the batch API.  0 = auto from GPU memory.
+  int   batchSize          = 0;
+  /// Number of asynchronous executor streams for tier sub-batches. 1 = serial.
+  int   executorsPerRunner = 1;
+  /// For labeled inputs, require exact vertex-label equality.  When false,
+  /// atom compatibility is CompareAny-style.
+  bool  matchVertexLabels  = true;
+  /// For labeled inputs, require exact edge-label equality.  When false,
+  /// bond compatibility is CompareAny-style.
+  bool  matchEdgeLabels    = true;
+};
+
+/// Find the connected MCES for a batch of unlabeled graph pairs.
+///
+/// `graphsA` and `graphsB` must have equal length. For unlabeled input,
+/// atom/bond compatibility is topology-only. When a graph
+/// exceeds the maximum supported maxSize, that pair's result has `overflowed`
+/// set and all counts are zero. Graphs containing a vertex with more than
+/// @ref kMaxNeighborsPerAtom neighbors are rejected.
+std::vector<MCSResult> findMCESfMCSBatch(const std::vector<Graph>& graphsA,
+                                         const std::vector<Graph>& graphsB,
+                                         Parameters                params = {},
+                                         cudaStream_t              stream = nullptr);
+
+}  // namespace fmcs
+}  // namespace mcs
+
+#endif  // FMCS_CUDA_FMCS_CUH

--- a/src/mcs/fmcs_cuda/fmcs_kernel.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_kernel.cuh
@@ -1,0 +1,548 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef FMCS_CUDA_FMCS_KERNEL_CUH
+#define FMCS_CUDA_FMCS_KERNEL_CUH
+
+#include "src/mcs/fmcs_cuda/fmcs_search_support.cuh"
+
+namespace mcs {
+namespace fmcs {
+
+/// Tier-128 per-group substructure scratch does not fit in shared memory once
+/// a block runs more than four warp groups, so those specializations take the
+/// scratch from a global-memory slab instead.
+template <int blockThreads, int maxAtoms>
+inline constexpr bool kUseGlobalSubstructureScratch = maxAtoms == 128 && blockThreads >= 256;
+
+template <int maxAtoms, int maxBonds, int blockThreads, class Policy, bool GlobalSubstructureScratch = false>
+__global__ void fmcsKernel(const DevicePerPairInput* __restrict__ pairs,
+                           DeviceMCSResult<maxAtoms, maxBonds>* __restrict__ results,
+                           QueuedSeed<maxAtoms, maxBonds, maxAtoms, maxBonds>* __restrict__ queueStorageAll,
+                           FmcsSubstructureScratch<maxAtoms, maxAtoms>* __restrict__ scratchStorageAll,
+                           int                queueCapacity,
+                           int                numPairs,
+                           unsigned long long timeoutClocks) {
+  const int pairIdx = blockIdx.x;
+  if (pairIdx >= numPairs)
+    return;
+
+  auto                      block = cg::this_thread_block();
+  const DevicePerPairInput& pair  = pairs[pairIdx];
+
+  using QueuedT                     = QueuedSeed<maxAtoms, maxBonds, maxAtoms, maxBonds>;
+  using SubstructureScratchT        = FmcsSubstructureScratch<maxAtoms, maxAtoms>;
+  constexpr int kMaxNewBondsForTier = maxBonds;
+  constexpr int kNumGroups          = FmcsBlockConfig<blockThreads>::numGroups;
+
+  // Block-shared resources: the queue, the incumbent, and the early-exit
+  // flags are visible to every group. Cross-group queue/incumbent updates use
+  // atomics; loop-control reads are made uniform before any branch that can
+  // skip a later block/group rendezvous.
+  __shared__ SeedQueue<QueuedT, ThreadBlockScope> queue;
+  __shared__ __align__(16) unsigned char bestStorage[sizeof(QueuedT)];
+  QueuedT&                               best = *reinterpret_cast<QueuedT*>(bestStorage);
+  // Atomic incumbent score: high 16 bits = numBonds, low 16 bits =
+  // numAtoms.  Groups race through atomicCAS on this single int to
+  // claim the right to write @c best.
+  __shared__ unsigned int                bestScore;
+  __shared__ int                         bestCopyLock;
+  __shared__ DeviceCsrView               queryView;
+  __shared__ DeviceCsrView               targetView;
+  __shared__ bool                        overflowed;
+  __shared__ bool                        timedOut;
+  __shared__ bool                        phase2Done;
+  __shared__ unsigned long long          startClock;
+  SubstructureScratchT*                  substructureScratch;
+  if constexpr (GlobalSubstructureScratch) {
+    substructureScratch = scratchStorageAll + static_cast<size_t>(pairIdx) * kNumGroups;
+  } else {
+    (void)scratchStorageAll;
+    __shared__ SubstructureScratchT sharedSubstructureScratch[kNumGroups];
+    substructureScratch = sharedSubstructureScratch;
+  }
+
+  // Cooperative Phase 2 working state.  Approach 1 gives each warp group an
+  // independent seed workspace and fallback scratch so groups can pop and
+  // grow seeds concurrently.
+  __shared__ __align__(16) unsigned char currentStorage[sizeof(QueuedT) * kNumGroups];
+  __shared__ __align__(16) unsigned char biggestStorage[sizeof(QueuedT) * kNumGroups];
+  QueuedT*                               current = reinterpret_cast<QueuedT*>(currentStorage);
+  QueuedT*                               biggest = reinterpret_cast<QueuedT*>(biggestStorage);
+  __shared__ NewBond                     newBondsArr[kNumGroups][kMaxNewBondsForTier];
+  __shared__ int                         newBondCount[kNumGroups];
+  __shared__ bool                        popped[kNumGroups];
+  __shared__ bool                        stage0Ok[kNumGroups];
+  __shared__ std::uint8_t remainingAtomStack[kNumGroups][maxAtoms];
+  __shared__ typename Seed<maxAtoms, maxBonds>::atom_word_type
+    remainingVisitedAtoms[kNumGroups][Seed<maxAtoms, maxBonds>::kAtomWords];
+  __shared__ typename Seed<maxAtoms, maxBonds>::bond_word_type
+                 remainingVisitedBonds[kNumGroups][Seed<maxAtoms, maxBonds>::kBondWords];
+  __shared__ int remainingStackSize[kNumGroups];
+  __shared__
+    typename Seed<maxAtoms, maxBonds>::bond_word_type initialExcludedBonds[Seed<maxAtoms, maxBonds>::kBondWords];
+
+  auto                  group                 = cg::tiled_partition<kFmcsGroupSize>(block);
+  const int             groupId               = static_cast<int>(block.thread_rank()) / kFmcsGroupSize;
+  const int             groupRank             = static_cast<int>(group.thread_rank());
+  SubstructureScratchT& mySubstructureScratch = substructureScratch[groupId];
+
+  QueuedT* myQueueStorage = queueStorageAll + static_cast<size_t>(pairIdx) * queueCapacity;
+
+  if (block.thread_rank() == 0) {
+    queue.init(myQueueStorage, queueCapacity);
+    seedClearWithinThread(best.seed);
+    matchResultClearWithinThread(best.match);
+    bestScore    = 0;
+    bestCopyLock = 0;
+    overflowed   = false;
+    timedOut     = false;
+    phase2Done   = false;
+    startClock   = clock64();
+
+    queryView.rowOffsets    = pair.queryRowOffsets;
+    queryView.colIndices    = pair.queryColIndices;
+    queryView.bondIndices   = pair.queryBondIndices;
+    queryView.bondEndpoints = pair.queryBondEndpoints;
+    queryView.numAtoms      = pair.queryNumAtoms;
+    queryView.numBonds      = pair.queryNumBonds;
+
+    targetView.rowOffsets    = pair.targetRowOffsets;
+    targetView.colIndices    = pair.targetColIndices;
+    targetView.bondIndices   = pair.targetBondIndices;
+    targetView.bondEndpoints = pair.targetBondEndpoints;
+    targetView.numAtoms      = pair.targetNumAtoms;
+    targetView.numBonds      = pair.targetNumBonds;
+  }
+  block.sync();
+
+  QueuedT&      myCurrent               = current[groupId];
+  QueuedT&      myBiggest               = biggest[groupId];
+  NewBond*      myNewBonds              = newBondsArr[groupId];
+  std::uint8_t* myRemainingAtomStack    = remainingAtomStack[groupId];
+  auto*         myRemainingVisitedAtoms = remainingVisitedAtoms[groupId];
+  auto*         myRemainingVisitedBonds = remainingVisitedBonds[groupId];
+
+  // ---- Phase 1: RDKit makeInitialSeeds() analogue ----
+  // RDKit creates one initial seed per query bond, not one per target
+  // embedding.  Each candidate goes through checkIfMatchAndAppend(), which
+  // runs substructure matching and stores one witness MatchResult on success.
+  // Initial ExcludedBonds is prefix-like: later initial seeds exclude earlier
+  // query bonds, and a mismatched initial bond is also excluded from seeds
+  // already admitted.  Group 0 handles this serial state; the substructure
+  // check remains cooperative across that group's lanes.
+  if (block.thread_rank() < Seed<maxAtoms, maxBonds>::kBondWords) {
+    initialExcludedBonds[block.thread_rank()] = 0;
+  }
+  block.sync();
+
+  if (groupId == 0) {
+    for (int qBond = 0; qBond < pair.queryNumBonds && !overflowed && !timedOut; ++qBond) {
+      if (groupRank == 0) {
+        seedClearWithinThread(myCurrent.seed);
+        matchResultClearWithinThread(myCurrent.match);
+        for (int wordIdx = 0; wordIdx < Seed<maxAtoms, maxBonds>::kBondWords; ++wordIdx) {
+          myCurrent.seed.excludedBonds[wordIdx] = initialExcludedBonds[wordIdx];
+        }
+
+        const std::uint32_t queryEndpoints = queryView.bondEndpoints[qBond];
+        const int           queryEndpointU = static_cast<int>(queryEndpoints >> kBondEndpointShift);
+        const int           queryEndpointV = static_cast<int>(queryEndpoints & kBondEndpointMask);
+        seedAddBondWithinThread(myCurrent.seed, qBond);
+        seedAddAtomWithinThread(myCurrent.seed, queryEndpointU);
+        seedAddAtomWithinThread(myCurrent.seed, queryEndpointV);
+        myCurrent.seed.growingStage = kSeedGrowStageOuter;
+      }
+      group.sync();
+      seedComputeRemainingSizeRdkitCooperative(group,
+                                               myCurrent.seed,
+                                               queryView,
+                                               myRemainingAtomStack,
+                                               myRemainingVisitedAtoms,
+                                               myRemainingVisitedBonds,
+                                               &remainingStackSize[groupId]);
+
+      const bool matched =
+        checkSeedMatchAndAppendCooperative(group, myCurrent, queryView, targetView, pair.tables, mySubstructureScratch);
+      if (matched) {
+        updateIncumbentCooperative(group, myCurrent, best, &bestScore, &bestCopyLock);
+        if (!pushBackCooperative(group, queue, myCurrent)) {
+          overflowed = true;
+        }
+      } else if (groupRank == 0) {
+        const int queuedSeeds = queue.size();
+        for (int i = 0; i < queuedSeeds; ++i) {
+          seedExcludeBondWithinThread(queue.slot(i).seed, qBond);
+        }
+      }
+      group.sync();
+
+      if (groupRank == 0) {
+        const int  wordIdx = qBond / Seed<maxAtoms, maxBonds>::kBondBitsPerWord;
+        const auto mask    = static_cast<typename Seed<maxAtoms, maxBonds>::bond_word_type>(1)
+                       << (qBond % Seed<maxAtoms, maxBonds>::kBondBitsPerWord);
+        initialExcludedBonds[wordIdx] |= mask;
+      }
+      group.sync();
+    }
+  }
+
+  block.sync();
+  if (block.thread_rank() == 0 && timeoutClocks > 0 && clock64() - startClock > timeoutClocks) {
+    timedOut = true;
+  }
+  block.sync();
+
+  // ---- Phase 2: RDKit Seed::grow() analogue ----
+
+  // Approach 1 uses an atomic LIFO worklist so every warp group can pop and
+  // grow one seed per outer iteration.  This intentionally trades RDKit's
+  // sorted-front scheduling order for useful multi-warp work while preserving
+  // the full checkIfMatchAndAppend-style substructure validation.
+  while (true) {
+    if (block.thread_rank() == 0)
+      phase2Done = overflowed || timedOut || queue.empty();
+    block.sync();
+    if (phase2Done)
+      break;
+
+    const bool poppedThisGroup = popBackCooperative(group, queue, myCurrent);
+    if (groupRank == 0) {
+      popped[groupId] = poppedThisGroup;
+    }
+    group.sync();
+    // Complete every pop before any group can reserve and publish new work.
+    block.sync();
+
+    do {
+      if (!popped[groupId])
+        break;
+
+      // RDKit growSeeds() increments TotalSteps before Seed::grow(), then
+      // Seed::grow() first checks canGrowBiggerThan().
+      const unsigned int scoreSnapshot     = readBestScoreCooperative(group, &bestScore);
+      const int          bestBondsSnapshot = static_cast<int>(scoreSnapshot >> 16);
+      const int          bestAtomsSnapshot = static_cast<int>(scoreSnapshot & 0xFFFFu);
+      if (!seedCanGrowBiggerThanWithinThread(myCurrent.seed, bestBondsSnapshot, bestAtomsSnapshot)) {
+        break;
+      }
+
+      updateIncumbentCooperative(group, myCurrent, best, &bestScore, &bestCopyLock);
+
+      const bool fillOk = fillNewBondsCooperative(group,
+                                                  myCurrent.seed,
+                                                  queryView,
+                                                  myNewBonds,
+                                                  &newBondCount[groupId],
+                                                  kMaxNewBondsForTier);
+      group.sync();
+      if (!fillOk) {
+        if (groupRank == 0)
+          overflowed = true;
+        break;
+      }
+
+      if (newBondCount[groupId] == 0) {
+        break;
+      }
+
+      bool runInnerStage = myCurrent.seed.growingStage != kSeedGrowStageOuter;
+
+      // RDKit Seed::grow() stage 0: build the child containing all newly
+      // discovered outgoing bonds and run checkIfMatchAndAppend().  If this
+      // all-bonds child matches and there is more than one new bond, RDKit
+      // returns immediately with the parent left at GrowingStage=1; the next
+      // outer grow loop resumes the parent at the singleton/subset stage.
+      if (myCurrent.seed.growingStage == kSeedGrowStageOuter) {
+        warpCopy(group, &myBiggest, &myCurrent, sizeof(QueuedT));
+        group.sync();
+        if (groupRank == 0) {
+          seedBeginGrowStepWithinThread(myBiggest.seed);
+          myBiggest.seed.growingStage = kSeedGrowStageOuter;
+          for (int i = 0; i < newBondCount[groupId]; ++i) {
+            seedAddNewBondWithinThread(myBiggest.seed, myNewBonds[i]);
+          }
+        }
+        group.sync();
+        seedComputeRemainingSizeRdkitCooperative(group,
+                                                 myBiggest.seed,
+                                                 queryView,
+                                                 myRemainingAtomStack,
+                                                 myRemainingVisitedAtoms,
+                                                 myRemainingVisitedBonds,
+                                                 &remainingStackSize[groupId]);
+
+        const unsigned int childScoreSnapshot = readBestScoreCooperative(group, &bestScore);
+        const int          childBestBonds     = static_cast<int>(childScoreSnapshot >> 16);
+        const int          childBestAtoms     = static_cast<int>(childScoreSnapshot & 0xFFFFu);
+        if (!seedCanGrowBiggerThanWithinThread(myBiggest.seed, childBestBonds, childBestAtoms)) {
+          break;
+        }
+
+        const bool ok = checkSeedMatchAndAppendCooperative(group,
+                                                           myBiggest,
+                                                           queryView,
+                                                           targetView,
+                                                           pair.tables,
+                                                           mySubstructureScratch);
+        if (groupRank == 0)
+          stage0Ok[groupId] = ok;
+        group.sync();
+
+        if (stage0Ok[groupId]) {
+          updateIncumbentCooperative(group, myBiggest, best, &bestScore, &bestCopyLock);
+          if (!pushBackCooperative(group, queue, myBiggest)) {
+            overflowed = true;
+          }
+          group.sync();
+          if (newBondCount[groupId] > 1) {
+            if (groupRank == 0) {
+              myCurrent.seed.growingStage = kSeedGrowStageInner;
+            }
+            group.sync();
+            if (!pushBackCooperative(group, queue, myCurrent)) {
+              overflowed = true;
+            }
+            group.sync();
+          }
+          break;
+        }
+        if (newBondCount[groupId] == 1)
+          break;
+        runInnerStage = true;
+      }
+
+      if (!runInnerStage)
+        break;
+
+      // RDKit Seed::grow() stage 1: try every individual outgoing bond.
+      // A failed individual match excludes that NewBond from later subset
+      // enumeration and increments IndividualBondExcluded.
+      for (int i = 0; i < newBondCount[groupId]; ++i) {
+        if (!myNewBonds[i].alive)
+          continue;
+
+        warpCopy(group, &myBiggest, &myCurrent, sizeof(QueuedT));
+        group.sync();
+
+        if (groupRank == 0) {
+          seedBeginGrowStepWithinThread(myBiggest.seed);
+          myBiggest.seed.growingStage = kSeedGrowStageOuter;
+          seedAddNewBondWithinThread(myBiggest.seed, myNewBonds[i]);
+        }
+        group.sync();
+        seedComputeRemainingSizeRdkitCooperative(group,
+                                                 myBiggest.seed,
+                                                 queryView,
+                                                 myRemainingAtomStack,
+                                                 myRemainingVisitedAtoms,
+                                                 myRemainingVisitedBonds,
+                                                 &remainingStackSize[groupId]);
+
+        const unsigned int childScoreSnapshot = readBestScoreCooperative(group, &bestScore);
+        const int          childBestBonds     = static_cast<int>(childScoreSnapshot >> 16);
+        const int          childBestAtoms     = static_cast<int>(childScoreSnapshot & 0xFFFFu);
+        if (!seedCanGrowBiggerThanWithinThread(myBiggest.seed, childBestBonds, childBestAtoms)) {
+          continue;
+        }
+
+        const bool ok = checkSeedMatchAndAppendCooperative(group,
+                                                           myBiggest,
+                                                           queryView,
+                                                           targetView,
+                                                           pair.tables,
+                                                           mySubstructureScratch);
+        if (ok) {
+          updateIncumbentCooperative(group, myBiggest, best, &bestScore, &bestCopyLock);
+          if (!pushBackCooperative(group, queue, myBiggest)) {
+            overflowed = true;
+          }
+        } else if (groupRank == 0) {
+          myNewBonds[i].alive = false;
+        }
+        group.sync();
+      }
+
+      // RDKit Seed::grow() stage 2: enumerate all non-singleton subsets of
+      // the surviving NewBonds.  Singletons were handled by Stage 1; the
+      // all-bonds subset was handled by Stage 0 unless Stage 1 erased one or
+      // more individual bonds, in which case the all-surviving-bonds subset is
+      // new work and must be checked.
+      int aliveCount    = 0;
+      int aliveOverflow = 0;
+      if (groupRank == 0) {
+        for (int i = 0; i < newBondCount[groupId]; ++i) {
+          if (myNewBonds[i].alive)
+            ++aliveCount;
+        }
+        aliveOverflow = aliveCount > 63 ? 1 : 0;
+        if (aliveOverflow)
+          overflowed = true;
+      }
+      aliveCount    = group.shfl(aliveCount, 0);
+      aliveOverflow = group.shfl(aliveOverflow, 0);
+      if (aliveOverflow)
+        break;
+      if (aliveCount > 1) {
+        unsigned int erasedCount = 0;
+        if (groupRank == 0) {
+          erasedCount = static_cast<unsigned int>(newBondCount[groupId] - aliveCount);
+        }
+        erasedCount                             = group.shfl(erasedCount, 0);
+        const unsigned long long maxComposition = (1ULL << aliveCount) - 1ULL;
+        for (unsigned long long composition = maxComposition; composition != 0ULL; --composition) {
+          if (isPowerOfTwo64(composition))
+            continue;
+          if (erasedCount == 0 && composition == maxComposition)
+            continue;
+
+          warpCopy(group, &myBiggest, &myCurrent, sizeof(QueuedT));
+          group.sync();
+          if (groupRank == 0) {
+            seedBeginGrowStepWithinThread(myBiggest.seed);
+            myBiggest.seed.growingStage = kSeedGrowStageOuter;
+            int aliveBit                = 0;
+            for (int i = 0; i < newBondCount[groupId]; ++i) {
+              if (!myNewBonds[i].alive)
+                continue;
+              if ((composition & (1ULL << aliveBit)) != 0ULL) {
+                seedAddNewBondWithinThread(myBiggest.seed, myNewBonds[i]);
+              }
+              ++aliveBit;
+            }
+          }
+          group.sync();
+          seedComputeRemainingSizeRdkitCooperative(group,
+                                                   myBiggest.seed,
+                                                   queryView,
+                                                   myRemainingAtomStack,
+                                                   myRemainingVisitedAtoms,
+                                                   myRemainingVisitedBonds,
+                                                   &remainingStackSize[groupId]);
+
+          const unsigned int childScoreSnapshot = readBestScoreCooperative(group, &bestScore);
+          const int          childBestBonds     = static_cast<int>(childScoreSnapshot >> 16);
+          const int          childBestAtoms     = static_cast<int>(childScoreSnapshot & 0xFFFFu);
+          if (!seedCanGrowBiggerThanWithinThread(myBiggest.seed, childBestBonds, childBestAtoms)) {
+            continue;
+          }
+
+          const bool ok = checkSeedMatchAndAppendCooperative(group,
+                                                             myBiggest,
+                                                             queryView,
+                                                             targetView,
+                                                             pair.tables,
+                                                             mySubstructureScratch);
+          if (ok) {
+            updateIncumbentCooperative(group, myBiggest, best, &bestScore, &bestCopyLock);
+            if (!pushBackCooperative(group, queue, myBiggest)) {
+              overflowed = true;
+            }
+          }
+          group.sync();
+          if (readFlagCooperative(group, &overflowed))
+            break;
+        }
+      }
+
+    } while (false);
+
+    // End-of-iteration rendezvous: every group must reach here before
+    // group 0 decides whether the sorted queue is empty.
+    block.sync();
+    if (block.thread_rank() == 0 && timeoutClocks > 0 && clock64() - startClock > timeoutClocks) {
+      timedOut = true;
+    }
+    block.sync();
+
+    if (block.thread_rank() == 0)
+      phase2Done = overflowed || timedOut || queue.empty();
+    block.sync();
+    if (phase2Done)
+      break;
+  }
+
+  // ---- Phase 3: writeback ----
+  block.sync();
+  if (block.thread_rank() == 0) {
+    auto& dst             = results[pairIdx];
+    dst.numCommonVertices = best.seed.numAtoms;
+    dst.numCommonEdges    = best.seed.numBonds;
+    dst.timedOut          = timedOut;
+    dst.overflowed        = overflowed;
+
+    // Walk set bits of best.seed.atoms (in increasing query atom idx
+    // order, via __ffs/__ffsll) to fill mappingA/B.
+    using BestSeedT                = decltype(best.seed);
+    using AtomWord                 = typename BestSeedT::atom_word_type;
+    constexpr int kAtomBitsPerWord = BestSeedT::kAtomBitsPerWord;
+    constexpr int kAtomWords       = BestSeedT::kAtomWords;
+    int           outIdx           = 0;
+    for (int wordIdx = 0; wordIdx < kAtomWords; ++wordIdx) {
+      AtomWord remaining = best.seed.atoms[wordIdx];
+      while (remaining != 0) {
+        int bitPosInWord;
+        if constexpr (sizeof(AtomWord) == 4) {
+          bitPosInWord = __ffs(static_cast<unsigned int>(remaining)) - 1;
+        } else {
+          bitPosInWord = __ffsll(static_cast<unsigned long long>(remaining)) - 1;
+        }
+        const int queryAtomIdx = wordIdx * kAtomBitsPerWord + bitPosInWord;
+        remaining &= remaining - 1;
+        dst.mappingA[outIdx] = static_cast<std::uint8_t>(queryAtomIdx);
+        dst.mappingB[outIdx] = best.match.targetAtomIdx[queryAtomIdx];
+        ++outIdx;
+      }
+    }
+
+    // Walk set bits of best.seed.bonds to fill bondMapA/B.
+    using BondWord                 = typename BestSeedT::bond_word_type;
+    constexpr int kBondBitsPerWord = BestSeedT::kBondBitsPerWord;
+    constexpr int kBondWords       = BestSeedT::kBondWords;
+    outIdx                         = 0;
+    for (int wordIdx = 0; wordIdx < kBondWords; ++wordIdx) {
+      BondWord remaining = best.seed.bonds[wordIdx];
+      while (remaining != 0) {
+        int bitPosInWord;
+        if constexpr (sizeof(BondWord) == 4) {
+          bitPosInWord = __ffs(static_cast<unsigned int>(remaining)) - 1;
+        } else {
+          bitPosInWord = __ffsll(static_cast<unsigned long long>(remaining)) - 1;
+        }
+        const int queryBondIdx = wordIdx * kBondBitsPerWord + bitPosInWord;
+        remaining &= remaining - 1;
+        dst.bondMapA[outIdx] = static_cast<std::uint8_t>(queryBondIdx);
+        dst.bondMapB[outIdx] = best.match.targetBondIdx[queryBondIdx];
+        ++outIdx;
+      }
+    }
+  }
+}
+
+enum class MaxSizeTier {
+  k16,
+  k32,
+  k64,
+  k128,
+};
+
+/// Smallest tier whose bitset width covers both counts.  Returns -1 when
+/// the largest tier (128) does not fit; the caller must flag
+/// @ref MCSResult::overflowed.
+inline int pickMaxSizeTier(int numAtoms, int numBonds) {
+  const int need = numAtoms > numBonds ? numAtoms : numBonds;
+  if (need <= 16)
+    return 0;
+  if (need <= 32)
+    return 1;
+  if (need <= 64)
+    return 2;
+  if (need <= 128)
+    return 3;
+  return -1;
+}
+
+}  // namespace fmcs
+}  // namespace mcs
+
+#endif  // FMCS_CUDA_FMCS_KERNEL_CUH

--- a/src/mcs/fmcs_cuda/fmcs_match.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_match.cuh
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 
+#include "src/mcs/fmcs_cuda/fmcs.cuh"
 #include "src/mcs/fmcs_cuda/fmcs_match_tables.cuh"
 #include "src/mcs/fmcs_cuda/fmcs_seed.cuh"
 #include "src/mcs/fmcs_cuda/fmcs_topology.cuh"
@@ -34,7 +35,8 @@ namespace fmcs {
 /// rectangular (query size != target size) tiers need no matcher changes.
 /// Largest seed-atom degree the degreeAtLeast buckets distinguish.  Degrees
 /// above this clamp to the last bucket, which only weakens the filter.
-constexpr int kFmcsMaxSeedDegree = 8;
+constexpr int kFmcsMaxSeedDegree = kMaxNeighborsPerAtom;
+static_assert(kMaxNeighborsPerAtom == nvMolKit::subgraph::kMaxEdgeSlotsPerAtom);
 
 template <int maxTargetAtoms>
 constexpr int kFmcsMaskAtoms = (maxTargetAtoms <= 32 ? 32 : (maxTargetAtoms <= 64 ? 64 : 128));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,12 @@ target_include_directories(test_fmcs_search_support
 target_link_libraries(test_fmcs_search_support PRIVATE mcs_fmcs_foundations
                                                        device_vector)
 
+add_executable(test_fmcs_core test_fmcs_core.cpp)
+target_link_libraries(test_fmcs_core PRIVATE mcs_fmcs_core)
+
+add_executable(test_fmcs_engine_validation test_fmcs_engine_validation.cpp)
+target_link_libraries(test_fmcs_engine_validation PRIVATE mcs_fmcs_core)
+
 add_executable(test_openmp_helpers test_openmp_helpers.cpp)
 target_link_libraries(test_openmp_helpers PRIVATE openmp_helpers
                                                   OpenMP::OpenMP_CXX)
@@ -456,6 +462,8 @@ set(TEST_LIST
     test_fmcs_policy
     test_fmcs_substructure
     test_fmcs_search_support
+    test_fmcs_core
+    test_fmcs_engine_validation
     test_work_splitting
     test_fire_minimizer
     test_fire_minimizer_permol)

--- a/tests/test_fmcs_core.cpp
+++ b/tests/test_fmcs_core.cpp
@@ -1,0 +1,504 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <set>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "src/mcs/fmcs_cuda/fmcs.cuh"
+#include "src/mcs/mcs_common/mcs_types.cuh"
+
+namespace {
+
+using mcs::Graph;
+using mcs::MCSResult;
+using mcs::fmcs::Parameters;
+
+// ---------------------------------------------------------------------------
+// Construction helpers
+// ---------------------------------------------------------------------------
+
+Graph g(std::size_t n, std::vector<std::pair<std::size_t, std::size_t>> edges) {
+  return mcs::buildGraphFromEdges(n, std::move(edges));
+}
+
+MCSResult findSingleMCES(const Graph& a, const Graph& b, Parameters params = {}, cudaStream_t stream = nullptr) {
+  const auto results = mcs::fmcs::findMCESfMCSBatch({a}, {b}, params, stream);
+  EXPECT_EQ(results.size(), 1);
+  return results.empty() ? MCSResult{} : results.front();
+}
+
+// Path graph: numAtoms vertices in a chain, (i, i+1) edges.
+Graph path(int numAtoms) {
+  std::vector<std::pair<std::size_t, std::size_t>> edges;
+  for (int i = 0; i + 1 < numAtoms; ++i) {
+    edges.emplace_back(i, i + 1);
+  }
+  return mcs::buildGraphFromEdges(static_cast<std::size_t>(numAtoms), std::move(edges));
+}
+
+// Cycle graph: numAtoms vertices in a ring.
+Graph cycle(int numAtoms) {
+  std::vector<std::pair<std::size_t, std::size_t>> edges;
+  for (int i = 0; i + 1 < numAtoms; ++i)
+    edges.emplace_back(i, i + 1);
+  if (numAtoms >= 3)
+    edges.emplace_back(0, numAtoms - 1);
+  return mcs::buildGraphFromEdges(static_cast<std::size_t>(numAtoms), std::move(edges));
+}
+
+// Star K1,n: vertex 0 is the hub, vertices 1..n are leaves.
+Graph star(int numLeaves) {
+  std::vector<std::pair<std::size_t, std::size_t>> edges;
+  for (int i = 1; i <= numLeaves; ++i)
+    edges.emplace_back(0, i);
+  return mcs::buildGraphFromEdges(static_cast<std::size_t>(numLeaves + 1), std::move(edges));
+}
+
+// Standard six-membered ring (used as benzene topology).
+Graph benzene() {
+  return cycle(6);
+}
+
+// Toluene: benzene + a methyl substituent on atom 0 -> atom 6.
+Graph toluene() {
+  return g(7,
+           {
+             {0, 1},
+             {1, 2},
+             {2, 3},
+             {3, 4},
+             {4, 5},
+             {0, 5},
+             {0, 6}
+  });
+}
+
+// Naphthalene: two fused 6-rings sharing edge (4,5).
+//
+//   0 - 1
+//   |   |
+//   5 - 4 - 6
+//   |       |
+//   ...    ...
+//
+// Atoms: 0,1,2,3,4,5 (ring A), 5,4,6,7,8,9 (ring B sharing edge 4-5).
+// 10 atoms total.
+Graph naphthalene() {
+  return g(10,
+           {
+             {0, 1},
+             {1, 2},
+             {2, 3},
+             {3, 4},
+             {4, 5},
+             {0, 5}, // ring A
+             {4, 6},
+             {6, 7},
+             {7, 8},
+             {8, 9},
+             {5, 9}, // ring B (shares 4-5)
+  });
+}
+
+// Phenanthrene: three angularly fused 6-rings, 14 atoms / 16 bonds.
+// Ring A: 0-1-2-3-4-5-0
+// Ring B: 4-5-6-7-8-9 (shares edge 4-5)
+// Ring C: 8-9-10-11-12-13 (shares edge 8-9)
+Graph phenanthrene() {
+  return g(14,
+           {
+             { 0,  1},
+             { 1,  2},
+             { 2,  3},
+             { 3,  4},
+             { 4,  5},
+             { 0,  5}, // ring A
+             { 4,  6},
+             { 6,  7},
+             { 7,  8},
+             { 8,  9},
+             { 5,  9}, // ring B
+             { 8, 10},
+             {10, 11},
+             {11, 12},
+             {12, 13},
+             { 9, 13}, // ring C
+  });
+}
+
+// Biphenyl: two C6 rings linked by a single bond between atom 0 and atom 6.
+Graph biphenyl() {
+  return g(12,
+           {
+             { 0,  1},
+             { 1,  2},
+             { 2,  3},
+             { 3,  4},
+             { 4,  5},
+             { 0,  5}, // ring A
+             { 6,  7},
+             { 7,  8},
+             { 8,  9},
+             { 9, 10},
+             {10, 11},
+             { 6, 11}, // ring B
+             { 0,  6}, // linker
+  });
+}
+
+// Build a labelled LabeledGraph with the given topology, vertex
+// labels, and explicit (u, v, label) edge-label triples (symmetrized
+// into the dense edgeLabels matrix).
+void expectFullSelfPair(const MCSResult& r, const Graph& gph) {
+  EXPECT_FALSE(r.timedOut);
+  EXPECT_FALSE(r.overflowed);
+  EXPECT_EQ(r.numCommonVertices, gph.numVertices);
+  EXPECT_EQ(r.numCommonEdges, gph.numEdges);
+}
+
+// Verify the returned mappings form a valid subgraph isomorphism:
+//   - mappingA / mappingB cover numCommonVertices distinct query / target
+//     atoms; the i-th matched vertex pairs (mappingA[i], mappingB[i]).
+//   - For each (qBond, tBond) in (edgeMappingA[i], edgeMappingB[i]), the
+//     target endpoints are the targets that the query bond's endpoints
+//     mapped to.
+void expectMappingsConsistent(const MCSResult& r, const Graph& a, const Graph& b) {
+  ASSERT_EQ(static_cast<int>(r.mappingA.size()), r.numCommonVertices);
+  ASSERT_EQ(static_cast<int>(r.mappingB.size()), r.numCommonVertices);
+  ASSERT_EQ(static_cast<int>(r.edgeMappingA.size()), r.numCommonEdges);
+  ASSERT_EQ(static_cast<int>(r.edgeMappingB.size()), r.numCommonEdges);
+
+  // mappingA / mappingB are bijections within the matched subset.
+  std::set<std::size_t> qAtoms(r.mappingA.begin(), r.mappingA.end());
+  std::set<std::size_t> tAtoms(r.mappingB.begin(), r.mappingB.end());
+  EXPECT_EQ(qAtoms.size(), r.mappingA.size()) << "mappingA has duplicate query atoms";
+  EXPECT_EQ(tAtoms.size(), r.mappingB.size()) << "mappingB has duplicate target atoms";
+
+  // Every query atom is in graph a; every target atom is in graph b.
+  for (std::size_t qa : qAtoms) {
+    EXPECT_LT(qa, static_cast<std::size_t>(a.numVertices));
+  }
+  for (std::size_t ta : tAtoms) {
+    EXPECT_LT(ta, static_cast<std::size_t>(b.numVertices));
+  }
+
+  // Build atom-mapping lookup: query atom -> target atom.
+  std::vector<std::size_t> qToT(a.numVertices, static_cast<std::size_t>(-1));
+  for (int i = 0; i < r.numCommonVertices; ++i) {
+    qToT[r.mappingA[i]] = r.mappingB[i];
+  }
+
+  // Each matched edge: target endpoints == qToT of query endpoints (in
+  // either bond orientation).
+  for (int i = 0; i < r.numCommonEdges; ++i) {
+    const auto qE = r.edgeMappingA[i];
+    const auto tE = r.edgeMappingB[i];
+    const auto qU = qE.first, qV = qE.second;
+    const auto tU = tE.first, tV = tE.second;
+    EXPECT_LT(qU, static_cast<std::size_t>(a.numVertices));
+    EXPECT_LT(qV, static_cast<std::size_t>(a.numVertices));
+    EXPECT_LT(tU, static_cast<std::size_t>(b.numVertices));
+    EXPECT_LT(tV, static_cast<std::size_t>(b.numVertices));
+    const auto mappedU = qToT[qU];
+    const auto mappedV = qToT[qV];
+    const bool fwd     = (mappedU == tU && mappedV == tV);
+    const bool rev     = (mappedU == tV && mappedV == tU);
+    EXPECT_TRUE(fwd || rev) << "Edge mapping (" << qU << "," << qV << ") -> (" << tU << "," << tV
+                            << ") inconsistent with atom mapping (" << qU << "->" << mappedU << ", " << qV << "->"
+                            << mappedV << ")";
+  }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// FMCSDispatch: smoke tests on the host-level entry points.
+// ---------------------------------------------------------------------------
+
+TEST(FMCSDispatch, BatchSingleEntrySelfPathReturnsFullPath) {
+  const auto a = path(4);
+  auto       r = findSingleMCES(a, a);
+  expectFullSelfPair(r, a);
+  expectMappingsConsistent(r, a, a);
+}
+
+TEST(FMCSDispatch, BatchOfThreeReturnsExpectedSizes) {
+  std::vector<Graph> graphs{path(2), path(3), path(4)};
+  auto               rs = mcs::fmcs::findMCESfMCSBatch(graphs, graphs);
+  ASSERT_EQ(rs.size(), graphs.size());
+  for (size_t i = 0; i < graphs.size(); ++i) {
+    EXPECT_FALSE(rs[i].overflowed);
+    EXPECT_FALSE(rs[i].timedOut);
+    EXPECT_EQ(rs[i].numCommonEdges, graphs[i].numEdges);
+    EXPECT_EQ(rs[i].numCommonVertices, graphs[i].numVertices);
+  }
+}
+
+TEST(FMCSDispatch, MismatchedBatchSizesThrows) {
+  std::vector<Graph> a{path(2)};
+  std::vector<Graph> b{};
+  EXPECT_THROW(mcs::fmcs::findMCESfMCSBatch(a, b), std::runtime_error);
+}
+
+// ---------------------------------------------------------------------------
+// FMCSDegenerate: empty / single-vertex / no-shared-bond inputs.
+// ---------------------------------------------------------------------------
+
+TEST(FMCSDegenerate, EmptyGraphs) {
+  const auto a = g(0, {});
+  const auto b = g(0, {});
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 0);
+  EXPECT_EQ(r.numCommonEdges, 0);
+}
+
+TEST(FMCSDegenerate, SingleVertex) {
+  // No bonds anywhere -> seed-grow lattice is empty (Phase 1 enumerates
+  // bond pairs, of which there are zero).  Connected MCES is reported
+  // as size zero.
+  const auto a = g(1, {});
+  const auto b = g(1, {});
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 0);
+  EXPECT_EQ(r.numCommonEdges, 0);
+}
+
+TEST(FMCSDegenerate, SingleEdge) {
+  const auto a = g(2,
+                   {
+                     {0, 1}
+  });
+  const auto b = g(2,
+                   {
+                     {0, 1}
+  });
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 2);
+  EXPECT_EQ(r.numCommonEdges, 1);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSDegenerate, OneSideEmpty) {
+  const auto a = g(0, {});
+  const auto b = path(3);
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 0);
+  EXPECT_EQ(r.numCommonEdges, 0);
+}
+
+TEST(FMCSDegenerate, DisjointInputs) {
+  // Triangle vs three isolated atoms: target has zero bonds, so no
+  // (q_bond, t_bond) pair compatible -> empty MCES.
+  const auto a = cycle(3);
+  const auto b = g(3, {});
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 0);
+  EXPECT_EQ(r.numCommonEdges, 0);
+}
+
+// ---------------------------------------------------------------------------
+// FMCSBasics: hand-derived expected sizes on small graph topologies.
+// ---------------------------------------------------------------------------
+
+TEST(FMCSBasics, PathEqualLength) {
+  const auto p = path(4);
+  auto       r = findSingleMCES(p, p);
+  expectFullSelfPair(r, p);
+  expectMappingsConsistent(r, p, p);
+}
+
+TEST(FMCSBasics, PathShorterVsLonger) {
+  const auto a = path(3);
+  const auto b = path(6);
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 3);
+  EXPECT_EQ(r.numCommonEdges, 2);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSBasics, TreeVsTree) {
+  // K1,3 vs K1,4: the smaller star is a connected subgraph of the larger.
+  const auto a = star(3);
+  const auto b = star(4);
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 4);
+  EXPECT_EQ(r.numCommonEdges, 3);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSBasics, HighFanoutStarSelfPair) {
+  // Regression for the grow-step boundary scratch space: after seeding
+  // one spoke, the hub exposes seven more spokes at once.  A too-small
+  // new-bond buffer silently truncated this and missed the full star.
+  const auto s = star(8);
+  auto       r = findSingleMCES(s, s);
+  expectFullSelfPair(r, s);
+  expectMappingsConsistent(r, s, s);
+}
+
+TEST(FMCSBasics, StarKeepsHubFrontierForSiblingSpokes) {
+  // Query side after host swapping is K1,4; target is a diamond
+  // (K4 missing one edge).  The exact connected MCES is K1,3: center
+  // at either degree-3 diamond vertex.  If a singleton grow from one
+  // spoke drops the hub from lastAddedAtoms, sibling spokes are never
+  // considered and the search gets stuck at 2 bonds.
+  const auto diamond  = g(4,
+                          {
+                           {0, 1},
+                           {0, 2},
+                           {1, 2},
+                           {1, 3},
+                           {2, 3}
+  });
+  const auto fourStar = star(4);
+  auto       r        = findSingleMCES(diamond, fourStar);
+  EXPECT_EQ(r.numCommonVertices, 4);
+  EXPECT_EQ(r.numCommonEdges, 3);
+  EXPECT_FALSE(r.overflowed);
+  expectMappingsConsistent(r, diamond, fourStar);
+}
+
+TEST(FMCSBasics, CycleVsCycleSame) {
+  const auto c = cycle(6);
+  auto       r = findSingleMCES(c, c);
+  expectFullSelfPair(r, c);
+  expectMappingsConsistent(r, c, c);
+}
+
+TEST(FMCSBasics, CycleVsCycleLarger) {
+  // C3 (triangle) vs C4 (square).  C4 has no triangle subgraph; the
+  // best connected common edge subgraph is a 2-bond path.
+  const auto a = cycle(3);
+  const auto b = cycle(4);
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonEdges, 2);
+  EXPECT_EQ(r.numCommonVertices, 3);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSBasics, TreeVsCycle) {
+  const auto a = path(3);
+  const auto b = cycle(3);
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonEdges, 2);  // path-3 in C3
+  EXPECT_EQ(r.numCommonVertices, 3);
+  expectMappingsConsistent(r, a, b);
+}
+
+// ---------------------------------------------------------------------------
+// FMCSConnected: connected-MCES behaviour on graphs whose unconstrained
+// common subgraph would be disconnected.
+// ---------------------------------------------------------------------------
+
+TEST(FMCSConnected, DisconnectedCommonGraphReturnsOnlyLargestConnected) {
+  // Two disjoint edges on each side: 4 atoms / 2 bonds, no path between
+  // the two components.  Connected MCES is therefore at most a single
+  // edge (the largest connected subgraph of either component).
+  const auto a = g(4,
+                   {
+                     {0, 1},
+                     {2, 3}
+  });
+  const auto b = g(4,
+                   {
+                     {0, 1},
+                     {2, 3}
+  });
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonEdges, 1);
+  EXPECT_EQ(r.numCommonVertices, 2);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSConnected, TwoComponentsEachReturnsOneComponent) {
+  // Each side has a path-3 component and an isolated edge; connected
+  // MCES is the larger component (path-3 -> 2 bonds).
+  const auto a = g(5,
+                   {
+                     {0, 1},
+                     {1, 2},
+                     {3, 4}
+  });
+  const auto b = g(5,
+                   {
+                     {0, 1},
+                     {1, 2},
+                     {3, 4}
+  });
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonEdges, 2);
+  EXPECT_EQ(r.numCommonVertices, 3);
+  expectMappingsConsistent(r, a, b);
+}
+
+// ---------------------------------------------------------------------------
+// FMCSMolecule: hand-encoded molecule pairs with reference values
+// computed from rdFMCS.FindMCS(MaximizeBonds=True, Threshold=1.0,
+// AtomCompareElements, BondCompareOrder).  Topology-only here -- the
+// labelled equivalents live in FMCSLabels below.
+// ---------------------------------------------------------------------------
+
+TEST(FMCSMolecule, BenzeneVsBenzene) {
+  const auto a = benzene();
+  auto       r = findSingleMCES(a, a);
+  expectFullSelfPair(r, a);
+  expectMappingsConsistent(r, a, a);
+}
+
+TEST(FMCSMolecule, BenzeneVsToluene) {
+  // Benzene ring is a connected subgraph of toluene (NullPolicy =
+  // topology only, so aromatic-vs-single bond labelling is ignored).
+  const auto a = benzene();
+  const auto b = toluene();
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 6);
+  EXPECT_EQ(r.numCommonEdges, 6);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSMolecule, BenzeneVsCyclohexaneTopologyOnly) {
+  // Same topology (6-cycle), different chemistry; NullPolicy ignores
+  // bond labels so both look like C6.
+  const auto a = benzene();
+  const auto b = cycle(6);  // cyclohexane topology = 6-cycle
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 6);
+  EXPECT_EQ(r.numCommonEdges, 6);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSMolecule, NaphthaleneVsPhenanthrene) {
+  // Naphthalene is a connected subgraph of phenanthrene (the two
+  // terminal rings share an edge, matching naphthalene's topology).
+  const auto a = naphthalene();
+  const auto b = phenanthrene();
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 10);
+  EXPECT_EQ(r.numCommonEdges, 11);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSMolecule, BiphenylVsBiphenyl) {
+  const auto a = biphenyl();
+  auto       r = findSingleMCES(a, a);
+  expectFullSelfPair(r, a);
+  expectMappingsConsistent(r, a, a);
+}

--- a/tests/test_fmcs_engine_validation.cpp
+++ b/tests/test_fmcs_engine_validation.cpp
@@ -1,0 +1,667 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <set>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "src/mcs/fmcs_cuda/fmcs.cuh"
+#include "src/mcs/mcs_common/mcs_types.cuh"
+
+namespace {
+
+using mcs::Graph;
+using mcs::MCSResult;
+using mcs::fmcs::Parameters;
+
+// ---------------------------------------------------------------------------
+// Construction helpers
+// ---------------------------------------------------------------------------
+
+Graph g(std::size_t n, std::vector<std::pair<std::size_t, std::size_t>> edges) {
+  return mcs::buildGraphFromEdges(n, std::move(edges));
+}
+
+MCSResult findSingleMCES(const Graph& a, const Graph& b, Parameters params = {}, cudaStream_t stream = nullptr) {
+  const auto results = mcs::fmcs::findMCESfMCSBatch({a}, {b}, params, stream);
+  EXPECT_EQ(results.size(), 1);
+  return results.empty() ? MCSResult{} : results.front();
+}
+
+// Path graph: numAtoms vertices in a chain, (i, i+1) edges.
+Graph path(int numAtoms) {
+  std::vector<std::pair<std::size_t, std::size_t>> edges;
+  for (int i = 0; i + 1 < numAtoms; ++i) {
+    edges.emplace_back(i, i + 1);
+  }
+  return mcs::buildGraphFromEdges(static_cast<std::size_t>(numAtoms), std::move(edges));
+}
+
+// Cycle graph: numAtoms vertices in a ring.
+Graph cycle(int numAtoms) {
+  std::vector<std::pair<std::size_t, std::size_t>> edges;
+  for (int i = 0; i + 1 < numAtoms; ++i)
+    edges.emplace_back(i, i + 1);
+  if (numAtoms >= 3)
+    edges.emplace_back(0, numAtoms - 1);
+  return mcs::buildGraphFromEdges(static_cast<std::size_t>(numAtoms), std::move(edges));
+}
+
+// Star K1,n: vertex 0 is the hub, vertices 1..n are leaves.
+Graph star(int numLeaves) {
+  std::vector<std::pair<std::size_t, std::size_t>> edges;
+  for (int i = 1; i <= numLeaves; ++i)
+    edges.emplace_back(0, i);
+  return mcs::buildGraphFromEdges(static_cast<std::size_t>(numLeaves + 1), std::move(edges));
+}
+
+// Naphthalene: two fused 6-rings sharing edge (4,5).
+//
+//   0 - 1
+//   |   |
+//   5 - 4 - 6
+//   |       |
+//   ...    ...
+//
+// Atoms: 0,1,2,3,4,5 (ring A), 5,4,6,7,8,9 (ring B sharing edge 4-5).
+// 10 atoms total.
+Graph naphthalene() {
+  return g(10,
+           {
+             {0, 1},
+             {1, 2},
+             {2, 3},
+             {3, 4},
+             {4, 5},
+             {0, 5}, // ring A
+             {4, 6},
+             {6, 7},
+             {7, 8},
+             {8, 9},
+             {5, 9}, // ring B (shares 4-5)
+  });
+}
+
+// Phenanthrene: three angularly fused 6-rings, 14 atoms / 16 bonds.
+// Ring A: 0-1-2-3-4-5-0
+// Ring B: 4-5-6-7-8-9 (shares edge 4-5)
+// Ring C: 8-9-10-11-12-13 (shares edge 8-9)
+Graph phenanthrene() {
+  return g(14,
+           {
+             { 0,  1},
+             { 1,  2},
+             { 2,  3},
+             { 3,  4},
+             { 4,  5},
+             { 0,  5}, // ring A
+             { 4,  6},
+             { 6,  7},
+             { 7,  8},
+             { 8,  9},
+             { 5,  9}, // ring B
+             { 8, 10},
+             {10, 11},
+             {11, 12},
+             {12, 13},
+             { 9, 13}, // ring C
+  });
+}
+
+void expectFullSelfPair(const MCSResult& r, const Graph& gph) {
+  EXPECT_FALSE(r.timedOut);
+  EXPECT_FALSE(r.overflowed);
+  EXPECT_EQ(r.numCommonVertices, gph.numVertices);
+  EXPECT_EQ(r.numCommonEdges, gph.numEdges);
+}
+
+// Verify the returned mappings form a valid subgraph isomorphism:
+//   - mappingA / mappingB cover numCommonVertices distinct query / target
+//     atoms; the i-th matched vertex pairs (mappingA[i], mappingB[i]).
+//   - For each (qBond, tBond) in (edgeMappingA[i], edgeMappingB[i]), the
+//     target endpoints are the targets that the query bond's endpoints
+//     mapped to.
+void expectMappingsConsistent(const MCSResult& r, const Graph& a, const Graph& b) {
+  ASSERT_EQ(static_cast<int>(r.mappingA.size()), r.numCommonVertices);
+  ASSERT_EQ(static_cast<int>(r.mappingB.size()), r.numCommonVertices);
+  ASSERT_EQ(static_cast<int>(r.edgeMappingA.size()), r.numCommonEdges);
+  ASSERT_EQ(static_cast<int>(r.edgeMappingB.size()), r.numCommonEdges);
+
+  // mappingA / mappingB are bijections within the matched subset.
+  std::set<std::size_t> qAtoms(r.mappingA.begin(), r.mappingA.end());
+  std::set<std::size_t> tAtoms(r.mappingB.begin(), r.mappingB.end());
+  EXPECT_EQ(qAtoms.size(), r.mappingA.size()) << "mappingA has duplicate query atoms";
+  EXPECT_EQ(tAtoms.size(), r.mappingB.size()) << "mappingB has duplicate target atoms";
+
+  // Every query atom is in graph a; every target atom is in graph b.
+  for (std::size_t qa : qAtoms) {
+    EXPECT_LT(qa, static_cast<std::size_t>(a.numVertices));
+  }
+  for (std::size_t ta : tAtoms) {
+    EXPECT_LT(ta, static_cast<std::size_t>(b.numVertices));
+  }
+
+  // Build atom-mapping lookup: query atom -> target atom.
+  std::vector<std::size_t> qToT(a.numVertices, static_cast<std::size_t>(-1));
+  for (int i = 0; i < r.numCommonVertices; ++i) {
+    qToT[r.mappingA[i]] = r.mappingB[i];
+  }
+
+  // Each matched edge: target endpoints == qToT of query endpoints (in
+  // either bond orientation).
+  for (int i = 0; i < r.numCommonEdges; ++i) {
+    const auto qE = r.edgeMappingA[i];
+    const auto tE = r.edgeMappingB[i];
+    const auto qU = qE.first, qV = qE.second;
+    const auto tU = tE.first, tV = tE.second;
+    EXPECT_LT(qU, static_cast<std::size_t>(a.numVertices));
+    EXPECT_LT(qV, static_cast<std::size_t>(a.numVertices));
+    EXPECT_LT(tU, static_cast<std::size_t>(b.numVertices));
+    EXPECT_LT(tV, static_cast<std::size_t>(b.numVertices));
+    const auto mappedU = qToT[qU];
+    const auto mappedV = qToT[qV];
+    const bool fwd     = (mappedU == tU && mappedV == tV);
+    const bool rev     = (mappedU == tV && mappedV == tU);
+    EXPECT_TRUE(fwd || rev) << "Edge mapping (" << qU << "," << qV << ") -> (" << tU << "," << tV
+                            << ") inconsistent with atom mapping (" << qU << "->" << mappedU << ", " << qV << "->"
+                            << mappedV << ")";
+  }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// FMCSRegression: larger topology cases that have previously regressed.
+// ---------------------------------------------------------------------------
+
+TEST(FMCSRegression, FixturePair00x03UnlabeledTopology) {
+  // First non-overflow mismatch from tests/test_fmcs_parity.py:
+  // sampled_smiles pair00x03, unlabeled.  RDKit's connected MCES is
+  // the 17-bond subgraph of the first molecule that omits edge (2,3).
+  const auto a = g(17,
+                   {
+                     { 0,  1},
+                     { 1,  2},
+                     { 2,  3},
+                     { 3,  4},
+                     { 4,  5},
+                     { 5,  6},
+                     { 5,  7},
+                     { 7,  8},
+                     { 8,  9},
+                     { 9, 10},
+                     {10, 11},
+                     {11, 12},
+                     {12, 13},
+                     {12, 14},
+                     {14, 15},
+                     { 4, 16},
+                     { 1, 16},
+                     { 9, 15}
+  });
+  const auto b = g(18,
+                   {
+                     { 0,  1},
+                     { 1,  2},
+                     { 2,  3},
+                     { 3,  4},
+                     { 4,  5},
+                     { 5,  6},
+                     { 6,  7},
+                     { 7,  8},
+                     { 8,  9},
+                     { 8, 10},
+                     {10, 11},
+                     {11, 12},
+                     {12, 13},
+                     {13, 14},
+                     {13, 15},
+                     {15, 16},
+                     { 3, 17},
+                     { 1, 17},
+                     { 3,  6},
+                     {10, 16}
+  });
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 17);
+  EXPECT_EQ(r.numCommonEdges, 17);
+  EXPECT_FALSE(r.overflowed);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSRegression, FixturePair01x03UnlabeledTopology) {
+  // Current first non-overflow mismatch after restoring Stage 1 coverage:
+  // sampled_smiles pair01x03, unlabeled.  RDKit's connected MCES is 17/17.
+  const auto a = g(19,
+                   {
+                     { 0,  1},
+                     { 1,  2},
+                     { 2,  3},
+                     { 2,  4},
+                     { 4,  5},
+                     { 5,  6},
+                     { 6,  7},
+                     { 7,  8},
+                     { 8,  9},
+                     { 9, 10},
+                     {10, 11},
+                     {11, 12},
+                     {10, 13},
+                     {13, 14},
+                     { 1, 15},
+                     {15, 16},
+                     {16, 17},
+                     {16, 18},
+                     { 1, 18},
+                     { 8, 14}
+  });
+  const auto b = g(18,
+                   {
+                     { 0,  1},
+                     { 1,  2},
+                     { 2,  3},
+                     { 3,  4},
+                     { 4,  5},
+                     { 5,  6},
+                     { 6,  7},
+                     { 7,  8},
+                     { 8,  9},
+                     { 8, 10},
+                     {10, 11},
+                     {11, 12},
+                     {12, 13},
+                     {13, 14},
+                     {13, 15},
+                     {15, 16},
+                     { 3, 17},
+                     { 1, 17},
+                     { 3,  6},
+                     {10, 16}
+  });
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 17);
+  EXPECT_EQ(r.numCommonEdges, 17);
+  EXPECT_FALSE(r.overflowed);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSRegression, FiveNodePathInsideTriangleWithLeaves) {
+  // Query contains a 4-edge path 4-0-2-1-3 plus the extra chord (0,1).
+  // Target is exactly a 4-edge path 0-3-2-1-4.
+  const auto a = g(5,
+                   {
+                     {0, 1},
+                     {0, 2},
+                     {0, 4},
+                     {1, 2},
+                     {1, 3}
+  });
+  const auto b = g(5,
+                   {
+                     {0, 3},
+                     {1, 2},
+                     {1, 4},
+                     {2, 3}
+  });
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 5);
+  EXPECT_EQ(r.numCommonEdges, 4);
+  EXPECT_FALSE(r.overflowed);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSTiers, MaxSize16) {
+  const auto p = path(16);
+  auto       r = findSingleMCES(p, p);
+  expectFullSelfPair(r, p);
+}
+
+TEST(FMCSTiers, MaxSize32) {
+  const auto p = path(32);
+  auto       r = findSingleMCES(p, p);
+  expectFullSelfPair(r, p);
+}
+
+TEST(FMCSTiers, MaxSize64) {
+  const auto p = path(64);
+  auto       r = findSingleMCES(p, p);
+  expectFullSelfPair(r, p);
+}
+
+TEST(FMCSTiers, MaxSize128) {
+  const auto p = path(128);
+  auto       r = findSingleMCES(p, p);
+  expectFullSelfPair(r, p);
+}
+
+TEST(FMCSBlockSize, SupportedSpecializationsMatchDefault) {
+  const auto p = path(32);
+  for (int blockSize : {64, 128, 256, 512}) {
+    Parameters params;
+    params.blockSize = blockSize;
+    auto r           = findSingleMCES(p, p, params);
+    expectFullSelfPair(r, p);
+  }
+}
+
+TEST(FMCSBlockSize, Block512SupportsTier128WithGlobalScratch) {
+  const auto p = path(128);
+  Parameters params;
+  params.blockSize = 512;
+  auto r           = findSingleMCES(p, p, params);
+  expectFullSelfPair(r, p);
+}
+
+TEST(FMCSBlockSize, RejectsOneWarpBlockSize) {
+  const auto p = path(8);
+  Parameters params;
+  params.blockSize = 32;
+  EXPECT_THROW((void)mcs::fmcs::findMCESfMCSBatch({p}, {p}, params), std::invalid_argument);
+}
+
+TEST(FMCSInputValidation, RejectsDegreeAboveEight) {
+  const auto degreeNine = star(9);
+  EXPECT_THROW((void)mcs::fmcs::findMCESfMCSBatch({degreeNine}, {degreeNine}), std::invalid_argument);
+}
+
+// ---------------------------------------------------------------------------
+// FMCSObjective: MaximizeBonds tie-break.
+// ---------------------------------------------------------------------------
+
+TEST(FMCSObjective, MaximizeBondsPreferredOverVerticesWhenTie) {
+  // A query that contains both a 3-atom path (3 atoms, 2 bonds) and a
+  // 3-atom triangle (3 atoms, 3 bonds) as connected subgraphs.  Target
+  // is just the triangle.  Both candidate MCSes have 3 atoms; the
+  // triangle has more bonds, so MaximizeBonds picks it.
+  const auto a = g(4,
+                   {
+                     {0, 1},
+                     {1, 2},
+                     {0, 2},
+                     {2, 3}
+  });
+  // Triangle on a, plus a tail 2-3.
+  const auto b = cycle(3);
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(r.numCommonVertices, 3);
+  EXPECT_EQ(r.numCommonEdges, 3);
+  expectMappingsConsistent(r, a, b);
+}
+
+// ---------------------------------------------------------------------------
+// FMCSBatch: batch-mode dispatch.
+// ---------------------------------------------------------------------------
+
+TEST(FMCSBatch, MixedSizes) {
+  // One pair per tier.
+  std::vector<Graph> a{path(8), path(24), path(48), path(96)};
+  std::vector<Graph> b  = a;
+  auto               rs = mcs::fmcs::findMCESfMCSBatch(a, b);
+  ASSERT_EQ(rs.size(), 4u);
+  for (size_t i = 0; i < a.size(); ++i) {
+    EXPECT_FALSE(rs[i].overflowed) << "pair " << i;
+    EXPECT_EQ(rs[i].numCommonEdges, a[i].numEdges) << "pair " << i;
+  }
+}
+
+TEST(FMCSBatch, EmptyInputReturnsEmpty) {
+  std::vector<Graph> a;
+  std::vector<Graph> b;
+  auto               rs = mcs::fmcs::findMCESfMCSBatch(a, b);
+  EXPECT_TRUE(rs.empty());
+}
+
+TEST(FMCSBatch, TwoPairsDifferentAnswersSameTier) {
+  // Same launch, same tier, different known answers.  A per-block slab
+  // indexing bug tends to show up as pair 0 receiving pair 1's answer,
+  // or vice versa.
+  std::vector<Graph> a{path(3), star(3)};
+  std::vector<Graph> b{path(6), star(4)};
+  auto               rs = mcs::fmcs::findMCESfMCSBatch(a, b);
+  ASSERT_EQ(rs.size(), 2u);
+
+  EXPECT_EQ(rs[0].numCommonVertices, 3);
+  EXPECT_EQ(rs[0].numCommonEdges, 2);
+  expectMappingsConsistent(rs[0], a[0], b[0]);
+
+  EXPECT_EQ(rs[1].numCommonVertices, 4);
+  EXPECT_EQ(rs[1].numCommonEdges, 3);
+  expectMappingsConsistent(rs[1], a[1], b[1]);
+}
+
+TEST(FMCSBatch, NoCommonPairAdjacentToFullMatch) {
+  // The zero-bond pairs should not leave stale mappings/results that
+  // contaminate the full-match pair in the middle.
+  std::vector<Graph> a{g(3, {}), path(5), path(2)};
+  std::vector<Graph> b{path(4), path(5), g(2, {})};
+  auto               rs = mcs::fmcs::findMCESfMCSBatch(a, b);
+  ASSERT_EQ(rs.size(), 3u);
+
+  EXPECT_EQ(rs[0].numCommonVertices, 0);
+  EXPECT_EQ(rs[0].numCommonEdges, 0);
+  EXPECT_FALSE(rs[0].overflowed);
+
+  expectFullSelfPair(rs[1], a[1]);
+  expectMappingsConsistent(rs[1], a[1], b[1]);
+
+  EXPECT_EQ(rs[2].numCommonVertices, 0);
+  EXPECT_EQ(rs[2].numCommonEdges, 0);
+  EXPECT_FALSE(rs[2].overflowed);
+}
+
+TEST(FMCSBatch, EmptyPairInBatch) {
+  // Middle pair empty; flanking pairs should still produce results.
+  std::vector<Graph> a{path(3), g(0, {}), path(5)};
+  std::vector<Graph> b  = a;
+  auto               rs = mcs::fmcs::findMCESfMCSBatch(a, b);
+  ASSERT_EQ(rs.size(), 3u);
+  EXPECT_EQ(rs[0].numCommonEdges, 2);
+  EXPECT_EQ(rs[1].numCommonEdges, 0);
+  EXPECT_EQ(rs[2].numCommonEdges, 4);
+}
+
+TEST(FMCSBatch, HonorsBatchSizeChunksResults) {
+  std::vector<Graph> a{path(3), star(3), cycle(4), path(5), g(4, {})};
+  std::vector<Graph> b{path(6), star(4), cycle(4), path(7), path(3)};
+  Parameters         params;
+  params.batchSize = 2;
+
+  auto rs = mcs::fmcs::findMCESfMCSBatch(a, b, params);
+  ASSERT_EQ(rs.size(), a.size());
+  EXPECT_EQ(rs[0].numCommonEdges, 2);
+  EXPECT_EQ(rs[1].numCommonEdges, 3);
+  EXPECT_EQ(rs[2].numCommonEdges, 4);
+  EXPECT_EQ(rs[3].numCommonEdges, 4);
+  EXPECT_EQ(rs[4].numCommonEdges, 0);
+  for (size_t i = 0; i < rs.size(); ++i) {
+    EXPECT_FALSE(rs[i].overflowed) << "pair " << i;
+    expectMappingsConsistent(rs[i], a[i], b[i]);
+  }
+}
+
+TEST(FMCSBatch, MultiExecutorChunksResults) {
+  std::vector<Graph> a{path(3), star(3), cycle(4), path(5), g(4, {})};
+  std::vector<Graph> b{path(6), star(4), cycle(4), path(7), path(3)};
+  Parameters         params;
+  params.batchSize          = 1;
+  params.executorsPerRunner = 2;
+
+  auto rs = mcs::fmcs::findMCESfMCSBatch(a, b, params);
+  ASSERT_EQ(rs.size(), a.size());
+  EXPECT_EQ(rs[0].numCommonEdges, 2);
+  EXPECT_EQ(rs[1].numCommonEdges, 3);
+  EXPECT_EQ(rs[2].numCommonEdges, 4);
+  EXPECT_EQ(rs[3].numCommonEdges, 4);
+  EXPECT_EQ(rs[4].numCommonEdges, 0);
+  for (size_t i = 0; i < rs.size(); ++i) {
+    EXPECT_FALSE(rs[i].overflowed) << "pair " << i;
+    expectMappingsConsistent(rs[i], a[i], b[i]);
+  }
+}
+
+TEST(FMCSBatch, ManyTinyPairsReusePerBlockSlabs) {
+  // This is intentionally moderate while kFmcsQueueCapacity is still
+  // over-provisioned per pair.  It still creates far more blocks than
+  // the small correctness batches and exercises repeated queue/cache
+  // slab slices within one tier launch.
+  constexpr int      kNumPairs = 512;
+  std::vector<Graph> a;
+  std::vector<Graph> b;
+  a.reserve(kNumPairs);
+  b.reserve(kNumPairs);
+  for (int i = 0; i < kNumPairs; ++i) {
+    const int n = (i % 2 == 0) ? 3 : 4;
+    a.push_back(path(n));
+    b.push_back(path(n));
+  }
+
+  auto rs = mcs::fmcs::findMCESfMCSBatch(a, b);
+  ASSERT_EQ(rs.size(), static_cast<size_t>(kNumPairs));
+  for (int i = 0; i < kNumPairs; ++i) {
+    EXPECT_FALSE(rs[i].overflowed) << "pair " << i;
+    EXPECT_EQ(rs[i].numCommonVertices, a[i].numVertices) << "pair " << i;
+    EXPECT_EQ(rs[i].numCommonEdges, a[i].numEdges) << "pair " << i;
+  }
+}
+
+TEST(FMCSBatch, TargetLargerThanQueryUsesTargetTier) {
+  // MatchResult target-side bitsets are tier-sized too.  This pair
+  // should dispatch to the 64 tier even though the query itself fits
+  // in tier 16.
+  const auto small = path(4);
+  const auto large = path(64);
+
+  auto forward = findSingleMCES(small, large);
+  EXPECT_EQ(forward.numCommonVertices, small.numVertices);
+  EXPECT_EQ(forward.numCommonEdges, small.numEdges);
+  EXPECT_FALSE(forward.overflowed);
+  expectMappingsConsistent(forward, small, large);
+
+  auto reversed = findSingleMCES(large, small);
+  EXPECT_EQ(reversed.numCommonVertices, small.numVertices);
+  EXPECT_EQ(reversed.numCommonEdges, small.numEdges);
+  EXPECT_FALSE(reversed.overflowed);
+  expectMappingsConsistent(reversed, large, small);
+}
+
+TEST(FMCSBatch, OverflowPairDoesNotBlockNeighbors) {
+  std::vector<Graph> a{path(4), path(200), path(3)};
+  std::vector<Graph> b  = a;
+  auto               rs = mcs::fmcs::findMCESfMCSBatch(a, b);
+  ASSERT_EQ(rs.size(), 3u);
+
+  EXPECT_EQ(rs[0].numCommonEdges, 3);
+  EXPECT_FALSE(rs[0].overflowed);
+
+  EXPECT_TRUE(rs[1].overflowed);
+  EXPECT_EQ(rs[1].numCommonVertices, 0);
+  EXPECT_EQ(rs[1].numCommonEdges, 0);
+
+  EXPECT_EQ(rs[2].numCommonEdges, 2);
+  EXPECT_FALSE(rs[2].overflowed);
+}
+
+// ---------------------------------------------------------------------------
+// FMCSOverflow: graph too large for the largest tier.
+// ---------------------------------------------------------------------------
+
+TEST(FMCSOverflow, GraphTooLargeFlagSet) {
+  // Tier cap is 128 atoms / 128 bonds.  Build a path with 200 atoms
+  // (199 bonds) -- exceeds tier 128 in atoms AND bonds.
+  const auto p = path(200);
+  auto       r = findSingleMCES(p, p);
+  EXPECT_TRUE(r.overflowed);
+  EXPECT_EQ(r.numCommonEdges, 0);
+  EXPECT_EQ(r.numCommonVertices, 0);
+}
+
+TEST(FMCSOverflow, TargetTooLargeFlagSetEvenWhenQueryFits) {
+  const auto small = path(4);
+  const auto large = path(200);
+  auto       r     = findSingleMCES(small, large);
+  EXPECT_TRUE(r.overflowed);
+  EXPECT_EQ(r.numCommonEdges, 0);
+  EXPECT_EQ(r.numCommonVertices, 0);
+}
+
+TEST(FMCSTimeout, PartialResultReturned) {
+  const auto p = path(128);
+  Parameters params;
+  params.timeoutMs = 0.0001f;
+
+  auto r = findSingleMCES(p, p, params);
+  EXPECT_TRUE(r.timedOut);
+  EXPECT_FALSE(r.overflowed);
+  EXPECT_LT(r.numCommonEdges, p.numEdges);
+  EXPECT_LT(r.numCommonVertices, p.numVertices);
+}
+
+// ---------------------------------------------------------------------------
+// FMCSMappingConsistency: dedicated mapping-correctness tests.
+//
+// expectMappingsConsistent already checks the bond-mapping structure;
+// these tests pin specific known properties on top of that.
+// ---------------------------------------------------------------------------
+
+TEST(FMCSMappingConsistency, SelfPairMappingsAreBijection) {
+  const auto c = cycle(6);
+  auto       r = findSingleMCES(c, c);
+  expectFullSelfPair(r, c);
+
+  // Bijection: every query atom mapped exactly once, every target atom
+  // mapped exactly once.
+  std::set<std::size_t> qSeen(r.mappingA.begin(), r.mappingA.end());
+  std::set<std::size_t> tSeen(r.mappingB.begin(), r.mappingB.end());
+  ASSERT_EQ(qSeen.size(), 6u);
+  ASSERT_EQ(tSeen.size(), 6u);
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_TRUE(qSeen.count(i)) << "missing query atom " << i;
+    EXPECT_TRUE(tSeen.count(i)) << "missing target atom " << i;
+  }
+}
+
+TEST(FMCSMappingConsistency, BondMappingsConnectMatchedAtoms) {
+  const auto a = path(5);
+  const auto b = path(5);
+  auto       r = findSingleMCES(a, b);
+  expectFullSelfPair(r, a);
+  // expectMappingsConsistent does the structural check; we additionally
+  // assert that every query bond appears in edgeMappingA exactly once.
+  std::set<std::pair<std::size_t, std::size_t>> qBonds;
+  for (const auto& e : r.edgeMappingA) {
+    auto canon = std::make_pair(std::min(e.first, e.second), std::max(e.first, e.second));
+    EXPECT_TRUE(qBonds.insert(canon).second) << "duplicate query bond (" << e.first << "," << e.second << ")";
+  }
+  EXPECT_EQ(static_cast<int>(qBonds.size()), r.numCommonEdges);
+  expectMappingsConsistent(r, a, b);
+}
+
+TEST(FMCSMappingConsistency, EdgeMappingArrayLengths) {
+  // numCommonEdges must equal both edgeMappingA.size() and
+  // edgeMappingB.size().  numCommonVertices must equal both
+  // mappingA.size() and mappingB.size().
+  const auto a = naphthalene();
+  const auto b = phenanthrene();
+  auto       r = findSingleMCES(a, b);
+  EXPECT_EQ(static_cast<int>(r.mappingA.size()), r.numCommonVertices);
+  EXPECT_EQ(static_cast<int>(r.mappingB.size()), r.numCommonVertices);
+  EXPECT_EQ(static_cast<int>(r.edgeMappingA.size()), r.numCommonEdges);
+  EXPECT_EQ(static_cast<int>(r.edgeMappingB.size()), r.numCommonEdges);
+  expectMappingsConsistent(r, a, b);
+}


### PR DESCRIPTION
Ports the tier-dispatched fMCS driver and block kernel onto the shared subgraph candidate tables. The seed/substructure match caches are gone: the kernel calls the fallback matcher directly, so the cache storage parameter, its device allocation, and the global partial-storage slab all drop out.

Tier-128 now needs global substructure scratch at block size 256 as well as 512, since the shared per-group scratch no longer fits.

Covered by two suites: test_fmcs_core for result correctness (paths, trees, cycles, molecules, degenerate and disconnected inputs) and test_fmcs_engine_validation for the batch machinery (tier and block-size dispatch, batch chunking, multi-executor runs, timeout and overflow reporting, and atom/bond mapping consistency).