### PR TITLE
Standardize Python benchmark infrastructure

### DIFF
--- a/benchmarks/bench_utils/__init__.py
+++ b/benchmarks/bench_utils/__init__.py
@@ -19,6 +19,8 @@ Re-exports timing primitives, file loaders, and molecule preparation helpers
 so individual bench scripts can ``from bench_utils import time_it, load_smiles``.
 """
 
+from bench_utils.cli import add_backend_selection_args
+from bench_utils.concurrent import BoundedProcessMapResult, process_map_bounded
 from bench_utils.loaders import load_pickle, load_sdf, load_smarts, load_smiles
 from bench_utils.molprep import (
     available_cpu_count,
@@ -26,7 +28,9 @@ from bench_utils.molprep import (
     embed_and_jitter,
     perturb_conformer,
     prep_mols,
+    slice_conformers,
 )
+from bench_utils.results import print_csv_rows, result_fieldnames, write_csv_rows
 from bench_utils.timing import (
     Deadline,
     TimingResult,
@@ -37,8 +41,10 @@ from bench_utils.timing import (
 )
 
 __all__ = [
+    "BoundedProcessMapResult",
     "Deadline",
     "TimingResult",
+    "add_backend_selection_args",
     "add_rdkit_max_seconds_arg",
     "available_cpu_count",
     "clone_mols_with_conformers",
@@ -49,7 +55,12 @@ __all__ = [
     "load_smiles",
     "perturb_conformer",
     "prep_mols",
+    "print_csv_rows",
+    "process_map_bounded",
+    "result_fieldnames",
+    "slice_conformers",
     "throughput_per_s",
     "time_it",
     "time_it_bounded",
+    "write_csv_rows",
 ]

--- a/benchmarks/bench_utils/cli.py
+++ b/benchmarks/bench_utils/cli.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Common CLI arguments for nvMolKit benchmark drivers."""
+
+import argparse
+from collections.abc import Sequence
+
+
+def add_backend_selection_args(
+    parser: argparse.ArgumentParser,
+    *,
+    rdkit_dest: str = "no_rdkit",
+    nvmolkit_dest: str = "no_nvmolkit",
+    rdkit_aliases: Sequence[str] = (),
+    nvmolkit_aliases: Sequence[str] = (),
+) -> None:
+    """Add compatible hyphenated/underscored backend-disable flags."""
+    parser.add_argument(
+        "--no-rdkit",
+        "--no_rdkit",
+        *rdkit_aliases,
+        dest=rdkit_dest,
+        action="store_true",
+        help="Skip the RDKit benchmark",
+    )
+    parser.add_argument(
+        "--no-nvmolkit",
+        "--no_nvmolkit",
+        *nvmolkit_aliases,
+        dest=nvmolkit_dest,
+        action="store_true",
+        help="Skip the nvMolKit benchmark",
+    )

--- a/benchmarks/bench_utils/concurrent.py
+++ b/benchmarks/bench_utils/concurrent.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded multiprocessing helpers for benchmark preparation/reference work."""
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from multiprocessing import Pool
+from multiprocessing import TimeoutError as MultiprocessingTimeoutError
+from typing import Any, Generic, TypeVar
+
+from bench_utils.timing import Deadline
+
+InputT = TypeVar("InputT")
+OutputT = TypeVar("OutputT")
+
+
+@dataclass
+class BoundedProcessMapResult(Generic[OutputT]):
+    """Completed results from a bounded process map."""
+
+    results: list[OutputT]
+    timed_out: bool
+
+
+def process_map_bounded(
+    function: Callable[[InputT], OutputT],
+    items: Sequence[InputT],
+    *,
+    max_workers: int,
+    deadline: Deadline,
+    initializer: Callable[..., Any] | None = None,
+    initargs: tuple[Any, ...] = (),
+) -> BoundedProcessMapResult[OutputT]:
+    """Map process-safe work and retain completed items when a deadline expires.
+
+    Unlike :func:`tqdm.contrib.concurrent.process_map`, this helper uses the
+    deadline as a total wall-clock budget, returns completed results, and
+    terminates workers still processing items when the budget expires.
+    Callers should submit coarse batches when individual tasks are tiny.
+    Result order is completion order; include an index in each result when
+    input order must be reconstructed.
+    """
+    if not items:
+        return BoundedProcessMapResult([], False)
+
+    pool = Pool(max_workers, initializer=initializer, initargs=initargs)
+    iterator = pool.imap_unordered(function, items, chunksize=1)
+    completed: list[OutputT] = []
+    timed_out = False
+    try:
+        for _ in items:
+            remaining = deadline.remaining_seconds()
+            if remaining is not None:
+                if remaining <= 0:
+                    timed_out = True
+                    break
+                try:
+                    completed.append(iterator.next(timeout=remaining))
+                except MultiprocessingTimeoutError:
+                    timed_out = True
+                    break
+            else:
+                completed.append(next(iterator))
+    finally:
+        if timed_out:
+            pool.terminate()
+        else:
+            pool.close()
+        pool.join()
+    return BoundedProcessMapResult(completed, timed_out)

--- a/benchmarks/bench_utils/molprep.py
+++ b/benchmarks/bench_utils/molprep.py
@@ -87,6 +87,19 @@ def clone_mols_with_conformers(mols: list[Chem.Mol]) -> list[Chem.RWMol]:
     return [Chem.RWMol(mol) for mol in mols]
 
 
+def slice_conformers(mols: list[Chem.Mol], target: int) -> list[Chem.Mol]:
+    """Copy molecules while retaining at most the first ``target`` conformers."""
+    if target < 0:
+        raise ValueError(f"target must be non-negative, got {target}")
+    out: list[Chem.Mol] = []
+    for mol in mols:
+        copy_mol = Chem.Mol(mol, True)
+        for conf in list(mol.GetConformers())[:target]:
+            copy_mol.AddConformer(Chem.Conformer(conf), assignId=True)
+        out.append(copy_mol)
+    return out
+
+
 def perturb_conformer(
     conf: Chem.Conformer,
     seed: int,

--- a/benchmarks/bench_utils/results.py
+++ b/benchmarks/bench_utils/results.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structured result output shared by nvMolKit benchmark drivers."""
+
+import csv
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, TextIO
+
+
+def result_fieldnames(rows: Sequence[Mapping[str, Any]]) -> list[str]:
+    """Return keys in first-seen order across heterogeneous result rows."""
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    return fieldnames
+
+
+def write_csv_rows(
+    rows: Sequence[Mapping[str, Any]],
+    output: str | Path | None = None,
+    *,
+    stream: TextIO | None = None,
+) -> None:
+    """Write benchmark rows as valid CSV to a path and/or text stream.
+
+    Parent directories are created for file output. Heterogeneous rows are
+    supported: missing fields are emitted empty and columns retain first-seen
+    order. Passing neither ``output`` nor ``stream`` is a no-op.
+    """
+    if not rows or (output is None and stream is None):
+        return
+
+    fieldnames = result_fieldnames(rows)
+
+    def write(destination: TextIO) -> None:
+        writer = csv.DictWriter(destination, fieldnames=fieldnames, extrasaction="raise")
+        writer.writeheader()
+        writer.writerows(rows)
+
+    if stream is not None:
+        write(stream)
+    if output is not None:
+        path = Path(output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", newline="", encoding="utf-8") as destination:
+            write(destination)
+
+
+def print_csv_rows(rows: Sequence[Mapping[str, Any]]) -> None:
+    """Print benchmark rows as CSV to stdout."""
+    write_csv_rows(rows, stream=sys.stdout)

--- a/benchmarks/bench_utils/timing.py
+++ b/benchmarks/bench_utils/timing.py
@@ -101,15 +101,23 @@ class Deadline:
     """
 
     def __init__(self, max_seconds: float) -> None:
+        """Start a deadline lasting ``max_seconds``; non-positive disables it."""
         self._end: float | None = time.perf_counter() + max_seconds if max_seconds > 0 else None
 
     def expired(self) -> bool:
+        """Return whether the active deadline has elapsed."""
         return self._end is not None and time.perf_counter() >= self._end
 
     @property
     def active(self) -> bool:
         """``True`` when a real budget is being enforced."""
         return self._end is not None
+
+    def remaining_seconds(self) -> float | None:
+        """Seconds remaining, or ``None`` when the deadline is disabled."""
+        if self._end is None:
+            return None
+        return max(0.0, self._end - time.perf_counter())
 
 
 def throughput_per_s(items: float, elapsed_ms: float) -> float:
@@ -135,9 +143,10 @@ def time_it_bounded(
     workload was actually completed; a value below ``progress_target`` is
     treated as a partial run and further iterations are skipped.
 
-    Returns ``(avg_ms, std_ms, last_progress)``. ``avg`` and ``std`` are
-    computed only over runs that completed end-to-end; if no full run
-    finished, the single partial timing is returned with ``std=0``.
+    Returns ``(avg_ms, std_ms, measured_progress)``. ``avg`` and ``std`` are
+    computed only over runs that completed end-to-end, with
+    ``measured_progress == progress_target``. If no full run finished, the
+    single partial timing and its progress are returned with ``std=0``.
     """
     deadline = Deadline(max_seconds)
     completed_times_ms: list[float] = []
@@ -157,7 +166,9 @@ def time_it_bounded(
     if completed_times_ms:
         avg_ms = statistics.mean(completed_times_ms)
         std_ms = statistics.pstdev(completed_times_ms) if len(completed_times_ms) > 1 else 0.0
-        return avg_ms, std_ms, last_progress
+        # Partial work after one or more complete samples is not included in
+        # these timing statistics, so report the matching full-run progress.
+        return avg_ms, std_ms, progress_target
     if partial_time_ms is not None:
         return partial_time_ms, 0.0, last_progress
     return 0.0, 0.0, last_progress

--- a/benchmarks/benchmark_timing.py
+++ b/benchmarks/benchmark_timing.py
@@ -13,79 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared timing utilities for nvMolKit benchmarks."""
+"""Compatibility imports for the historical benchmark timing module.
 
-import statistics
-import time
-from dataclasses import dataclass, field
-from typing import Callable
+New benchmark code should import these names from :mod:`bench_utils`.
+"""
 
+from bench_utils.timing import TimingResult, time_it
 
-@dataclass
-class TimingResult:
-    """Holds timing results from a benchmark run."""
-
-    times_ms: list[float] = field(default_factory=list)
-
-    @property
-    def median_ms(self) -> float:
-        """Median time in milliseconds."""
-        return statistics.median(self.times_ms)
-
-    @property
-    def mean_ms(self) -> float:
-        """Mean time in milliseconds."""
-        return statistics.mean(self.times_ms)
-
-    @property
-    def std_ms(self) -> float:
-        """Sample standard deviation in milliseconds."""
-        if len(self.times_ms) < 2:
-            return 0.0
-        return statistics.stdev(self.times_ms)
-
-    @property
-    def median_s(self) -> float:
-        """Median time in seconds."""
-        return self.median_ms / 1000.0
-
-
-def time_it(func: Callable, runs: int = 3, warmups: int = 1, gpu_sync: bool = False) -> TimingResult:
-    """Time a callable with warmup iterations and optional CUDA synchronization.
-
-    Args:
-        func: Zero-argument callable to benchmark.
-        runs: Number of timed iterations.
-        warmups: Number of untimed warmup iterations.
-        gpu_sync: If True, call torch.cuda.synchronize() before and after each
-                  timed iteration to ensure GPU work is included in the measurement.
-
-    Returns:
-        A TimingResult with per-iteration times in milliseconds.
-    """
-    if gpu_sync:
-        import torch
-
-        sync = torch.cuda.synchronize
-    else:
-
-        def sync() -> None:
-            pass
-
-    for _ in range(warmups):
-        func()
-        sync()
-
-    if runs <= 0:
-        raise ValueError(f"runs must be positive, got {runs}")
-
-    times_ms = []
-    for _ in range(runs):
-        sync()
-        t0 = time.perf_counter()
-        func()
-        sync()
-        t1 = time.perf_counter()
-        times_ms.append((t1 - t0) * 1000.0)
-
-    return TimingResult(times_ms=times_ms)
+__all__ = ["TimingResult", "time_it"]

--- a/benchmarks/butina_clustering_bench.py
+++ b/benchmarks/butina_clustering_bench.py
@@ -18,16 +18,15 @@ import json
 import sys
 
 import numpy as np
-import pandas as pd
 import torch
-from bench_utils import load_smiles
-from benchmark_timing import time_it
+from bench_utils import add_backend_selection_args, load_smiles, print_csv_rows, time_it, write_csv_rows
 from rdkit import DataStructs
 from rdkit.Chem import AllChem
 from rdkit.DataStructs import BulkTanimotoSimilarity
 from rdkit.ML.Cluster.Butina import ClusterData
 
-from nvmolkit.clustering import butina as butina_nvmol, fused_butina
+from nvmolkit.clustering import butina as butina_nvmol
+from nvmolkit.clustering import fused_butina
 from nvmolkit.fingerprints import MorganFingerprintGenerator as nvmolMorganGen
 from nvmolkit.similarity import crossTanimotoSimilarity
 
@@ -149,9 +148,8 @@ DEFAULT_SIZES = [1000, 5000, 10000, 20000, 30000, 40000]
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Benchmark Butina clustering")
     parser.add_argument("input_smiles_file", help="Path to input SMILES file")
-    parser.add_argument("--no-rdkit", action="store_true", help="Disable RDKit benchmarks")
     parser.add_argument("--no-fused", action="store_true", help="Disable fused Butina benchmarks")
-    parser.add_argument("--no-nvmolkit", action="store_true", help="Disable nvMolKit Butina benchmarks")
+    add_backend_selection_args(parser)
     parser.add_argument(
         "--rdkit-lowmem",
         action="store_true",
@@ -176,6 +174,17 @@ if __name__ == "__main__":
     )
     parser.add_argument("--runs", type=int, default=3, help="Number of timed repetitions (default: 3)")
     parser.add_argument("--seed", type=int, default=42, help="Random seed for sampling SMILES (default: 42)")
+    parser.add_argument(
+        "--allow-synthetic-padding",
+        action="store_true",
+        help="Pad undersized inputs with synthetic fingerprints/distances instead of failing",
+    )
+    parser.add_argument(
+        "--validate-max-size",
+        type=int,
+        default=10000,
+        help="Largest problem size for the expensive dense correctness check (default: 10000; 0 disables)",
+    )
     parser.add_argument(
         "-o", "--output", type=str, default="results.csv", help="Output CSV file path (default: results.csv)"
     )
@@ -220,8 +229,16 @@ if __name__ == "__main__":
     max_size = max(e["size"] for e in run_plan)
 
     mols = load_smiles(args.input_smiles_file, max_count=max_size + 100, sanitize=True, seed=args.seed)
+    if len(mols) < max_size and not args.allow_synthetic_padding:
+        print(
+            f"Error: requested size {max_size}, but only {len(mols)} molecules loaded; "
+            "pass --allow-synthetic-padding to benchmark synthetic padded data",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
-    fps = get_fingerprints(mols)
+    need_nvmolkit_fps = any("fused" in entry["run"] or "nvmolkit" in entry["run"] for entry in run_plan)
+    fps = get_fingerprints(mols) if need_nvmolkit_fps else None
 
     # All three rdkit paths (cluster_only, with_tanimoto, lowmem) need real
     # RDKit fingerprints, so build them once if any rdkit row is planned.
@@ -241,9 +258,7 @@ if __name__ == "__main__":
     results = []
 
     def save_results():
-        df = pd.DataFrame(results)
-        df.to_csv(output_path, index=False)
-        return df
+        write_csv_rows(results, output_path)
 
     try:
         for entry in run_plan:
@@ -354,7 +369,7 @@ if __name__ == "__main__":
                                 tuple(torch.argwhere(nvmol_res == i).flatten().tolist())
                                 for i in range(nvmol_res.max() + 1)
                             ]
-                            if nvmol_reordering:
+                            if nvmol_reordering and 0 < size <= args.validate_max_size:
                                 check_butina_correctness(dist_mat <= cutoff, nvmol_clusts)
 
                             results.append(
@@ -400,5 +415,8 @@ if __name__ == "__main__":
             save_results()
     except Exception as e:
         print(f"Got exception: {e}, exiting early")
-    df = save_results()
-    print(df)
+        save_results()
+        raise
+    save_results()
+    print("\nCSV Results:")
+    print_csv_rows(results)

--- a/benchmarks/conformer_rmsd_bench.py
+++ b/benchmarks/conformer_rmsd_bench.py
@@ -20,14 +20,23 @@ CPU GetConformerRMSMatrix across varying conformer counts.
 """
 
 import argparse
-import csv
 import statistics
 import time
 from pathlib import Path
 
 import torch
-from bench_utils import Deadline, add_rdkit_max_seconds_arg, available_cpu_count, embed_and_jitter, load_smiles
-from benchmark_timing import time_it
+from bench_utils import (
+    Deadline,
+    add_backend_selection_args,
+    add_rdkit_max_seconds_arg,
+    available_cpu_count,
+    embed_and_jitter,
+    load_smiles,
+    print_csv_rows,
+    slice_conformers,
+    time_it,
+    write_csv_rows,
+)
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
@@ -108,18 +117,6 @@ def validate(mols: list[Chem.Mol], num_check: int, tol: float) -> None:
     print(f"  OK (max abs diff {max_abs_diff:.5f})")
 
 
-def _slice_to_confs(mols: list[Chem.Mol], target: int) -> list[Chem.Mol]:
-    """Return copies of ``mols`` keeping only the first ``target`` conformers each."""
-    out: list[Chem.Mol] = []
-    for mol in mols:
-        copy_mol = Chem.Mol(mol, True)  # quickCopy: keeps graph, drops conformers
-        confs = list(mol.GetConformers())[:target]
-        for conf in confs:
-            copy_mol.AddConformer(Chem.Conformer(conf), assignId=True)
-        out.append(copy_mol)
-    return out
-
-
 def run(
     smiles_path: str,
     num_mols: int,
@@ -154,7 +151,7 @@ def run(
     avg_atoms = sum(mol.GetNumAtoms() for mol in base_mols) / len(base_mols)
     print(f"  {len(base_mols)} mols, ~{avg_atoms:.1f} heavy atoms/mol")
     if validate_count > 0 and not no_rdkit and not no_nvmolkit:
-        validate(_slice_to_confs(base_mols, max_confs), validate_count, validate_tol)
+        validate(slice_conformers(base_mols, max_confs), validate_count, validate_tol)
     elif validate_count > 0:
         print("\nValidation skipped (requires both --rdkit and --nvmolkit enabled)")
 
@@ -162,7 +159,7 @@ def run(
 
     rows: list[dict[str, float | int | str]] = []
     for target_confs in sorted(confs_per_mol_list):
-        mols = _slice_to_confs(base_mols, target_confs)
+        mols = slice_conformers(base_mols, target_confs)
         actual_confs = [mol.GetNumConformers() for mol in mols]
         total_pairs = sum(count * (count - 1) // 2 for count in actual_confs)
         print(f"\n=== confs_per_mol={target_confs}: {len(mols)} mols, {total_pairs} RMSD pairs ===")
@@ -227,18 +224,13 @@ def run(
 
         rows.append(row)
 
+    if rows:
+        print("\nCSV Results:")
+        print_csv_rows(rows)
+
     if output and rows:
         out_path = Path(output)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        fieldnames: list[str] = []
-        for row in rows:
-            for key in row:
-                if key not in fieldnames:
-                    fieldnames.append(key)
-        with out_path.open("w", newline="") as csv_file:
-            writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
-            writer.writeheader()
-            writer.writerows(rows)
+        write_csv_rows(rows, out_path)
         print(f"\nWrote {out_path}")
 
 
@@ -272,8 +264,7 @@ def main():
     parser.add_argument("--no_validate", action="store_true", help="Skip the GPU-vs-RDKit correctness check")
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--output", type=str, default=None, help="Optional CSV output path")
-    parser.add_argument("--no_rdkit", action="store_true", help="Skip RDKit CPU benchmark")
-    parser.add_argument("--no_nvmolkit", action="store_true", help="Skip nvMolKit GPU benchmark")
+    add_backend_selection_args(parser)
     args = parser.parse_args()
 
     if args.no_rdkit and args.no_nvmolkit:

--- a/benchmarks/etkdg_bench.py
+++ b/benchmarks/etkdg_bench.py
@@ -35,20 +35,24 @@ import nvtx
 from bench_utils import (
     Deadline,
     TimingResult,
+    add_backend_selection_args,
     add_rdkit_max_seconds_arg,
     clone_mols_with_conformers,
     load_pickle,
     load_sdf,
     load_smiles,
     prep_mols,
+    print_csv_rows,
     throughput_per_s,
     time_it,
+    write_csv_rows,
 )
-from nvmolkit import autotune as nv_autotune
-from nvmolkit.types import HardwareOptions
 from rdkit import Chem
 from rdkit.Chem import AllChem, rdDistGeom
 from tqdm.contrib.concurrent import process_map
+
+from nvmolkit import autotune as nv_autotune
+from nvmolkit.types import HardwareOptions
 
 OPTUNA_AVAILABLE = nv_autotune.is_available()
 
@@ -185,16 +189,16 @@ def bench_rdkit(
 
     @nvtx.annotate("etkdg_rdkit_run", color="yellow")
     def run() -> None:
-        cloned = clone_mols_with_conformers(mols)
         deadline = Deadline(max_seconds)
-        n_done = 0
-        for mol in cloned:
+        processed: list[Chem.Mol] = []
+        for source_mol in mols:
+            mol = Chem.RWMol(source_mol)
             rdDistGeom.EmbedMultipleConfs(mol, numConfs=confs_per_mol, params=params)
-            n_done += 1
+            processed.append(mol)
             if deadline.expired():
                 break
-        last_run_mols[0] = cloned[:n_done]
-        processed_count[0] = n_done
+        last_run_mols[0] = processed
+        processed_count[0] = len(processed)
 
     if warmup:
         warmup_mol = Chem.RWMol(mols[0])
@@ -228,15 +232,6 @@ def _build_hardware_options(
     )
 
 
-CSV_HEADER = (
-    "method,input_file,input_type,num_mols,mols_processed,confs_per_mol,max_iterations,"
-    "batch_size,batches_per_gpu,prep_threads,num_gpus,nvmolkit_config_source,"
-    "rdkit_threads,rdkit_max_seconds,time_ms,std_ms,conformers_generated,"
-    "confs_per_second,vs_rdkit_throughput_ratio,"
-    "mean_energy_diff,median_energy_diff,energy_diff_pairs"
-)
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="ETKDG conformer generation benchmark: nvmolkit vs RDKit",
@@ -265,8 +260,7 @@ def main() -> None:
     parser.add_argument("--no_warmup", action="store_false", dest="warmup", help="Skip warmup")
     parser.set_defaults(warmup=True)
 
-    parser.add_argument("--no_nvmolkit", action="store_true", help="Skip nvmolkit benchmark")
-    parser.add_argument("--no_rdkit", action="store_true", help="Skip RDKit benchmark")
+    add_backend_selection_args(parser)
     parser.add_argument(
         "--rdkit_threads",
         type=int,
@@ -394,7 +388,7 @@ def main() -> None:
     if not args.no_rdkit:
         print(f"  RDKit threads: {args.rdkit_threads}")
     if not args.no_nvmolkit:
-        print(f"  nvmolkit hardware:")
+        print("  nvmolkit hardware:")
         print(f"    batch_size: {args.batch_size}")
         print(f"    batches_per_gpu: {args.batches_per_gpu if args.batches_per_gpu > 0 else 'auto'}")
         print(f"    prep_threads: {args.prep_threads if args.prep_threads > 0 else 'auto'}")
@@ -564,7 +558,7 @@ def main() -> None:
         else:
             print("  No paired conformers with valid energies on both sides")
 
-    csv_rows: list[str] = []
+    csv_rows: list[dict[str, object]] = []
     for name, (timing, run_mols) in results.items():
         is_nv = name == "nvmolkit"
         is_rdkit = name == "rdkit"
@@ -586,24 +580,37 @@ def main() -> None:
         median_diff = energy_median if (diff_computed and is_nv) else "N/A"
         pairs = energy_pairs if (diff_computed and is_nv) else "N/A"
         csv_rows.append(
-            f"{name},{input_file},{input_type},{len(mols)},{mols_processed},{args.confs_per_mol},"
-            f"{args.max_iterations},{batch_size},{batches_per_gpu},{prep_threads},{num_gpus},"
-            f"{nvmolkit_config_source},{rdkit_threads},{rdkit_max_seconds},"
-            f"{timing.mean_ms:.2f},{timing.std_ms:.2f},"
-            f"{confs_generated},{confs_per_second:.2f},{vs_rdkit_throughput_ratio},"
-            f"{mean_diff},{median_diff},{pairs}"
+            {
+                "method": name,
+                "input_file": input_file,
+                "input_type": input_type,
+                "num_mols": len(mols),
+                "mols_processed": mols_processed,
+                "confs_per_mol": args.confs_per_mol,
+                "max_iterations": args.max_iterations,
+                "batch_size": batch_size,
+                "batches_per_gpu": batches_per_gpu,
+                "prep_threads": prep_threads,
+                "num_gpus": num_gpus,
+                "nvmolkit_config_source": nvmolkit_config_source,
+                "rdkit_threads": rdkit_threads,
+                "rdkit_max_seconds": rdkit_max_seconds,
+                "time_ms": round(timing.mean_ms, 2),
+                "std_ms": round(timing.std_ms, 2),
+                "conformers_generated": confs_generated,
+                "confs_per_second": round(confs_per_second, 2),
+                "vs_rdkit_throughput_ratio": vs_rdkit_throughput_ratio,
+                "mean_energy_diff": mean_diff,
+                "median_energy_diff": median_diff,
+                "energy_diff_pairs": pairs,
+            }
         )
 
     print("\n\nCSV Results:")
-    print(CSV_HEADER)
-    for row in csv_rows:
-        print(row)
+    print_csv_rows(csv_rows)
 
     if args.output:
-        with open(args.output, "w", encoding="utf-8") as fh:
-            fh.write(CSV_HEADER + "\n")
-            for row in csv_rows:
-                fh.write(row + "\n")
+        write_csv_rows(csv_rows, args.output)
         print(f"\nWrote results to {args.output}")
 
 

--- a/benchmarks/ff_optimize_bench.py
+++ b/benchmarks/ff_optimize_bench.py
@@ -40,6 +40,7 @@ import nvtx
 import torch
 from bench_utils import (
     Deadline,
+    add_backend_selection_args,
     add_rdkit_max_seconds_arg,
     available_cpu_count,
     clone_mols_with_conformers,
@@ -48,8 +49,10 @@ from bench_utils import (
     load_sdf,
     load_smiles,
     prep_mols,
+    print_csv_rows,
     throughput_per_s,
     time_it,
+    write_csv_rows,
 )
 from rdkit import Chem
 from rdkit.Chem import AllChem
@@ -183,17 +186,15 @@ def bench_rdkit(
 
     @nvtx.annotate("ff_rdkit_run", color="yellow")
     def run() -> None:
-        cloned = clone_mols_with_conformers(mols)
         deadline = Deadline(max_seconds)
         out: list[list[tuple[int, float]]] = []
-        n_done = 0
-        for mol in cloned:
+        for source_mol in mols:
+            mol = Chem.RWMol(source_mol)
             out.append(rdkit_optimize(mol))
-            n_done += 1
             if deadline.expired():
                 break
         last_results[0] = out
-        processed_count[0] = n_done
+        processed_count[0] = len(out)
 
     if warmup:
         warmup_mols = clone_mols_with_conformers(mols[: min(4, len(mols))])
@@ -219,15 +220,6 @@ def _build_hardware_options(
         batchesPerGpu=batches_per_gpu,
         gpuIds=list(range(num_gpus)) if num_gpus > 0 else None,
     )
-
-
-CSV_HEADER = (
-    "method,ff,minimizer_kind,input_file,input_type,num_mols,mols_processed,confs_per_mol,max_iters,"
-    "batch_size,batches_per_gpu,prep_threads,num_gpus,nvmolkit_config_source,"
-    "rdkit_threads,rdkit_max_seconds,time_ms,std_ms,"
-    "confs_per_second,vs_rdkit_throughput_ratio,"
-    "energies_compared,mean_abs_energy_diff,max_abs_energy_diff"
-)
 
 
 def main() -> None:
@@ -267,8 +259,7 @@ def main() -> None:
     parser.add_argument("--no_warmup", action="store_false", dest="warmup", help="Skip warmup")
     parser.set_defaults(warmup=True)
 
-    parser.add_argument("--no_nvmolkit", action="store_true", help="Skip nvmolkit benchmark")
-    parser.add_argument("--no_rdkit", action="store_true", help="Skip RDKit benchmark")
+    add_backend_selection_args(parser)
     parser.add_argument(
         "--rdkit_threads",
         type=int,
@@ -483,16 +474,16 @@ def main() -> None:
                 rng = random.Random(args.autotune_seed)
                 size = min(args.autotune_calibration_size, len(mols))
                 explicit_calibration = rng.sample(range(len(mols)), size)
-            tune_kwargs = dict(
-                maxIters=args.max_iters,
-                minimizerKind=args.minimizer_kind,
-                gpuIds=gpu_ids,
-                n_trials=args.autotune_trials,
-                target_seconds_per_trial=args.autotune_time_budget,
-                calibration_set=explicit_calibration,
-                seed=args.autotune_seed,
-                verbose=True,
-            )
+            tune_kwargs = {
+                "maxIters": args.max_iters,
+                "minimizerKind": args.minimizer_kind,
+                "gpuIds": gpu_ids,
+                "n_trials": args.autotune_trials,
+                "target_seconds_per_trial": args.autotune_time_budget,
+                "calibration_set": explicit_calibration,
+                "seed": args.autotune_seed,
+                "verbose": True,
+            }
             if args.ff == "mmff":
                 tune_result = nv_autotune.tune_mmff_optimize(mols, **tune_kwargs)
             else:
@@ -582,7 +573,7 @@ def main() -> None:
         applied_prep_threads = args.prep_threads
         applied_num_gpus = args.num_gpus
 
-    csv_rows: list[str] = []
+    csv_rows: list[dict[str, object]] = []
     for name, (avg_ms, std_ms, energies) in results.items():
         is_nv = name == "nvmolkit"
         is_rdkit = name == "rdkit"
@@ -603,25 +594,38 @@ def main() -> None:
         max_diff = energy_max if (args.validate and is_nv) else "N/A"
         pairs = energy_pairs if (args.validate and is_nv) else "N/A"
         csv_rows.append(
-            f"{name},{args.ff},{args.minimizer_kind if is_nv else 'N/A'},{input_file},{input_type},"
-            f"{len(mols)},{mols_processed},{args.confs_per_mol},"
-            f"{args.max_iters},{batch_size},{batches_per_gpu},{prep_threads},{num_gpus},"
-            f"{nvmolkit_config_source},{rdkit_threads},{rdkit_max_seconds},"
-            f"{avg_ms:.2f},{std_ms:.2f},"
-            f"{confs_per_second:.2f},{vs_rdkit_throughput_ratio},"
-            f"{pairs},{mean_diff},{max_diff}"
+            {
+                "method": name,
+                "ff": args.ff,
+                "minimizer_kind": args.minimizer_kind if is_nv else "N/A",
+                "input_file": input_file,
+                "input_type": input_type,
+                "num_mols": len(mols),
+                "mols_processed": mols_processed,
+                "confs_per_mol": args.confs_per_mol,
+                "max_iters": args.max_iters,
+                "batch_size": batch_size,
+                "batches_per_gpu": batches_per_gpu,
+                "prep_threads": prep_threads,
+                "num_gpus": num_gpus,
+                "nvmolkit_config_source": nvmolkit_config_source,
+                "rdkit_threads": rdkit_threads,
+                "rdkit_max_seconds": rdkit_max_seconds,
+                "time_ms": round(avg_ms, 2),
+                "std_ms": round(std_ms, 2),
+                "confs_per_second": round(confs_per_second, 2),
+                "vs_rdkit_throughput_ratio": vs_rdkit_throughput_ratio,
+                "energies_compared": pairs,
+                "mean_abs_energy_diff": mean_diff,
+                "max_abs_energy_diff": max_diff,
+            }
         )
 
     print("\n\nCSV Results:")
-    print(CSV_HEADER)
-    for row in csv_rows:
-        print(row)
+    print_csv_rows(csv_rows)
 
     if args.output:
-        with open(args.output, "w", encoding="utf-8") as fh:
-            fh.write(CSV_HEADER + "\n")
-            for row in csv_rows:
-                fh.write(row + "\n")
+        write_csv_rows(csv_rows, args.output)
         print(f"\nWrote results to {args.output}")
 
     if not args.no_nvmolkit:

--- a/benchmarks/substruct_bench.py
+++ b/benchmarks/substruct_bench.py
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Substructure search benchmark comparing nvmolkit GPU substructure search against RDKit.
+"""Substructure search benchmark comparing nvmolkit GPU substructure search against RDKit.
 
 Compares two approaches:
   1. nvmolkit GPU-accelerated substructure search
@@ -64,13 +63,26 @@ import argparse
 import gc
 import random
 import sys
-from multiprocessing import Pool
+from pathlib import Path
 from typing import Callable
 
 import nvtx
 import pandas as pd
-from bench_utils import add_rdkit_max_seconds_arg, load_pickle, load_smarts, load_smiles, time_it_bounded
-from benchmark_timing import time_it as _time_it
+from bench_utils import (
+    Deadline,
+    add_backend_selection_args,
+    add_rdkit_max_seconds_arg,
+    load_pickle,
+    load_smarts,
+    load_smiles,
+    print_csv_rows,
+    process_map_bounded,
+    time_it_bounded,
+    write_csv_rows,
+)
+from bench_utils import (
+    time_it as _time_it,
+)
 from rdkit import Chem
 from rdkit.Chem import rdSubstructLibrary
 
@@ -123,6 +135,21 @@ def _rdkit_worker_count(mol_binary: bytes) -> list[int]:
     return [len(mol.GetSubstructMatches(q, _worker_params)) for q in _worker_queries]
 
 
+def _rdkit_worker_has_batch(item: tuple[int, list[bytes]]) -> tuple[int, list[list[bool]]]:
+    start, mol_binaries = item
+    return start, [_rdkit_worker_has(mol_binary) for mol_binary in mol_binaries]
+
+
+def _rdkit_worker_get_batch(item: tuple[int, list[bytes]]) -> tuple[int, list[list[tuple]]]:
+    start, mol_binaries = item
+    return start, [_rdkit_worker_get(mol_binary) for mol_binary in mol_binaries]
+
+
+def _rdkit_worker_count_batch(item: tuple[int, list[bytes]]) -> tuple[int, list[list[int]]]:
+    start, mol_binaries = item
+    return start, [_rdkit_worker_count(mol_binary) for mol_binary in mol_binaries]
+
+
 @nvtx.annotate("bench_rdkit_substruct", color="green")
 def bench_rdkit_substruct(
     mols: list[Chem.Mol],
@@ -135,10 +162,9 @@ def bench_rdkit_substruct(
 ) -> tuple[float, float, list, int]:
     """Benchmark RDKit SubstructMatch API.
 
-    @param max_seconds  When > 0, abort additional runs (and the per-molecule
-                        loop in single-threaded mode) once the elapsed time
-                        exceeds this budget. The threaded path can only be
-                        bounded between runs since `pool.map` is monolithic.
+    @param max_seconds  When > 0, abort at a molecule boundary in single-threaded
+                        mode or at a completed molecule-batch boundary in the
+                        multiprocessing path.
     @return tuple of (avg_ms, std_ms, results_data, pairs_processed_per_run).
     """
     num_mols = len(mols)
@@ -150,25 +176,39 @@ def bench_rdkit_substruct(
         params.maxMatches = max_matches
 
     results_data = []
+    complete_results_data = None
     pairs_done_this_run = 0
 
     if threads > 1:
         mol_binaries = [mol.ToBinary() for mol in mols]
         query_binaries = [q.ToBinary() for q in queries]
         if mode == "hasSubstructMatch":
-            worker_func = _rdkit_worker_has
+            worker_func = _rdkit_worker_has_batch
         elif mode == "countSubstructMatches":
-            worker_func = _rdkit_worker_count
+            worker_func = _rdkit_worker_count_batch
         else:
-            worker_func = _rdkit_worker_get
-        chunksize = max(1, len(mol_binaries) // (threads * 4))
+            worker_func = _rdkit_worker_get_batch
+        batch_size = max(1, len(mol_binaries) // (threads * 8))
+        batches = [
+            (start, mol_binaries[start : start + batch_size]) for start in range(0, len(mol_binaries), batch_size)
+        ]
 
         @nvtx.annotate("substruct_run_mp", color="yellow")
-        def run(_deadline):
-            nonlocal results_data, pairs_done_this_run
-            with Pool(threads, initializer=_rdkit_worker_init, initargs=(query_binaries, max_matches)) as pool:
-                results_data = pool.map(worker_func, mol_binaries, chunksize=chunksize)
-            pairs_done_this_run = pairs_total
+        def run(deadline: Deadline):
+            nonlocal complete_results_data, results_data, pairs_done_this_run
+            mapped = process_map_bounded(
+                worker_func,
+                batches,
+                max_workers=threads,
+                deadline=deadline,
+                initializer=_rdkit_worker_init,
+                initargs=(query_binaries, max_matches),
+            )
+            completed = dict(mapped.results)
+            pairs_done_this_run = sum(len(rows) * num_queries for rows in completed.values())
+            results_data = [row for start in sorted(completed) for row in completed[start]]
+            if pairs_done_this_run == pairs_total:
+                complete_results_data = results_data
     else:
         if mode == "hasSubstructMatch":
             match_fn = lambda mol, query: mol.HasSubstructMatch(query, params)  # noqa: E731
@@ -179,7 +219,7 @@ def bench_rdkit_substruct(
 
         @nvtx.annotate("substruct_run", color="yellow")
         def run(deadline):
-            nonlocal results_data, pairs_done_this_run
+            nonlocal complete_results_data, results_data, pairs_done_this_run
             results_data = []
             pairs_done_this_run = 0
             for mol in mols:
@@ -187,8 +227,12 @@ def bench_rdkit_substruct(
                     break
                 results_data.append([match_fn(mol, query) for query in queries])
                 pairs_done_this_run += num_queries
+            if pairs_done_this_run == pairs_total:
+                complete_results_data = results_data
 
     avg_ms, std_ms, last_pairs = time_it_bounded(run, runs, max_seconds, lambda: pairs_done_this_run, pairs_total)
+    if last_pairs == pairs_total and complete_results_data is not None:
+        results_data = complete_results_data
     return avg_ms, std_ms, results_data, last_pairs
 
 
@@ -220,6 +264,7 @@ def bench_rdkit_substructlib(
         params.maxMatches = max_matches
 
     results_data = [[None] * num_queries for _ in range(num_mols)]
+    complete_results_data = None
     pairs_done_this_run = 0
 
     if mode == "hasSubstructMatch":
@@ -246,7 +291,7 @@ def bench_rdkit_substructlib(
 
     @nvtx.annotate("substructlib_run", color="yellow")
     def run(deadline):
-        nonlocal results_data, pairs_done_this_run
+        nonlocal complete_results_data, results_data, pairs_done_this_run
 
         mol_holder = rdSubstructLibrary.CachedMolHolder()
         fp_holder = rdSubstructLibrary.PatternHolder()
@@ -263,8 +308,12 @@ def bench_rdkit_substructlib(
             matching_set = set(lib.GetMatches(query, numThreads=threads))
             fill_column(q_idx, query, matching_set)
             pairs_done_this_run += num_mols
+        if pairs_done_this_run == pairs_total:
+            complete_results_data = results_data
 
     avg_ms, std_ms, last_pairs = time_it_bounded(run, runs, max_seconds, lambda: pairs_done_this_run, pairs_total)
+    if last_pairs == pairs_total and complete_results_data is not None:
+        results_data = complete_results_data
     return avg_ms, std_ms, results_data, last_pairs
 
 
@@ -290,7 +339,16 @@ def bench_nvmolkit(
 
 
 def _load_config_dataframe(config_path: str) -> list[dict]:
-    return pd.read_csv(config_path).to_dict("records")
+    suffix = Path(config_path).suffix.lower()
+    if suffix == ".csv":
+        dataframe = pd.read_csv(config_path)
+    elif suffix in {".pkl", ".pickle"}:
+        dataframe = pd.read_pickle(config_path)
+    elif suffix == ".parquet":
+        dataframe = pd.read_parquet(config_path)
+    else:
+        raise ValueError(f"unsupported config format {suffix!r}; expected .csv, .pkl, .pickle, or .parquet")
+    return dataframe.to_dict("records")
 
 
 def _validate_matches(mode: str, nvmolkit_data, rdkit_data, num_mols: int, num_queries: int) -> None:
@@ -312,7 +370,7 @@ def _validate_matches(mode: str, nvmolkit_data, rdkit_data, num_mols: int, num_q
     else:
         for t in range(num_mols):
             for q in range(num_queries):
-                nv_matches = set(tuple(m) for m in nvmolkit_data[t][q])
+                nv_matches = {tuple(m) for m in nvmolkit_data[t][q]}
                 rd_matches = set(rdkit_data[t][q])
                 if nv_matches == rd_matches:
                     matches += 1
@@ -360,8 +418,7 @@ def main():
     parser.add_argument(
         "--max_matches", type=int, default=0, help="Maximum matches per target/query pair, 0 = all (default: 0)"
     )
-    parser.add_argument("--no_nvmolkit", action="store_true", help="Skip nvmolkit benchmark")
-    parser.add_argument("--no_rdkit", action="store_true", help="Skip RDKit benchmark")
+    add_backend_selection_args(parser)
     parser.add_argument(
         "--rdkit_match_mode",
         choices=["raw", "substructlib"],
@@ -386,8 +443,8 @@ def main():
     add_rdkit_max_seconds_arg(
         parser,
         extra_help=(
-            "RDKit aborts between queries (substructlib) or molecules (raw, single-thread); "
-            "the threaded raw path can only be bounded between runs."
+            "RDKit aborts between queries (substructlib), molecules (raw single-thread), "
+            "or completed molecule batches (raw multiprocessing)."
         ),
     )
     parser.add_argument("--batch_size", "-b", type=int, default=1024, help="nvmolkit batch size (default: 1024)")
@@ -453,6 +510,7 @@ def main():
     )
     parser.add_argument("--no_validate", action="store_false", dest="validate", help="Skip validation checks")
     parser.set_defaults(validate=True)
+    parser.add_argument("--output", "-o", default=None, help="Optional path to write CSV results")
 
     args = parser.parse_args()
 
@@ -593,7 +651,7 @@ def main():
             smarts_cache[smarts_path] = (queries, smarts_list)
 
         num_patterns = len(queries)
-        print(f"\nBenchmarking substructure search ({mode}): {len(mols)} molecules × {num_patterns} patterns")
+        print(f"\nBenchmarking substructure search ({mode}): {len(mols)} molecules x {num_patterns} patterns")
         print("=" * 70)
 
         results = {}
@@ -834,31 +892,31 @@ def main():
             throughput = (pairs_done * 1000.0 / avg_ms) if avg_ms > 0 else 0.0
             vs_rdkit = (throughput / baseline_throughput) if (not is_rdkit and baseline_throughput > 0) else "N/A"
             csv_rows.append(
-                (
-                    name,
-                    mode,
-                    applied_algorithm if name == "nvmolkit" else "N/A",
-                    smarts_path,
-                    input_file,
-                    input_type,
-                    sanitize_value,
-                    len(mols),
-                    num_patterns,
-                    args.max_matches,
-                    batch_size,
-                    num_gpus,
-                    workers,
-                    prep_threads,
-                    nvmolkit_config_source,
-                    rdkit_threads,
-                    rdkit_match_mode,
-                    avg_ms,
-                    std_ms,
-                    pairs_done,
-                    rdkit_max_seconds,
-                    throughput,
-                    vs_rdkit,
-                )
+                {
+                    "method": name,
+                    "mode": mode,
+                    "algorithm": applied_algorithm if name == "nvmolkit" else "N/A",
+                    "smarts": smarts_path,
+                    "input_file": input_file,
+                    "input_type": input_type,
+                    "sanitize": sanitize_value,
+                    "num_mols": len(mols),
+                    "num_patterns": num_patterns,
+                    "max_matches": args.max_matches,
+                    "batch_size": batch_size,
+                    "num_gpus": num_gpus,
+                    "workers": workers,
+                    "prep_threads": prep_threads,
+                    "nvmolkit_config_source": nvmolkit_config_source,
+                    "rdkit_threads": rdkit_threads,
+                    "rdkit_match_mode": rdkit_match_mode,
+                    "time_ms": round(avg_ms, 2),
+                    "std_ms": round(std_ms, 2),
+                    "pairs_processed": pairs_done,
+                    "rdkit_max_seconds": rdkit_max_seconds,
+                    "pairs_per_second": round(throughput, 2),
+                    "vs_rdkit_throughput_ratio": vs_rdkit,
+                }
             )
 
         if ran_nvmolkit:
@@ -868,48 +926,10 @@ def main():
         gc.collect()
 
     print("\n\nCSV Results:")
-    print(
-        "method,mode,algorithm,smarts,input_file,input_type,sanitize,num_mols,num_patterns,"
-        "max_matches,batch_size,num_gpus,workers,prep_threads,nvmolkit_config_source,"
-        "rdkit_threads,rdkit_match_mode,time_ms,std_ms,"
-        "pairs_processed,rdkit_max_seconds,pairs_per_second,vs_rdkit_throughput_ratio"
-    )
-    for row in csv_rows:
-        (
-            name,
-            mode,
-            algorithm,
-            smarts_path,
-            input_file,
-            input_type,
-            sanitize,
-            num_mols,
-            num_patterns,
-            max_matches,
-            batch_size,
-            num_gpus,
-            workers,
-            prep_threads,
-            nvmolkit_config_source,
-            rdkit_threads,
-            rdkit_match_mode,
-            avg_ms,
-            std_ms,
-            pairs_done,
-            rdkit_max_seconds,
-            throughput,
-            vs_rdkit,
-        ) = row
-        vs_rdkit_str = f"{vs_rdkit:.4f}" if isinstance(vs_rdkit, float) else str(vs_rdkit)
-        rdkit_max_seconds_str = (
-            f"{rdkit_max_seconds:g}" if isinstance(rdkit_max_seconds, float) else str(rdkit_max_seconds)
-        )
-        print(
-            f"{name},{mode},{algorithm},{smarts_path},{input_file},{input_type},{sanitize},"
-            f"{num_mols},{num_patterns},{max_matches},{batch_size},{num_gpus},{workers},{prep_threads},"
-            f"{nvmolkit_config_source},{rdkit_threads},{rdkit_match_mode},{avg_ms:.2f},{std_ms:.2f},"
-            f"{pairs_done},{rdkit_max_seconds_str},{throughput:.2f},{vs_rdkit_str}"
-        )
+    print_csv_rows(csv_rows)
+    if args.output:
+        write_csv_rows(csv_rows, args.output)
+        print(f"\nWrote results to {args.output}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_cli.py
+++ b/benchmarks/tests/test_cli.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+import pytest
+from bench_utils.cli import add_backend_selection_args
+
+
+@pytest.mark.parametrize("flag", ["--no-rdkit", "--no_rdkit", "--skip-rdkit"])
+def test_backend_selection_accepts_common_and_legacy_aliases(flag):
+    parser = argparse.ArgumentParser()
+    add_backend_selection_args(parser, rdkit_dest="skip_rdkit", rdkit_aliases=("--skip-rdkit",))
+    args = parser.parse_args([flag])
+    assert args.skip_rdkit
+    assert not args.no_nvmolkit
+
+
+@pytest.mark.parametrize("flag", ["--no-nvmolkit", "--no_nvmolkit"])
+def test_backend_selection_accepts_nvmolkit_spellings(flag):
+    parser = argparse.ArgumentParser()
+    add_backend_selection_args(parser)
+    args = parser.parse_args([flag])
+    assert args.no_nvmolkit
+    assert not args.no_rdkit

--- a/benchmarks/tests/test_concurrent.py
+++ b/benchmarks/tests/test_concurrent.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+from bench_utils.concurrent import process_map_bounded
+from bench_utils.timing import Deadline
+
+
+def _sleep_and_return(item):
+    delay, value = item
+    time.sleep(delay)
+    return value
+
+
+def test_process_map_bounded_returns_all_results_without_deadline():
+    result = process_map_bounded(
+        _sleep_and_return,
+        [(0.001, 1), (0.001, 2)],
+        max_workers=2,
+        deadline=Deadline(0.0),
+    )
+    assert sorted(result.results) == [1, 2]
+    assert not result.timed_out
+
+
+def test_process_map_bounded_retains_completed_results_on_timeout():
+    result = process_map_bounded(
+        _sleep_and_return,
+        [(0.001, 1), (2.0, 2)],
+        max_workers=1,
+        deadline=Deadline(0.25),
+    )
+    assert result.results == [1]
+    assert result.timed_out

--- a/benchmarks/tests/test_loaders.py
+++ b/benchmarks/tests/test_loaders.py
@@ -6,6 +6,7 @@
 import os
 
 from bench_utils import loaders, molprep
+from rdkit import Chem
 
 
 def test_load_smiles_can_return_candidate_buffer(tmp_path, monkeypatch):
@@ -31,3 +32,15 @@ def test_available_cpu_count_supports_python_312(monkeypatch):
     monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {2, 4, 6}, raising=False)
 
     assert molprep.available_cpu_count() == 3
+
+
+def test_slice_conformers_copies_and_limits_each_molecule():
+    mol = Chem.MolFromSmiles("CC")
+    for _ in range(3):
+        mol.AddConformer(Chem.Conformer(mol.GetNumAtoms()), assignId=True)
+
+    sliced = molprep.slice_conformers([mol], 2)
+
+    assert sliced[0] is not mol
+    assert sliced[0].GetNumConformers() == 2
+    assert mol.GetNumConformers() == 3

--- a/benchmarks/tests/test_results.py
+++ b/benchmarks/tests/test_results.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import csv
+import io
+
+from bench_utils.results import result_fieldnames, write_csv_rows
+
+
+def test_result_fieldnames_preserve_first_seen_order():
+    rows = [{"method": "a", "time_ms": 1.0}, {"method": "b", "pairs": 10}]
+    assert result_fieldnames(rows) == ["method", "time_ms", "pairs"]
+
+
+def test_write_csv_rows_quotes_values_and_fills_missing_fields():
+    rows = [{"method": "a", "input": "path,with,commas"}, {"method": "b", "pairs": 10}]
+    stream = io.StringIO()
+
+    write_csv_rows(rows, stream=stream)
+
+    assert list(csv.DictReader(io.StringIO(stream.getvalue()))) == [
+        {"method": "a", "input": "path,with,commas", "pairs": ""},
+        {"method": "b", "input": "", "pairs": "10"},
+    ]
+
+
+def test_write_csv_rows_creates_parent_directories(tmp_path):
+    output = tmp_path / "nested" / "results.csv"
+    write_csv_rows([{"method": "a"}], output)
+    assert output.read_text().splitlines() == ["method", "a"]

--- a/benchmarks/tests/test_timing.py
+++ b/benchmarks/tests/test_timing.py
@@ -33,6 +33,14 @@ def test_deadline_independent_instances():
     assert not long.expired()
 
 
+def test_deadline_reports_remaining_seconds():
+    disabled = Deadline(0.0)
+    active = Deadline(1.0)
+
+    assert disabled.remaining_seconds() is None
+    assert 0.0 < active.remaining_seconds() <= 1.0
+
+
 def test_throughput_per_s_simple_conversion():
     # 100 items in 500ms -> 200 items/s
     assert throughput_per_s(100, 500.0) == pytest.approx(200.0)
@@ -115,6 +123,22 @@ def test_time_it_bounded_stddev_positive_for_multiple_completed_runs():
         run, runs=3, max_seconds=0.0, progress_getter=lambda: 1, progress_target=1
     )
     assert std_ms > 0.0
+
+
+def test_time_it_bounded_does_not_pair_full_timing_with_partial_progress():
+    progresses = iter([10, 3])
+    progress = [0]
+
+    def run(_deadline):
+        progress[0] = next(progresses)
+
+    avg_ms, std_ms, reported_progress = time_it_bounded(
+        run, runs=3, max_seconds=0.0, progress_getter=lambda: progress[0], progress_target=10
+    )
+
+    assert avg_ms >= 0.0
+    assert std_ms == 0.0
+    assert reported_progress == 10
 
 
 def test_time_it_bounded_shared_deadline_caps_inner_loop():

--- a/benchmarks/tfd_bench.py
+++ b/benchmarks/tfd_bench.py
@@ -20,7 +20,7 @@ Compares:
 - nvMolKit GPU (CUDA) with different return types (list, numpy, tensor)
 
 Usage:
-    python tfd_bench.py [--smiles-file FILE] [--output FILE] [--skip-rdkit]
+    python tfd_bench.py [--smiles-file FILE] [--output FILE] [--no-rdkit]
     python tfd_bench.py --pkl-file data1.pkl data2.pkl [--output FILE]
 
 Example:
@@ -35,42 +35,24 @@ import argparse
 import os
 import pickle
 import sys
-import time
-from typing import List, Tuple
+from typing import List
 
 import pandas as pd
 import torch
-from bench_utils import available_cpu_count, embed_and_jitter, load_smiles
+from bench_utils import (
+    add_backend_selection_args,
+    available_cpu_count,
+    embed_and_jitter,
+    load_smiles,
+    print_csv_rows,
+    slice_conformers,
+    time_it,
+    write_csv_rows,
+)
 from rdkit import Chem
 from rdkit.Chem import TorsionFingerprints
 
 import nvmolkit.tfd as nvmol_tfd
-
-
-def time_it(func, runs: int = 3, warmups: int = 1) -> Tuple[float, float]:
-    """Time a function with warmup runs.
-
-    Args:
-        func: Function to time (no arguments)
-        runs: Number of timed runs
-        warmups: Number of warmup runs
-
-    Returns:
-        Tuple of (average_time_ms, std_time_ms)
-    """
-    for _ in range(warmups):
-        func()
-
-    times = []
-    for _ in range(runs):
-        start = time.perf_counter_ns()
-        func()
-        end = time.perf_counter_ns()
-        times.append(end - start)
-
-    avg_time = sum(times) / runs
-    std_time = (sum((t - avg_time) ** 2 for t in times) / runs) ** 0.5
-    return avg_time / 1.0e6, std_time / 1.0e6  # Return in milliseconds
 
 
 def generate_conformers_batch(
@@ -100,7 +82,7 @@ def generate_conformers_batch(
     )
 
 
-def _try_load_pickle(num_confs: int, max_mols: int, smiles_file: str = None) -> List[Chem.Mol]:
+def _try_load_pickle(num_confs: int, max_mols: int, smiles_file: str | None = None) -> List[Chem.Mol] | None:
     """Try to load precomputed molecules from pickle file."""
     search_dirs = []
     if smiles_file:
@@ -122,8 +104,9 @@ def prepare_molecules(
     input_mols: List[Chem.Mol],
     num_confs: int,
     max_mols: int = 100,
-    smiles_file: str = None,
+    smiles_file: str | None = None,
     num_workers: int = 0,
+    seed: int = 42,
 ) -> List[Chem.Mol]:
     """Prepare molecules with conformers, using precomputed pickle if available.
 
@@ -133,6 +116,7 @@ def prepare_molecules(
         max_mols: Maximum number of molecules to prepare
         smiles_file: Path to SMILES file (used to locate sibling pickle files)
         num_workers: Parallel workers for ETKDG embedding (0 = auto, half of CPUs)
+        seed: Seed for base embedding and conformer perturbations.
 
     Returns:
         List of molecules with conformers
@@ -141,7 +125,7 @@ def prepare_molecules(
     if cached is not None:
         return cached
 
-    print(f"  No precomputed pickle found, generating from scratch...")
+    print("  No precomputed pickle found, generating from scratch...")
     candidates: List[Chem.Mol] = []
     for mol in input_mols:
         if mol is None or mol.GetNumAtoms() < 4:
@@ -150,7 +134,7 @@ def prepare_molecules(
         if len(candidates) >= max_mols:
             break
 
-    return generate_conformers_batch(candidates, num_confs, seed=42, num_workers=num_workers)
+    return generate_conformers_batch(candidates, num_confs, seed=seed, num_workers=num_workers)
 
 
 def bench_rdkit_single(mol: Chem.Mol) -> None:
@@ -227,11 +211,14 @@ def run_benchmarks(
     skip_rdkit: bool = False,
     skip_nvmolkit: bool = False,
     output_file: str = "tfd_results.csv",
-    smiles_file: str = None,
-    mol_counts: List[int] = None,
-    conformer_counts: List[int] = None,
+    smiles_file: str | None = None,
+    mol_counts: List[int] | None = None,
+    conformer_counts: List[int] | None = None,
     preloaded_mols: List[Chem.Mol] | None = None,
     num_workers: int = 0,
+    runs: int = 3,
+    warmups: int = 1,
+    seed: int = 42,
 ) -> pd.DataFrame:
     """Run TFD benchmarks with various configurations.
 
@@ -247,6 +234,9 @@ def run_benchmarks(
             When provided, input_mols/smiles_file/conformer_counts are ignored and
             the actual conformer count is read from the molecules.
         num_workers: Parallel workers for ETKDG embedding (0 = auto, half of CPUs).
+        runs: Number of timed repetitions per workload point.
+        warmups: Number of warmup repetitions per workload point.
+        seed: Sampling and conformer-preparation seed.
 
     Returns:
         DataFrame with benchmark results
@@ -265,7 +255,7 @@ def run_benchmarks(
     elif conformer_counts is None:
         conformer_counts = [5, 10, 20]
 
-    results = []
+    results: list[dict[str, object]] = []
 
     print("=" * 70)
     print("TFD Benchmark: RDKit vs nvMolKit (GPU)")
@@ -273,18 +263,25 @@ def run_benchmarks(
     print(f"Conformer counts: {conformer_counts}")
     print("=" * 70)
 
+    prepared_max: List[Chem.Mol] | None = None
+    if preloaded_mols is None:
+        max_confs = max(conformer_counts)
+        print(f"\n--- Preparing molecules once with {max_confs} conformers ---")
+        prepared_max = prepare_molecules(
+            input_mols,
+            max_confs,
+            max_mols=max(mol_counts) + 20,
+            smiles_file=smiles_file,
+            num_workers=num_workers,
+            seed=seed,
+        )
+
     for num_confs in conformer_counts:
         if preloaded_mols is not None:
             all_mols = preloaded_mols[: max(mol_counts)]
         else:
-            print(f"\n--- Preparing molecules with {num_confs} conformers ---")
-            all_mols = prepare_molecules(
-                input_mols,
-                num_confs,
-                max_mols=max(mol_counts) + 20,
-                smiles_file=smiles_file,
-                num_workers=num_workers,
-            )
+            assert prepared_max is not None
+            all_mols = slice_conformers(prepared_max, num_confs)
 
         if len(all_mols) < max(mol_counts):
             print(f"Warning: Only {len(all_mols)} molecules available")
@@ -314,7 +311,8 @@ def run_benchmarks(
             # RDKit benchmark (single-threaded Python)
             if not skip_rdkit:
                 try:
-                    rdkit_time, rdkit_std = time_it(lambda: bench_rdkit_batch(mols))
+                    timing = time_it(lambda: bench_rdkit_batch(mols), runs=runs, warmups=warmups)
+                    rdkit_time, rdkit_std = timing.mean_ms, timing.std_ms
                     result["rdkit_time_ms"] = rdkit_time
                     result["rdkit_std_ms"] = rdkit_std
                     print(f"  RDKit (Python):     {rdkit_time:8.2f} ms (+/- {rdkit_std:.2f})")
@@ -328,7 +326,8 @@ def run_benchmarks(
 
             if not skip_nvmolkit:
                 try:
-                    t, s = time_it(lambda: bench_nvmol_gpu_list(mols))
+                    timing = time_it(lambda: bench_nvmol_gpu_list(mols), runs=runs, warmups=warmups)
+                    t, s = timing.mean_ms, timing.std_ms
                     result["nvmol_gpu_list_time_ms"] = t
                     result["nvmol_gpu_list_std_ms"] = s
                     print(f"  nvMolKit (GPU list):  {t:8.2f} ms (+/- {s:.2f})")
@@ -337,7 +336,8 @@ def run_benchmarks(
                     result["nvmol_gpu_list_time_ms"] = None
 
                 try:
-                    t, s = time_it(lambda: bench_nvmol_gpu_numpy(mols))
+                    timing = time_it(lambda: bench_nvmol_gpu_numpy(mols), runs=runs, warmups=warmups)
+                    t, s = timing.mean_ms, timing.std_ms
                     result["nvmol_gpu_numpy_time_ms"] = t
                     result["nvmol_gpu_numpy_std_ms"] = s
                     print(f"  nvMolKit (GPU numpy): {t:8.2f} ms (+/- {s:.2f})")
@@ -346,7 +346,8 @@ def run_benchmarks(
                     result["nvmol_gpu_numpy_time_ms"] = None
 
                 try:
-                    t, s = time_it(lambda: bench_nvmol_gpu_tensor(mols))
+                    timing = time_it(lambda: bench_nvmol_gpu_tensor(mols), runs=runs, warmups=warmups)
+                    t, s = timing.mean_ms, timing.std_ms
                     result["nvmol_gpu_tensor_time_ms"] = t
                     result["nvmol_gpu_tensor_std_ms"] = s
                     print(f"  nvMolKit (GPU ten):  {t:8.2f} ms (+/- {s:.2f})")
@@ -374,7 +375,9 @@ def run_benchmarks(
 
     # Create DataFrame and save
     df = pd.DataFrame(results)
-    df.to_csv(output_file, index=False)
+    write_csv_rows(results, output_file)
+    print("\nCSV Results:")
+    print_csv_rows(results)
     print(f"\n{'=' * 70}")
     print(f"Results saved to: {output_file}")
     print(f"{'=' * 70}")
@@ -412,15 +415,12 @@ def main():
         default=[5, 10, 20, 50],
         help="Conformer counts to benchmark (default: 5 10 20 50)",
     )
-    parser.add_argument(
-        "--skip-rdkit",
-        action="store_true",
-        help="Skip RDKit benchmarks (faster)",
-    )
-    parser.add_argument(
-        "--skip-nvmolkit",
-        action="store_true",
-        help="Skip nvMolKit GPU benchmarks (RDKit-only mode)",
+    add_backend_selection_args(
+        parser,
+        rdkit_dest="skip_rdkit",
+        nvmolkit_dest="skip_nvmolkit",
+        rdkit_aliases=("--skip-rdkit",),
+        nvmolkit_aliases=("--skip-nvmolkit",),
     )
     parser.add_argument(
         "--pkl-file",
@@ -446,6 +446,9 @@ def main():
         default=0,
         help="Parallel workers for ETKDG embedding during prep (0 = auto, half of CPUs)",
     )
+    parser.add_argument("--runs", type=int, default=3, help="Number of timed repetitions (default: 3)")
+    parser.add_argument("--warmups", type=int, default=1, help="Number of warmup repetitions (default: 1)")
+    parser.add_argument("--seed", type=int, default=42, help="Sampling and conformer-generation seed (default: 42)")
     args = parser.parse_args()
 
     if args.skip_rdkit and args.skip_nvmolkit:
@@ -464,7 +467,7 @@ def main():
     else:
         print(f"Loading SMILES from: {args.smiles_file}")
         try:
-            input_mols = load_smiles(args.smiles_file, max_count=max(args.num_mols) + 100)
+            input_mols = load_smiles(args.smiles_file, max_count=max(args.num_mols) + 100, seed=args.seed)
         except Exception as e:
             print(f"Error loading SMILES file: {e}")
             sys.exit(1)
@@ -481,6 +484,7 @@ def main():
                 max_mols=50,
                 smiles_file=args.smiles_file,
                 num_workers=args.prep_workers,
+                seed=args.seed,
             )
         all_correct = True
         mismatches = 0
@@ -509,6 +513,9 @@ def main():
         conformer_counts=args.num_confs if not args.pkl_file else None,
         preloaded_mols=preloaded_mols,
         num_workers=args.prep_workers,
+        runs=args.runs,
+        warmups=args.warmups,
+        seed=args.seed,
     )
 
 


### PR DESCRIPTION
* Removed last bespoke timing code
* Standardized --no-rdkit, --no-nvmolkit flags
* Standardized multiprocess rdkit with timeout + partial results collection
* Standardize output writing to csvs

Note that none of this is being applied to the similarity bench - it's a weird edge case that uses pyperf, we'll leave it alone. 