### PR TITLE
Fix partial-run benchmark timing accounting

### DIFF
--- a/benchmarks/bench_utils/__init__.py
+++ b/benchmarks/bench_utils/__init__.py
@@ -38,6 +38,7 @@ from bench_utils.timing import (
     throughput_per_s,
     time_it,
     time_it_bounded,
+    time_it_bounded_result,
 )
 
 __all__ = [
@@ -62,5 +63,6 @@ __all__ = [
     "throughput_per_s",
     "time_it",
     "time_it_bounded",
+    "time_it_bounded_result",
     "write_csv_rows",
 ]

--- a/benchmarks/bench_utils/timing.py
+++ b/benchmarks/bench_utils/timing.py
@@ -148,12 +148,47 @@ def time_it_bounded(
     ``measured_progress == progress_target``. If no full run finished, the
     single partial timing and its progress are returned with ``std=0``.
     """
+    timing, measured_progress = time_it_bounded_result(
+        run,
+        runs,
+        max_seconds,
+        progress_getter,
+        progress_target,
+    )
+    if not timing.times_ms:
+        return 0.0, 0.0, measured_progress
+    std_ms = statistics.pstdev(timing.times_ms) if len(timing.times_ms) > 1 else 0.0
+    return timing.mean_ms, std_ms, measured_progress
+
+
+def time_it_bounded_result(
+    run: Callable[[Deadline], None],
+    runs: int,
+    max_seconds: float,
+    progress_getter: Callable[[], int],
+    progress_target: int,
+) -> tuple[TimingResult, int]:
+    """Return the actual timing samples retained by :func:`time_it_bounded`.
+
+    Complete samples are retained together and a later partial sample is
+    discarded. If the first sample is partial, that sample and its measured
+    progress are returned. This form is useful when callers need a
+    :class:`TimingResult` without pairing aggregate timing from one run with
+    progress or output captured from another.
+
+    At least one timed invocation is attempted for valid input, even when an
+    active deadline has already expired. Bounded callers need one indivisible
+    unit of work to produce a partial timing suitable for extrapolation.
+    """
+    if runs <= 0:
+        raise ValueError(f"runs must be positive, got {runs}")
+
     deadline = Deadline(max_seconds)
     completed_times_ms: list[float] = []
     partial_time_ms: float | None = None
     last_progress = 0
-    for _ in range(runs):
-        if deadline.expired():
+    for run_idx in range(runs):
+        if run_idx > 0 and deadline.expired():
             break
         start = time.perf_counter()
         run(deadline)
@@ -164,14 +199,12 @@ def time_it_bounded(
             break
         completed_times_ms.append(elapsed_ms)
     if completed_times_ms:
-        avg_ms = statistics.mean(completed_times_ms)
-        std_ms = statistics.pstdev(completed_times_ms) if len(completed_times_ms) > 1 else 0.0
         # Partial work after one or more complete samples is not included in
         # these timing statistics, so report the matching full-run progress.
-        return avg_ms, std_ms, progress_target
-    if partial_time_ms is not None:
-        return partial_time_ms, 0.0, last_progress
-    return 0.0, 0.0, last_progress
+        return TimingResult(times_ms=completed_times_ms), progress_target
+    if partial_time_ms is None:
+        raise RuntimeError("bounded timing completed without recording a sample")
+    return TimingResult(times_ms=[partial_time_ms]), last_progress
 
 
 def add_rdkit_max_seconds_arg(parser: argparse.ArgumentParser, *, extra_help: str = "") -> None:

--- a/benchmarks/etkdg_bench.py
+++ b/benchmarks/etkdg_bench.py
@@ -45,6 +45,7 @@ from bench_utils import (
     print_csv_rows,
     throughput_per_s,
     time_it,
+    time_it_bounded_result,
     write_csv_rows,
 )
 from rdkit import Chem
@@ -178,18 +179,18 @@ def bench_rdkit(
 ) -> tuple[TimingResult, list[Chem.Mol], int]:
     """Benchmark RDKit ``EmbedMultipleConfs``; return ``(timing, processed_mols, processed_count)``.
 
-    When ``max_seconds > 0``, the inner loop stops processing molecules once
-    wall-clock elapsed exceeds the cap. The reported timing is over the
-    molecules actually processed; throughput is items / elapsed at the call
-    site. Cloned molecules that were never processed are omitted from the
-    returned list so downstream energy validation only sees comparable inputs.
+    When ``max_seconds > 0``, one deadline is shared across all timed runs and
+    the inner loop stops processing at the next molecule boundary. The timing,
+    processed count, and returned molecules always come from the same retained
+    sample set: complete samples take precedence over a later partial sample.
+    This keeps throughput and downstream energy validation comparable.
     """
     last_run_mols: list[list[Chem.Mol]] = [[]]
+    complete_run_mols: list[list[Chem.Mol]] = [[]]
     processed_count = [0]
 
     @nvtx.annotate("etkdg_rdkit_run", color="yellow")
-    def run() -> None:
-        deadline = Deadline(max_seconds)
+    def run(deadline: Deadline) -> None:
         processed: list[Chem.Mol] = []
         for source_mol in mols:
             mol = Chem.RWMol(source_mol)
@@ -199,13 +200,22 @@ def bench_rdkit(
                 break
         last_run_mols[0] = processed
         processed_count[0] = len(processed)
+        if processed_count[0] == len(mols):
+            complete_run_mols[0] = processed
 
     if warmup:
         warmup_mol = Chem.RWMol(mols[0])
         rdDistGeom.EmbedMultipleConfs(warmup_mol, numConfs=1, params=params)
 
-    timing = time_it(run, runs=runs, warmups=0, gpu_sync=False)
-    return timing, last_run_mols[0], processed_count[0]
+    timing, measured_count = time_it_bounded_result(
+        run,
+        runs=runs,
+        max_seconds=max_seconds,
+        progress_getter=lambda: processed_count[0],
+        progress_target=len(mols),
+    )
+    measured_mols = complete_run_mols[0] if measured_count == len(mols) else last_run_mols[0]
+    return timing, measured_mols, measured_count
 
 
 def _build_etkdg_params(max_iterations: int, num_threads: int, seed: int) -> rdDistGeom.EmbedParameters:

--- a/benchmarks/ff_optimize_bench.py
+++ b/benchmarks/ff_optimize_bench.py
@@ -52,6 +52,7 @@ from bench_utils import (
     print_csv_rows,
     throughput_per_s,
     time_it,
+    time_it_bounded_result,
     write_csv_rows,
 )
 from rdkit import Chem
@@ -165,10 +166,10 @@ def bench_rdkit(
 ) -> tuple[float, float, list[float], int]:
     """Benchmark RDKit MMFF/UFF optimization; return ``(mean_ms, std_ms, energies, processed_mols)``.
 
-    When ``max_seconds > 0`` the per-molecule loop stops once wall-clock
-    elapsed exceeds the cap. Throughput at the call site should be measured
-    as items / elapsed; the returned timing is over the molecules actually
-    processed.
+    When ``max_seconds > 0``, one deadline is shared across all timed runs and
+    the inner loop stops processing at the next molecule boundary. The timing,
+    processed count, and returned energies always come from the same retained
+    sample set: complete samples take precedence over a later partial sample.
     """
     if ff == "mmff":
         rdkit_optimize = lambda mol: AllChem.MMFFOptimizeMoleculeConfs(  # noqa: E731
@@ -182,11 +183,11 @@ def bench_rdkit(
         raise ValueError(f"Unknown ff: {ff!r}")
 
     last_results: list[list[list[tuple[int, float]]]] = [[]]
+    complete_results: list[list[list[tuple[int, float]]]] = [[]]
     processed_count = [0]
 
     @nvtx.annotate("ff_rdkit_run", color="yellow")
-    def run() -> None:
-        deadline = Deadline(max_seconds)
+    def run(deadline: Deadline) -> None:
         out: list[list[tuple[int, float]]] = []
         for source_mol in mols:
             mol = Chem.RWMol(source_mol)
@@ -195,17 +196,26 @@ def bench_rdkit(
                 break
         last_results[0] = out
         processed_count[0] = len(out)
+        if processed_count[0] == len(mols):
+            complete_results[0] = out
 
     if warmup:
         warmup_mols = clone_mols_with_conformers(mols[: min(4, len(mols))])
         for warmup_mol in warmup_mols:
             rdkit_optimize(warmup_mol)
 
-    result = time_it(run, runs=runs, warmups=0, gpu_sync=False)
-    energies, not_converged = _flatten_rdkit_energies(last_results[0])
+    timing, measured_count = time_it_bounded_result(
+        run,
+        runs=runs,
+        max_seconds=max_seconds,
+        progress_getter=lambda: processed_count[0],
+        progress_target=len(mols),
+    )
+    measured_results = complete_results[0] if measured_count == len(mols) else last_results[0]
+    energies, not_converged = _flatten_rdkit_energies(measured_results)
     if not_converged > 0:
         print(f"  RDKit: {not_converged} conformer(s) reported non-zero status (not converged)")
-    return result.mean_ms, result.std_ms, energies, processed_count[0]
+    return timing.mean_ms, timing.std_ms, energies, measured_count
 
 
 def _build_hardware_options(

--- a/benchmarks/tests/test_timing.py
+++ b/benchmarks/tests/test_timing.py
@@ -7,7 +7,7 @@ import math
 import time
 
 import pytest
-from bench_utils.timing import Deadline, throughput_per_s, time_it_bounded
+from bench_utils.timing import Deadline, throughput_per_s, time_it_bounded, time_it_bounded_result
 
 
 @pytest.mark.parametrize("max_seconds", [0.0, -1.0])
@@ -104,13 +104,30 @@ def test_time_it_bounded_stops_when_budget_exhausted_between_runs():
     assert avg_ms > 0
 
 
-def test_time_it_bounded_zero_runs_returns_zero():
-    avg_ms, std_ms, progress = time_it_bounded(
-        lambda _deadline: None, runs=0, max_seconds=0.0, progress_getter=lambda: 0, progress_target=1
+@pytest.mark.parametrize("timing_func", [time_it_bounded, time_it_bounded_result])
+def test_time_it_bounded_rejects_non_positive_runs(timing_func):
+    with pytest.raises(ValueError, match="runs must be positive"):
+        timing_func(lambda _deadline: None, runs=0, max_seconds=0.0, progress_getter=lambda: 0, progress_target=1)
+
+
+def test_time_it_bounded_result_runs_first_sample_when_deadline_already_expired(monkeypatch):
+    monkeypatch.setattr(Deadline, "expired", lambda _self: True)
+    call_count = [0]
+
+    def run(_deadline):
+        call_count[0] += 1
+
+    timing, reported_progress = time_it_bounded_result(
+        run,
+        runs=3,
+        max_seconds=1.0,
+        progress_getter=lambda: call_count[0],
+        progress_target=1,
     )
-    assert avg_ms == 0.0
-    assert std_ms == 0.0
-    assert progress == 0
+
+    assert call_count[0] == 1
+    assert len(timing.times_ms) == 1
+    assert reported_progress == 1
 
 
 def test_time_it_bounded_stddev_positive_for_multiple_completed_runs():
@@ -139,6 +156,36 @@ def test_time_it_bounded_does_not_pair_full_timing_with_partial_progress():
     assert avg_ms >= 0.0
     assert std_ms == 0.0
     assert reported_progress == 10
+
+
+def test_time_it_bounded_result_retains_complete_samples_not_later_partial():
+    progresses = iter([10, 10, 3])
+    progress = [0]
+
+    def run(_deadline):
+        progress[0] = next(progresses)
+
+    timing, reported_progress = time_it_bounded_result(
+        run, runs=3, max_seconds=0.0, progress_getter=lambda: progress[0], progress_target=10
+    )
+
+    assert len(timing.times_ms) == 2
+    assert reported_progress == 10
+
+
+def test_time_it_bounded_result_returns_first_partial_sample_and_progress():
+    progress = [3]
+
+    timing, reported_progress = time_it_bounded_result(
+        lambda _deadline: None,
+        runs=3,
+        max_seconds=0.0,
+        progress_getter=lambda: progress[0],
+        progress_target=10,
+    )
+
+    assert len(timing.times_ms) == 1
+    assert reported_progress == 3
 
 
 def test_time_it_bounded_shared_deadline_caps_inner_loop():


### PR DESCRIPTION
ETKDG and FF optimization had some timing quirks, fixing and standardizing