### PR TITLE
Rewrite fMCS kernel on the shared subgraph layer

### DIFF
--- a/benchmarks/mcs_bench.py
+++ b/benchmarks/mcs_bench.py
@@ -99,7 +99,6 @@ def _normalize_config_row(row: dict, args: argparse.Namespace) -> dict:
     config_row = {
         "num_pairs": int(_row_value(row, "num_pairs", args.num_pairs)),
         "batch_size": int(_row_value(row, "batch_size", args.batch_size)),
-        "block_size": int(_row_value(row, "block_size", args.block_size)),
         "workers": int(_row_value(row, "workers", args.workers)),
         "prep_threads": int(_row_value(row, "prep_threads", args.prep_threads)),
         "executors_per_runner": int(_row_value(row, "executors_per_runner", args.executors_per_runner)),
@@ -113,8 +112,6 @@ def _normalize_config_row(row: dict, args: argparse.Namespace) -> dict:
     }
     if config_row["num_pairs"] <= 0:
         raise ValueError("num_pairs must be positive")
-    if config_row["block_size"] not in {64, 128, 256, 512}:
-        raise ValueError("block_size must be one of 64, 128, 256, or 512")
     if config_row["executors_per_runner"] != -1 and not 1 <= config_row["executors_per_runner"] <= 8:
         raise ValueError("executors_per_runner must be -1 or between 1 and 8")
     if config_row["num_gpus"] <= 0:
@@ -302,7 +299,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--config",
         help=(
             "Path to config dataframe (.csv/.pkl/.pickle/.parquet) with optional columns: num_pairs, "
-            "batch_size, block_size, workers, prep_threads, executors_per_runner, num_gpus, atom_compare, "
+            "batch_size, workers, prep_threads, executors_per_runner, num_gpus, atom_compare, "
             "bond_compare, match_valences, match_formal_charge, ring_matches_ring_only, timeout_seconds"
         ),
     )
@@ -331,7 +328,6 @@ def _build_parser() -> argparse.ArgumentParser:
         extra_help="The RDKit MCS loop stops at the next completed molecule-pair boundary.",
     )
     parser.add_argument("--batch_size", "-b", type=int, default=0, help="nvMolKit batch size (default: all pairs)")
-    parser.add_argument("--block_size", type=int, choices=[64, 128, 256, 512], default=128)
     parser.add_argument("--workers", type=int, default=-1, help="nvMolKit GPU worker threads per GPU (-1 = auto)")
     parser.add_argument("--prep_threads", type=int, default=-1, help="nvMolKit preprocessing threads (-1 = auto)")
     parser.add_argument(
@@ -360,7 +356,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--autotune_load",
         default=None,
         help=(
-            "Path to a previously saved MCSConfig JSON. Overrides batch_size, block_size, workers, "
+            "Path to a previously saved MCSConfig JSON. Overrides batch_size, workers, "
             "prep_threads, executors_per_runner, and num_gpus. Single-config mode only."
         ),
     )
@@ -475,7 +471,6 @@ def main() -> None:
         config_source = "dataframe" if args.config else "cli"
         applied_config = MCSConfig(
             batchSize=config_row["batch_size"],
-            blockSize=config_row["block_size"],
             workerThreads=config_row["workers"],
             preprocessingThreads=config_row["prep_threads"],
             executorsPerRunner=config_row["executors_per_runner"],
@@ -634,7 +629,6 @@ def main() -> None:
                     "ring_matches_ring_only": config_row["ring_matches_ring_only"],
                     "timeout_seconds": config_row["timeout_seconds"],
                     "batch_size": applied_config.batchSize if is_nvmolkit else "N/A",
-                    "block_size": applied_config.blockSize if is_nvmolkit else "N/A",
                     "workers": applied_config.workerThreads if is_nvmolkit else "N/A",
                     "prep_threads": applied_config.preprocessingThreads if is_nvmolkit else "N/A",
                     "executors_per_runner": applied_config.executorsPerRunner if is_nvmolkit else "N/A",

--- a/nvmolkit/autotune/tune_mcs.py
+++ b/nvmolkit/autotune/tune_mcs.py
@@ -40,7 +40,6 @@ def _default_mcs_search_space(num_gpus: int, cpus: int) -> dict:
     per_gpu_worker_max = max(1, min(8, cpus // max(1, num_gpus)))
     return {
         "batchSize": [0, 64, 128, 256, 512],
-        "blockSize": [64, 128, 256, 512],
         "workerThreads": (1, per_gpu_worker_max),
         "preprocessingThreads": (1, cpus),
         "executorsPerRunner": (1, 8),
@@ -123,7 +122,6 @@ def tune_mcs(
     def make_config(values: dict[str, Any]) -> MCSConfig:
         return MCSConfig(
             batchSize=int(values.get("batchSize", 0)),
-            blockSize=int(values.get("blockSize", 128)),
             workerThreads=int(values.get("workerThreads", -1)),
             preprocessingThreads=int(values.get("preprocessingThreads", -1)),
             executorsPerRunner=int(values.get("executorsPerRunner", -1)),

--- a/nvmolkit/mcs.cpp
+++ b/nvmolkit/mcs.cpp
@@ -163,7 +163,6 @@ BOOST_PYTHON_MODULE(_mcs) {
       params.requireGpu           = optionValue<bool>(options, "require_gpu", false);
       params.timeoutSeconds       = optionValue<unsigned int>(options, "timeout_seconds", 0);
       params.batchSize            = optionValue<int>(options, "batch_size", 0);
-      params.blockSize            = optionValue<int>(options, "block_size", 128);
       params.workerThreads        = optionValue<int>(options, "worker_threads", -1);
       params.preprocessingThreads = optionValue<int>(options, "preprocessing_threads", -1);
       params.executorsPerRunner   = optionValue<int>(options, "executors_per_runner", -1);

--- a/nvmolkit/mcs.py
+++ b/nvmolkit/mcs.py
@@ -279,8 +279,8 @@ def findMCS(
     second_molecule_index)`` atom or bond index pairs.
 
     Fallback behavior:
-        Molecule pairs outside the native GPU limits (currently more than 128
-        atoms, more than 128 bonds, or atom degree greater than 8), and pairs
+        Molecule pairs outside the native GPU limits (currently 128 or more
+        atoms or bonds, or atom degree greater than 8), and pairs
         whose GPU search queue overflows, transparently use RDKit on the CPU.
         Set ``require_gpu=True`` to raise instead.  This fallback is
         pair-specific; unsupported search options listed below raise for the

--- a/nvmolkit/mcs.py
+++ b/nvmolkit/mcs.py
@@ -119,8 +119,6 @@ class MCSConfig:
     Args:
         batchSize: Optional GPU batch chunk size. ``0`` processes each
             nonempty size tier as one chunk.
-        blockSize: CUDA threads per fMCS pair block. Supported values are
-            ``64``, ``128``, ``256``, and ``512``.
         workerThreads: GPU runner threads per GPU. ``-1`` autoselects.
         preprocessingThreads: CPU threads for pair preprocessing. ``-1``
             autoselects.
@@ -133,7 +131,6 @@ class MCSConfig:
     def __init__(
         self,
         batchSize: int = 0,
-        blockSize: int = 128,
         workerThreads: int = -1,
         preprocessingThreads: int = -1,
         executorsPerRunner: int = -1,
@@ -141,7 +138,6 @@ class MCSConfig:
     ) -> None:
         """Initialize GPU execution settings."""
         self.batchSize = int(batchSize)
-        self.blockSize = int(blockSize)
         self.workerThreads = int(workerThreads)
         self.preprocessingThreads = int(preprocessingThreads)
         self.executorsPerRunner = int(executorsPerRunner)
@@ -151,7 +147,6 @@ class MCSConfig:
         """Return a JSON-serializable dictionary of this object's fields."""
         return {
             "batchSize": self.batchSize,
-            "blockSize": self.blockSize,
             "workerThreads": self.workerThreads,
             "preprocessingThreads": self.preprocessingThreads,
             "executorsPerRunner": self.executorsPerRunner,
@@ -162,7 +157,6 @@ class MCSConfig:
         """Return keyword arguments accepted by :func:`findMCS`."""
         return {
             "batch_size": self.batchSize,
-            "block_size": self.blockSize,
             "worker_threads": self.workerThreads,
             "preprocessing_threads": self.preprocessingThreads,
             "executors_per_runner": self.executorsPerRunner,
@@ -174,7 +168,6 @@ class MCSConfig:
         """Create an :class:`MCSConfig` from a dictionary produced by :meth:`to_dict`."""
         known = {
             "batchSize",
-            "blockSize",
             "workerThreads",
             "preprocessingThreads",
             "executorsPerRunner",
@@ -253,7 +246,6 @@ def findMCS(
     timeout_seconds: int = 0,
     config: MCSConfig | None = None,
     batch_size: int = 0,
-    block_size: int = 128,
     worker_threads: int = -1,
     preprocessing_threads: int = -1,
     executors_per_runner: int = -1,
@@ -356,8 +348,6 @@ def findMCS(
             be combined with explicit GPU execution keyword options.
         batch_size: Optional GPU batch chunk size. ``0`` processes each
             nonempty size tier as one chunk.
-        block_size: CUDA threads per fMCS pair block. Supported values are
-            ``64``, ``128``, ``256``, and ``512``.
         worker_threads: GPU runner threads per GPU. ``-1`` autoselects.
         preprocessing_threads: CPU threads for pair preprocessing. ``-1``
             autoselects.
@@ -376,8 +366,6 @@ def findMCS(
         explicit_options = []
         if batch_size != 0:
             explicit_options.append("batch_size")
-        if block_size != 128:
-            explicit_options.append("block_size")
         if worker_threads != -1:
             explicit_options.append("worker_threads")
         if preprocessing_threads != -1:
@@ -390,7 +378,6 @@ def findMCS(
             joined = ", ".join(explicit_options)
             raise ValueError(f"config cannot be combined with explicit GPU execution options: {joined}")
         batch_size = config.batchSize
-        block_size = config.blockSize
         worker_threads = config.workerThreads
         preprocessing_threads = config.preprocessingThreads
         executors_per_runner = config.executorsPerRunner
@@ -446,7 +433,6 @@ def findMCS(
             "require_gpu": bool(require_gpu),
             "timeout_seconds": int(timeout_seconds),
             "batch_size": int(batch_size),
-            "block_size": int(block_size),
             "worker_threads": int(worker_threads),
             "preprocessing_threads": int(preprocessing_threads),
             "executors_per_runner": int(executors_per_runner),

--- a/nvmolkit/tests/test_autotune.py
+++ b/nvmolkit/tests/test_autotune.py
@@ -218,7 +218,6 @@ def test_save_load_substruct_config_roundtrip(tmp_path):
 def test_mcs_config_to_from_dict_roundtrip():
     config = MCSConfig(
         batchSize=256,
-        blockSize=512,
         workerThreads=2,
         preprocessingThreads=4,
         executorsPerRunner=3,
@@ -233,7 +232,6 @@ def test_mcs_config_to_from_dict_roundtrip():
 def test_save_load_mcs_config_roundtrip(tmp_path):
     config = MCSConfig(
         batchSize=128,
-        blockSize=256,
         workerThreads=2,
         preprocessingThreads=6,
         executorsPerRunner=4,
@@ -335,7 +333,6 @@ def test_default_mcs_search_space_covers_supported_execution_settings():
     space = _default_mcs_search_space(num_gpus=4, cpus=16)
 
     assert space["batchSize"] == [0, 64, 128, 256, 512]
-    assert space["blockSize"] == [64, 128, 256, 512]
     assert space["workerThreads"] == (1, 4)
     assert space["preprocessingThreads"] == (1, 16)
     assert space["executorsPerRunner"] == (1, 8)
@@ -614,7 +611,6 @@ def test_tune_mcs_smoke():
         calibration_max_size=len(pairs),
         search_space_overrides={
             "batchSize": [0, 64, 128, 256],
-            "blockSize": [64, 128, 256, 512],
             "workerThreads": 1,
             "preprocessingThreads": 1,
             "executorsPerRunner": 1,
@@ -626,7 +622,6 @@ def test_tune_mcs_smoke():
     assert result.best_throughput > 0
     assert result.n_trials_run == 2
     assert result.calibration_size == len(pairs)
-    assert result.best_config.blockSize in {64, 128, 256, 512}
     assert result.best_config.gpuIds == [0]
 
     final = findMCS(mols, mode="pairs", pairs=pairs, require_gpu=True, config=result.best_config)

--- a/nvmolkit/tests/test_mcs.py
+++ b/nvmolkit/tests/test_mcs.py
@@ -143,7 +143,6 @@ def test_pairs_mode_chunked_multi_executor_matches_rdkit():
         mode="pairs",
         pairs=pairs,
         batch_size=1,
-        block_size=64,
         executors_per_runner=2,
     )
 
@@ -160,7 +159,6 @@ def test_pairs_mode_threaded_gpu_options_match_rdkit():
         mode="pairs",
         pairs=pairs,
         batch_size=1,
-        block_size=256,
         worker_threads=2,
         preprocessing_threads=2,
         executors_per_runner=1,
@@ -176,7 +174,6 @@ def test_config_path_matches_rdkit_and_rejects_duplicate_execution_options():
     pairs = [(0, 1), (2, 3)]
     config = MCSConfig(
         batchSize=1,
-        blockSize=64,
         workerThreads=1,
         preprocessingThreads=1,
         executorsPerRunner=1,
@@ -188,7 +185,7 @@ def test_config_path_matches_rdkit_and_rejects_duplicate_execution_options():
     _assert_matches_rdkit(result, mols)
 
     with pytest.raises(ValueError, match="config cannot be combined"):
-        findMCS(mols, mode="pairs", pairs=pairs, config=config, block_size=256)
+        findMCS(mols, mode="pairs", pairs=pairs, config=config, batch_size=2)
 
 
 def test_all_pairs_default_is_upper_triangle_with_diagonal():
@@ -267,8 +264,6 @@ def test_invalid_mode_and_optional_arguments():
         findMCS(mols, mode="pairs", pairs=[(0, 1)], atom_compare="mass")
     with pytest.raises(ValueError, match="Unsupported bond_compare"):
         findMCS(mols, mode="pairs", pairs=[(0, 1)], bond_compare="shape")
-    with pytest.raises(ValueError, match="blockSize"):
-        findMCS(mols, mode="pairs", pairs=[(0, 1)], block_size=32)
 
 
 def test_out_of_range_pair_raises_from_native_layer():
@@ -418,23 +413,6 @@ def test_special_molecule_semantics_match_rdkit(smiles_a, smiles_b, kwargs, expe
 
     _assert_matches_rdkit(result, mols, **kwargs)
     assert (result[0].num_atoms, result[0].num_bonds) == (expected_atoms, expected_bonds)
-
-
-@pytest.mark.parametrize("block_size", [64, 128, 256, 512])
-def test_supported_block_sizes_match_rdkit(block_size):
-    mols = _mols(["CCOC(=O)N", "CCNC(=O)O"])
-    result = findMCS(
-        mols,
-        mode="pairs",
-        pairs=[(0, 1)],
-        block_size=block_size,
-        worker_threads=1,
-        preprocessing_threads=1,
-        executors_per_runner=1,
-        require_gpu=True,
-    )
-
-    _assert_matches_rdkit(result, mols)
 
 
 def test_higher_dispatch_tiers_and_pair_orientation_match_rdkit():

--- a/nvmolkit/tests/test_mcs.py
+++ b/nvmolkit/tests/test_mcs.py
@@ -499,6 +499,15 @@ def test_rdkit_fallback_is_transparent_and_require_gpu_rejects_it():
         findMCS([hypervalent], mode="pairs", pairs=[(0, 0)], require_gpu=True)
 
 
+def test_require_gpu_rejects_size_128():
+    chain = Chem.MolFromSmiles("C" * 128)
+    assert chain.GetNumAtoms() == 128
+    assert chain.GetNumBonds() == 127
+
+    with pytest.raises(RuntimeError, match="GPU MCS path unavailable"):
+        findMCS([chain], mode="pairs", pairs=[(0, 0)], require_gpu=True)
+
+
 @pytest.mark.parametrize(
     "kwargs,error",
     [

--- a/src/mcs/fmcs_cuda/fmcs.cu
+++ b/src/mcs/fmcs_cuda/fmcs.cu
@@ -163,8 +163,8 @@ HostPairDescriptor buildPairDescriptor(const InputT& sideA, const InputT& sideB,
   return desc;
 }
 
-/// Owning device allocations for one tier sub-batch. Results, queue, and
-/// scratch element types depend on the selected tier, so their storage is
+/// Owning device allocations for one tier sub-batch. Result and queue
+/// element types depend on the selected tier, so their storage is
 /// type-erased as bytes. The queue storage is one contiguous global-memory slab of
 /// @c kFmcsQueueCapacity * numPairs QueuedSeed entries; per-block slices
 /// are taken inside the kernel via @c blockIdx.x.
@@ -173,7 +173,6 @@ struct BatchDeviceBuffers {
   nvMolKit::AsyncDeviceVector<DevicePerPairInput> pairInputs;
   nvMolKit::AsyncDeviceVector<std::byte>          resultsStorage;
   nvMolKit::AsyncDeviceVector<std::byte>          queueStorage;
-  nvMolKit::AsyncDeviceVector<std::byte>          scratchStorage;
 };
 
 constexpr int    kMaxFmcsExecutorsPerRunner = 8;
@@ -192,7 +191,6 @@ struct DeviceRequirements {
   size_t pairInputCount  = 0;
   size_t resultBytes     = 0;
   size_t queueBytes      = 0;
-  size_t scratchBytes    = 0;
 };
 
 struct FmcsPinnedHostBuffer {
@@ -264,7 +262,6 @@ struct FmcsExecutor {
       nvMolKit::AsyncDeviceVector<DevicePerPairInput>(deviceRequirements.pairInputCount, stream);
     deviceBuffers.resultsStorage = nvMolKit::AsyncDeviceVector<std::byte>(deviceRequirements.resultBytes, stream);
     deviceBuffers.queueStorage   = nvMolKit::AsyncDeviceVector<std::byte>(deviceRequirements.queueBytes, stream);
-    deviceBuffers.scratchStorage = nvMolKit::AsyncDeviceVector<std::byte>(deviceRequirements.scratchBytes, stream);
   }
 };
 
@@ -274,13 +271,6 @@ int validateRequestedExecutorCount(const Parameters& params) {
                                 std::to_string(kMaxFmcsExecutorsPerRunner));
   }
   return params.executorsPerRunner;
-}
-
-int validateRequestedBlockSize(const Parameters& params) {
-  if (params.blockSize == 64 || params.blockSize == 128 || params.blockSize == 256 || params.blockSize == 512) {
-    return params.blockSize;
-  }
-  throw std::invalid_argument("fMCS blockSize must be one of 64, 128, 256, or 512");
 }
 
 std::vector<PairMatchTablesDevice> uploadPairMatchTablesToStorage(const std::vector<PairMatchTablesHost>& host,
@@ -389,7 +379,7 @@ void uploadCsrAndAssemblePairInputs(const std::vector<HostPairDescriptor*>&   de
     "cudaMemcpyAsync (packed CSR)");
 }
 
-template <int blockThreads, int maxAtoms, int maxBonds, class Policy>
+template <int maxAtoms, int maxBonds>
 void launchTierAsync(std::span<const DevicePerPairInput> hostPairInputs,
                      const Parameters&                   params,
                      cudaStream_t                        stream,
@@ -421,17 +411,6 @@ void launchTierAsync(std::span<const DevicePerPairInput> hostPairInputs,
   }
   auto* dQueue = reinterpret_cast<QueuedT*>(bufs.queueStorage.data());
 
-  using ScratchT     = FmcsSubstructureScratch<maxAtoms, maxAtoms>;
-  ScratchT* dScratch = nullptr;
-  if constexpr (kUseGlobalSubstructureScratch<blockThreads, maxAtoms>) {
-    const size_t scratchBytes =
-      static_cast<size_t>(numPairs) * static_cast<size_t>(FmcsBlockConfig<blockThreads>::numGroups) * sizeof(ScratchT);
-    if (bufs.scratchStorage.size() < scratchBytes) {
-      throw std::out_of_range("Device scratch buffer is too small");
-    }
-    dScratch = reinterpret_cast<ScratchT*>(bufs.scratchStorage.data());
-  }
-
   unsigned long long timeoutClocks = 0;
   if (params.timeoutMs > 0.0f) {
     int device = 0;
@@ -443,18 +422,24 @@ void launchTierAsync(std::span<const DevicePerPairInput> hostPairInputs,
       std::max(1.0, static_cast<double>(params.timeoutMs) * static_cast<double>(clockRateKHz)));
   }
 
-  // Block size is selected from compile-time kernel specializations so the
-  // kernel's per-group state arrays stay statically sized.
+  // One block per pair; block size and shared-state footprint are fixed by
+  // the tier (FmcsKernelConfig).  The block state exceeds the default 48 KB
+  // static shared limit, so it lives in dynamic shared memory with the
+  // opt-in attribute; the tier-128 layout is sized to fit the 64 KB cap of
+  // the smallest supported architectures (see FmcsKernelConfig).
+  constexpr size_t kSharedBytes = sizeof(FmcsPairShared<maxAtoms, maxBonds>);
+  static_assert(kSharedBytes <= 64 * 1024, "fMCS block state must fit the 64 KB opt-in shared-memory limit");
   dim3 grid(static_cast<unsigned>(numPairs));
-  dim3 block(static_cast<unsigned>(blockThreads));
-  fmcsKernel<maxAtoms, maxBonds, blockThreads, Policy, kUseGlobalSubstructureScratch<blockThreads, maxAtoms>>
-    <<<grid, block, 0, stream>>>(bufs.pairInputs.data(),
-                                 dResults,
-                                 dQueue,
-                                 dScratch,
-                                 kFmcsQueueCapacity,
-                                 numPairs,
-                                 timeoutClocks);
+  dim3 block(static_cast<unsigned>(FmcsKernelConfig<maxAtoms>::blockThreads));
+  auto kernel = fmcsKernel<maxAtoms, maxBonds>;
+  checkCuda(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(kSharedBytes)),
+            "cudaFuncSetAttribute (fmcsKernel)");
+  kernel<<<grid, block, kSharedBytes, stream>>>(bufs.pairInputs.data(),
+                                                dResults,
+                                                dQueue,
+                                                kFmcsQueueCapacity,
+                                                numPairs,
+                                                timeoutClocks);
   checkCuda(cudaGetLastError(), "fmcsKernel launch");
 }
 
@@ -532,7 +517,7 @@ std::unique_ptr<TierChunk<maxAtoms, maxBonds, Policy>> makeTierChunk(const std::
   return chunk;
 }
 
-template <int blockThreads, int maxAtoms, int maxBonds, class Policy>
+template <int maxAtoms, int maxBonds, class Policy>
 void enqueueTierChunks(const std::vector<HostPairDescriptor*>&              descs,
                        const std::vector<int>&                              indices,
                        size_t                                               chunkSize,
@@ -561,19 +546,12 @@ void enqueueTierChunks(const std::vector<HostPairDescriptor*>&              desc
     using QueuedT = QueuedSeed<maxAtoms, maxBonds, maxAtoms, maxBonds>;
     deviceRequirements.queueBytes =
       std::max(deviceRequirements.queueBytes, (end - begin) * kFmcsQueueCapacity * sizeof(QueuedT));
-    if constexpr (kUseGlobalSubstructureScratch<blockThreads, maxAtoms>) {
-      using ScratchT = FmcsSubstructureScratch<maxAtoms, maxAtoms>;
-      deviceRequirements.scratchBytes =
-        std::max(deviceRequirements.scratchBytes,
-                 (end - begin) * static_cast<size_t>(FmcsBlockConfig<blockThreads>::numGroups) * sizeof(ScratchT));
-    }
-
     TierChunkVariant<Policy> item = std::move(chunk);
     chunkQueue.push(std::move(item));
   }
 }
 
-template <int blockThreads, int maxAtoms, int maxBonds, class Policy>
+template <int maxAtoms, int maxBonds, class Policy>
 void launchTierChunk(FmcsExecutor&                                           executor,
                      std::unique_ptr<TierChunk<maxAtoms, maxBonds, Policy>>& chunk,
                      const Parameters&                                       params) {
@@ -593,7 +571,7 @@ void launchTierChunk(FmcsExecutor&                                           exe
                                  executorStream,
                                  executor.deviceBuffers.csrStorage);
 
-  launchTierAsync<blockThreads, maxAtoms, maxBonds, Policy>(
+  launchTierAsync<maxAtoms, maxBonds>(
     std::span<const DevicePerPairInput>(executor.pinnedHost.pairInputs.data(), numPairs),
     params,
     executorStream,
@@ -636,7 +614,7 @@ void drainTierChunk(FmcsExecutor&                                           exec
   }
 }
 
-template <int blockThreads, class Policy>
+template <class Policy>
 void runTierChunks(nvMolKit::ThreadSafeQueue<TierChunkVariant<Policy>>& chunkQueue,
                    size_t                                               numChunks,
                    const PinnedHostRequirements&                        pinnedRequirements,
@@ -669,7 +647,7 @@ void runTierChunks(nvMolKit::ThreadSafeQueue<TierChunkVariant<Policy>>& chunkQue
     std::visit(
       [&](auto& typedChunk) {
         if (typedChunk) {
-          launchTierChunk<blockThreads>(executor, typedChunk, params);
+          launchTierChunk(executor, typedChunk, params);
         }
       },
       chunk);
@@ -688,11 +666,11 @@ void runTierChunks(nvMolKit::ThreadSafeQueue<TierChunkVariant<Policy>>& chunkQue
   nvMolKit::runQueuedExecutorRing(executors, chunkQueue, launchChunk, drainChunk);
 }
 
-template <int blockThreads, class Policy, class InputT>
-std::vector<MCSResult> runBatchWithBlockSize(const std::vector<InputT>& a,
-                                             const std::vector<InputT>& b,
-                                             Parameters                 params,
-                                             cudaStream_t               stream) {
+template <class Policy, class InputT>
+std::vector<MCSResult> runBatch(const std::vector<InputT>& a,
+                                const std::vector<InputT>& b,
+                                Parameters                 params,
+                                cudaStream_t               stream) {
   if (a.size() != b.size()) {
     throw std::runtime_error("fMCS batch: graphsA and graphsB must have equal length");
   }
@@ -729,58 +707,34 @@ std::vector<MCSResult> runBatchWithBlockSize(const std::vector<InputT>& a,
   nvMolKit::ThreadSafeQueue<TierChunkVariant<Policy>> chunkQueue;
   PinnedHostRequirements                              pinnedRequirements;
   DeviceRequirements                                  deviceRequirements;
-  enqueueTierChunks<blockThreads, 16, 16, Policy>(descPtrs,
-                                                  tierIndices[0],
-                                                  chunkSize,
-                                                  chunkQueue,
-                                                  pinnedRequirements,
-                                                  deviceRequirements);
-  enqueueTierChunks<blockThreads, 32, 32, Policy>(descPtrs,
-                                                  tierIndices[1],
-                                                  chunkSize,
-                                                  chunkQueue,
-                                                  pinnedRequirements,
-                                                  deviceRequirements);
-  enqueueTierChunks<blockThreads, 64, 64, Policy>(descPtrs,
-                                                  tierIndices[2],
-                                                  chunkSize,
-                                                  chunkQueue,
-                                                  pinnedRequirements,
-                                                  deviceRequirements);
-  enqueueTierChunks<blockThreads, 128, 128, Policy>(descPtrs,
-                                                    tierIndices[3],
-                                                    chunkSize,
-                                                    chunkQueue,
-                                                    pinnedRequirements,
-                                                    deviceRequirements);
-  chunkQueue.close();
-  runTierChunks<blockThreads, Policy>(chunkQueue,
-                                      numChunks,
+  enqueueTierChunks<16, 16, Policy>(descPtrs,
+                                    tierIndices[0],
+                                    chunkSize,
+                                    chunkQueue,
+                                    pinnedRequirements,
+                                    deviceRequirements);
+  enqueueTierChunks<32, 32, Policy>(descPtrs,
+                                    tierIndices[1],
+                                    chunkSize,
+                                    chunkQueue,
+                                    pinnedRequirements,
+                                    deviceRequirements);
+  enqueueTierChunks<64, 64, Policy>(descPtrs,
+                                    tierIndices[2],
+                                    chunkSize,
+                                    chunkQueue,
+                                    pinnedRequirements,
+                                    deviceRequirements);
+  enqueueTierChunks<128, 128, Policy>(descPtrs,
+                                      tierIndices[3],
+                                      chunkSize,
+                                      chunkQueue,
                                       pinnedRequirements,
-                                      deviceRequirements,
-                                      params,
-                                      stream,
-                                      results);
+                                      deviceRequirements);
+  chunkQueue.close();
+  runTierChunks<Policy>(chunkQueue, numChunks, pinnedRequirements, deviceRequirements, params, stream, results);
 
   return results;
-}
-
-template <class Policy, class InputT>
-std::vector<MCSResult> runBatch(const std::vector<InputT>& a,
-                                const std::vector<InputT>& b,
-                                Parameters                 params,
-                                cudaStream_t               stream) {
-  switch (validateRequestedBlockSize(params)) {
-    case 64:
-      return runBatchWithBlockSize<64, Policy, InputT>(a, b, params, stream);
-    case 128:
-      return runBatchWithBlockSize<128, Policy, InputT>(a, b, params, stream);
-    case 256:
-      return runBatchWithBlockSize<256, Policy, InputT>(a, b, params, stream);
-    case 512:
-      return runBatchWithBlockSize<512, Policy, InputT>(a, b, params, stream);
-  }
-  throw std::logic_error("unreachable fMCS blockSize dispatch");
 }
 
 }  // namespace

--- a/src/mcs/fmcs_cuda/fmcs.cuh
+++ b/src/mcs/fmcs_cuda/fmcs.cuh
@@ -54,10 +54,6 @@ inline constexpr int kMaxNeighborsPerAtom = 8;
 /// The objective (connected MCES, MaximizeBonds, Threshold=1) is baked
 /// into the algorithm itself and is not exposed as a knob.
 struct Parameters {
-  /// CUDA block size for the per-pair kernel. Supported: 64, 128, 256, 512.
-  /// Tier-128 searches at 512 threads place substructure scratch in global
-  /// memory; smaller tiers retain shared-memory scratch.
-  int   blockSize          = 128;
   /// Per-pair wall timeout in milliseconds.  0 = no timeout.
   float timeoutMs          = 0;
   /// Max pairs per kernel launch in the batch API.  0 = no explicit limit;

--- a/src/mcs/fmcs_cuda/fmcs_grow.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_grow.cuh
@@ -69,7 +69,9 @@ __device__ __forceinline__ void seedAddNewBondWithinThread(Seed<maxAtoms, maxBon
 template <int maxAtoms, int maxBonds, class GroupT>
 __device__ __forceinline__ bool fillNewBondsCooperative(const GroupT&                   group,
                                                         const Seed<maxAtoms, maxBonds>& seed,
-                                                        const DeviceCsrView&            queryTopology,
+                                                        const std::uint8_t*             bondEndpointsU,
+                                                        const std::uint8_t*             bondEndpointsV,
+                                                        int                             numQueryBonds,
                                                         NewBond*                        outBonds,
                                                         int*                            outCount,
                                                         int                             maxNewBonds) {
@@ -86,16 +88,15 @@ __device__ __forceinline__ bool fillNewBondsCooperative(const GroupT&           
     *outCount = 0;
   group.sync();
 
-  for (int q = laneRank; q < queryTopology.numBonds; q += laneCount) {
+  for (int q = laneRank; q < numQueryBonds; q += laneCount) {
     // Excluded check first (cheapest).
     const BondWord excludedBondsWord = seed.excludedBonds[q / kBondBitsPerWord];
     if ((excludedBondsWord >> (q % kBondBitsPerWord)) & 1)
       continue;
 
-    // Decode this query bond's endpoints.
-    const std::uint32_t queryEndpoints = queryTopology.bondEndpoints[q];
-    const int           queryEndpointU = static_cast<int>(queryEndpoints >> kBondEndpointShift);
-    const int           queryEndpointV = static_cast<int>(queryEndpoints & kBondEndpointMask);
+    // This query bond's endpoints (byte-packed, typically block-shared).
+    const int queryEndpointU = bondEndpointsU[q];
+    const int queryEndpointV = bondEndpointsV[q];
 
     // Bond is a "new boundary" candidate iff at least one endpoint
     // was added in the most recent grow step.

--- a/src/mcs/fmcs_cuda/fmcs_kernel.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_kernel.cuh
@@ -450,10 +450,13 @@ enum class MaxSizeTier {
   k128,
 };
 
-/// Smallest tier whose bitset width covers both counts.  Returns -1 when
-/// the largest tier (128) does not fit; the caller must flag
-/// @ref MCSResult::overflowed.
+/// Smallest tier whose bitset width covers both counts. Tier 128 is reserved
+/// for counts below 128 because its byte-packed CSR row offsets cannot
+/// represent the 256 directed entries produced by 128 bonds. Returns -1 when
+/// the largest tier does not fit; the caller must flag @ref MCSResult::overflowed.
 inline int pickMaxSizeTier(int numAtoms, int numBonds) {
+  if (numAtoms >= 128 || numBonds >= 128)
+    return -1;
   const int need = numAtoms > numBonds ? numAtoms : numBonds;
   if (need <= 16)
     return 0;
@@ -461,7 +464,7 @@ inline int pickMaxSizeTier(int numAtoms, int numBonds) {
     return 1;
   if (need <= 64)
     return 2;
-  if (need <= 128)
+  if (need < 128)
     return 3;
   return -1;
 }

--- a/src/mcs/fmcs_cuda/fmcs_kernel.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_kernel.cuh
@@ -9,305 +9,262 @@
 namespace mcs {
 namespace fmcs {
 
-/// Tier-128 per-group substructure scratch does not fit in shared memory once
-/// a block runs more than four warp groups, so those specializations take the
-/// scratch from a global-memory slab instead.
-template <int blockThreads, int maxAtoms>
-inline constexpr bool kUseGlobalSubstructureScratch = maxAtoms == 128 && blockThreads >= 256;
+// One block per pair.  Same search semantics as RDKit's fMCS seed-grow with
+// exact per-seed substructure verification and the stage 0/1/2 subset
+// enumeration, restructured for the GPU:
+//
+//   Phase 1 tests every query bond's one-bond embedding directly in parallel
+//   -- whether bond q embeds depends only on q -- and reduces RDKit's
+//   sequential prefix/failed-bond exclusion bookkeeping to bitmask algebra.
+//
+//   Phase 2 runs FmcsKernelConfig::numGroups 32-lane grow groups against the
+//   block's atomic LIFO worklist; all pair-invariant data is block-shared
+//   (loadPairSharedCooperative) and the per-seed exact check runs on the
+//   shared subgraph DFS core (fmcs_match.cuh).
+template <int maxAtoms, int maxBonds>
+__global__ __launch_bounds__(FmcsKernelConfig<maxAtoms>::blockThreads) void fmcsKernel(
+  const DevicePerPairInput* __restrict__ pairs,
+  DeviceMCSResult<maxAtoms, maxBonds>* __restrict__ results,
+  QueuedSeed<maxAtoms, maxBonds, maxAtoms, maxBonds>* __restrict__ queueStorageAll,
+  int                queueCapacity,
+  int                numPairs,
+  unsigned long long timeoutClocks) {
+  using SharedT              = FmcsPairShared<maxAtoms, maxBonds>;
+  using QueuedT              = typename SharedT::QueuedT;
+  using AtomMask             = typename SharedT::AtomMask;
+  using BondMask             = typename SharedT::BondMask;
+  constexpr int kNumGroups   = SharedT::kNumGroups;
+  constexpr int blockThreads = FmcsKernelConfig<maxAtoms>::blockThreads;
 
-template <int maxAtoms, int maxBonds, int blockThreads, class Policy, bool GlobalSubstructureScratch = false>
-__global__ void fmcsKernel(const DevicePerPairInput* __restrict__ pairs,
-                           DeviceMCSResult<maxAtoms, maxBonds>* __restrict__ results,
-                           QueuedSeed<maxAtoms, maxBonds, maxAtoms, maxBonds>* __restrict__ queueStorageAll,
-                           FmcsSubstructureScratch<maxAtoms, maxAtoms>* __restrict__ scratchStorageAll,
-                           int                queueCapacity,
-                           int                numPairs,
-                           unsigned long long timeoutClocks) {
-  const int pairIdx = blockIdx.x;
+  extern __shared__ __align__(16) char sharedRaw[];
+  SharedT&                             S = *reinterpret_cast<SharedT*>(sharedRaw);
+
+  const int pairIdx = static_cast<int>(blockIdx.x);
   if (pairIdx >= numPairs)
     return;
 
-  auto                      block = cg::this_thread_block();
-  const DevicePerPairInput& pair  = pairs[pairIdx];
+  auto      block   = cg::this_thread_block();
+  auto      group   = cg::tiled_partition<kFmcsGroupSize>(block);
+  const int tid     = static_cast<int>(block.thread_rank());
+  const int groupId = tid / kFmcsGroupSize;
+  const int lane    = static_cast<int>(group.thread_rank());
 
-  using QueuedT                     = QueuedSeed<maxAtoms, maxBonds, maxAtoms, maxBonds>;
-  using SubstructureScratchT        = FmcsSubstructureScratch<maxAtoms, maxAtoms>;
-  constexpr int kMaxNewBondsForTier = maxBonds;
-  constexpr int kNumGroups          = FmcsBlockConfig<blockThreads>::numGroups;
+  const DevicePerPairInput& pair = pairs[pairIdx];
+  DeviceCsrView             queryView;
+  queryView.rowOffsets    = pair.queryRowOffsets;
+  queryView.colIndices    = pair.queryColIndices;
+  queryView.bondIndices   = pair.queryBondIndices;
+  queryView.bondEndpoints = pair.queryBondEndpoints;
+  queryView.numAtoms      = pair.queryNumAtoms;
+  queryView.numBonds      = pair.queryNumBonds;
+  DeviceCsrView targetView;
+  targetView.rowOffsets    = pair.targetRowOffsets;
+  targetView.colIndices    = pair.targetColIndices;
+  targetView.bondIndices   = pair.targetBondIndices;
+  targetView.bondEndpoints = pair.targetBondEndpoints;
+  targetView.numAtoms      = pair.targetNumAtoms;
+  targetView.numBonds      = pair.targetNumBonds;
 
-  // Block-shared resources: the queue, the incumbent, and the early-exit
-  // flags are visible to every group. Cross-group queue/incumbent updates use
-  // atomics; loop-control reads are made uniform before any branch that can
-  // skip a later block/group rendezvous.
-  __shared__ SeedQueue<QueuedT, ThreadBlockScope> queue;
-  __shared__ __align__(16) unsigned char bestStorage[sizeof(QueuedT)];
-  QueuedT&                               best = *reinterpret_cast<QueuedT*>(bestStorage);
-  // Atomic incumbent score: high 16 bits = numBonds, low 16 bits =
-  // numAtoms.  Groups race through atomicCAS on this single int to
-  // claim the right to write @c best.
-  __shared__ unsigned int                bestScore;
-  __shared__ int                         bestCopyLock;
-  __shared__ DeviceCsrView               queryView;
-  __shared__ DeviceCsrView               targetView;
-  __shared__ bool                        overflowed;
-  __shared__ bool                        timedOut;
-  __shared__ bool                        phase2Done;
-  __shared__ unsigned long long          startClock;
-  SubstructureScratchT*                  substructureScratch;
-  if constexpr (GlobalSubstructureScratch) {
-    substructureScratch = scratchStorageAll + static_cast<size_t>(pairIdx) * kNumGroups;
-  } else {
-    (void)scratchStorageAll;
-    __shared__ SubstructureScratchT sharedSubstructureScratch[kNumGroups];
-    substructureScratch = sharedSubstructureScratch;
+  if (tid == 0) {
+    S.startClock = clock64();
+    S.queue.init(queueStorageAll + static_cast<size_t>(pairIdx) * queueCapacity, queueCapacity);
   }
+  loadPairSharedCooperative(S, queryView, targetView, pair.tables, tid, blockThreads);
 
-  // Cooperative Phase 2 working state.  Approach 1 gives each warp group an
-  // independent seed workspace and fallback scratch so groups can pop and
-  // grow seeds concurrently.
-  __shared__ __align__(16) unsigned char currentStorage[sizeof(QueuedT) * kNumGroups];
-  __shared__ __align__(16) unsigned char biggestStorage[sizeof(QueuedT) * kNumGroups];
-  QueuedT*                               current = reinterpret_cast<QueuedT*>(currentStorage);
-  QueuedT*                               biggest = reinterpret_cast<QueuedT*>(biggestStorage);
-  __shared__ NewBond                     newBondsArr[kNumGroups][kMaxNewBondsForTier];
-  __shared__ int                         newBondCount[kNumGroups];
-  __shared__ bool                        popped[kNumGroups];
-  __shared__ bool                        stage0Ok[kNumGroups];
-  __shared__ std::uint8_t remainingAtomStack[kNumGroups][maxAtoms];
-  __shared__ typename Seed<maxAtoms, maxBonds>::atom_word_type
-    remainingVisitedAtoms[kNumGroups][Seed<maxAtoms, maxBonds>::kAtomWords];
-  __shared__ typename Seed<maxAtoms, maxBonds>::bond_word_type
-                 remainingVisitedBonds[kNumGroups][Seed<maxAtoms, maxBonds>::kBondWords];
-  __shared__ int remainingStackSize[kNumGroups];
-  __shared__
-    typename Seed<maxAtoms, maxBonds>::bond_word_type initialExcludedBonds[Seed<maxAtoms, maxBonds>::kBondWords];
-
-  auto                  group                 = cg::tiled_partition<kFmcsGroupSize>(block);
-  const int             groupId               = static_cast<int>(block.thread_rank()) / kFmcsGroupSize;
-  const int             groupRank             = static_cast<int>(group.thread_rank());
-  SubstructureScratchT& mySubstructureScratch = substructureScratch[groupId];
-
-  QueuedT* myQueueStorage = queueStorageAll + static_cast<size_t>(pairIdx) * queueCapacity;
-
-  if (block.thread_rank() == 0) {
-    queue.init(myQueueStorage, queueCapacity);
-    seedClearWithinThread(best.seed);
-    matchResultClearWithinThread(best.match);
-    bestScore    = 0;
-    bestCopyLock = 0;
-    overflowed   = false;
-    timedOut     = false;
-    phase2Done   = false;
-    startClock   = clock64();
-
-    queryView.rowOffsets    = pair.queryRowOffsets;
-    queryView.colIndices    = pair.queryColIndices;
-    queryView.bondIndices   = pair.queryBondIndices;
-    queryView.bondEndpoints = pair.queryBondEndpoints;
-    queryView.numAtoms      = pair.queryNumAtoms;
-    queryView.numBonds      = pair.queryNumBonds;
-
-    targetView.rowOffsets    = pair.targetRowOffsets;
-    targetView.colIndices    = pair.targetColIndices;
-    targetView.bondIndices   = pair.targetBondIndices;
-    targetView.bondEndpoints = pair.targetBondEndpoints;
-    targetView.numAtoms      = pair.targetNumAtoms;
-    targetView.numBonds      = pair.targetNumBonds;
+  // Clear the incumbent.
+  if (tid == 0) {
+    seedClearWithinThread(S.best.seed);
+    matchResultClearWithinThread(S.best.match);
   }
-  block.sync();
+  __syncthreads();
 
-  QueuedT&      myCurrent               = current[groupId];
-  QueuedT&      myBiggest               = biggest[groupId];
-  NewBond*      myNewBonds              = newBondsArr[groupId];
-  std::uint8_t* myRemainingAtomStack    = remainingAtomStack[groupId];
-  auto*         myRemainingVisitedAtoms = remainingVisitedAtoms[groupId];
-  auto*         myRemainingVisitedBonds = remainingVisitedBonds[groupId];
+  const int qNB = S.qNB;
 
   // ---- Phase 1: RDKit makeInitialSeeds() analogue ----
-  // RDKit creates one initial seed per query bond, not one per target
-  // embedding.  Each candidate goes through checkIfMatchAndAppend(), which
-  // runs substructure matching and stores one witness MatchResult on success.
-  // Initial ExcludedBonds is prefix-like: later initial seeds exclude earlier
-  // query bonds, and a mismatched initial bond is also excluded from seeds
-  // already admitted.  Group 0 handles this serial state; the substructure
-  // check remains cooperative across that group's lanes.
-  if (block.thread_rank() < Seed<maxAtoms, maxBonds>::kBondWords) {
-    initialExcludedBonds[block.thread_rank()] = 0;
+  // One thread per query bond runs the direct single-bond match; the
+  // matched/unmatched partition then yields each seed's exclusion set in
+  // closed form: RDKit's prefix exclusion plus its retroactive exclusion of
+  // later bonds that failed their own initial match.
+  if (tid < qNB) {
+    SingleBondMatch m;
+    const bool      ok      = matchSingleBondWithinThread(S, tid, m);
+    S.phase1TargetBond[tid] = ok ? m.targetBond : kUnmappedTargetIdx;
+    S.phase1AtomU[tid]      = ok ? m.targetAtomU : kUnmappedTargetIdx;
+    S.phase1AtomV[tid]      = ok ? m.targetAtomV : kUnmappedTargetIdx;
   }
-  block.sync();
+  __syncthreads();
 
-  if (groupId == 0) {
-    for (int qBond = 0; qBond < pair.queryNumBonds && !overflowed && !timedOut; ++qBond) {
-      if (groupRank == 0) {
-        seedClearWithinThread(myCurrent.seed);
-        matchResultClearWithinThread(myCurrent.match);
-        for (int wordIdx = 0; wordIdx < Seed<maxAtoms, maxBonds>::kBondWords; ++wordIdx) {
-          myCurrent.seed.excludedBonds[wordIdx] = initialExcludedBonds[wordIdx];
-        }
+  if (tid == 0) {
+    BondMask mm;
+    mm.clear();
+    for (int q = 0; q < qNB; ++q)
+      if (S.phase1TargetBond[q] != kUnmappedTargetIdx)
+        mm.set(q);
+    S.phase1Matched = mm;
+    S.phase1Count   = mm.popcount();
+  }
+  __syncthreads();
+  const BondMask matchedMask = S.phase1Matched;
+  const int      numMatched  = S.phase1Count;
+  BondMask       notMatched  = lowMaskThrough<kFmcsMaskAtoms<maxBonds>>(qNB - 1);
+  notMatched.andNotEq(matchedMask);
 
-        const std::uint32_t queryEndpoints = queryView.bondEndpoints[qBond];
-        const int           queryEndpointU = static_cast<int>(queryEndpoints >> kBondEndpointShift);
-        const int           queryEndpointV = static_cast<int>(queryEndpoints & kBondEndpointMask);
-        seedAddBondWithinThread(myCurrent.seed, qBond);
-        seedAddAtomWithinThread(myCurrent.seed, queryEndpointU);
-        seedAddAtomWithinThread(myCurrent.seed, queryEndpointV);
-        myCurrent.seed.growingStage = kSeedGrowStageOuter;
-      }
-      group.sync();
-      seedComputeRemainingSizeRdkitCooperative(group,
-                                               myCurrent.seed,
-                                               queryView,
-                                               myRemainingAtomStack,
-                                               myRemainingVisitedAtoms,
-                                               myRemainingVisitedBonds,
-                                               &remainingStackSize[groupId]);
+  for (int mi = groupId; mi < numMatched; mi += kNumGroups) {
+    // The mi-th matched query bond.
+    BondMask t = matchedMask;
+    for (int k = 0; k < mi; ++k)
+      t.clearLowest();
+    const int q = t.lowest();
 
-      const bool matched =
-        checkSeedMatchAndAppendCooperative(group, myCurrent, queryView, targetView, pair.tables, mySubstructureScratch);
-      if (matched) {
-        updateIncumbentCooperative(group, myCurrent, best, &bestScore, &bestCopyLock);
-        if (!pushBackCooperative(group, queue, myCurrent)) {
-          overflowed = true;
-        }
-      } else if (groupRank == 0) {
-        const int queuedSeeds = queue.size();
-        for (int i = 0; i < queuedSeeds; ++i) {
-          seedExcludeBondWithinThread(queue.slot(i).seed, qBond);
-        }
-      }
-      group.sync();
-
-      if (groupRank == 0) {
-        const int  wordIdx = qBond / Seed<maxAtoms, maxBonds>::kBondBitsPerWord;
-        const auto mask    = static_cast<typename Seed<maxAtoms, maxBonds>::bond_word_type>(1)
-                       << (qBond % Seed<maxAtoms, maxBonds>::kBondBitsPerWord);
-        initialExcludedBonds[wordIdx] |= mask;
-      }
-      group.sync();
+    QueuedT& c = S.current[groupId];
+    if (lane == 0) {
+      seedClearWithinThread(c.seed);
+      seedAddBondWithinThread(c.seed, q);
+      seedAddAtomWithinThread(c.seed, S.qEpU[q]);
+      seedAddAtomWithinThread(c.seed, S.qEpV[q]);
+      // RDKit prefix exclusion: earlier initial bonds are off limits.
+      maskToWords(lowMaskThrough<kFmcsMaskAtoms<maxBonds>>(q), c.seed.excludedBonds);
     }
+    group.sync();
+    seedComputeRemainingSizeCooperative(group, S, c.seed);
+    if (lane == 0) {
+      // Full exclusion set: the prefix plus every later bond that failed its
+      // own one-bond match (RDKit retro-excludes those from queued seeds).
+      BondMask excl = lowMaskThrough<kFmcsMaskAtoms<maxBonds>>(q);
+      BondMask nm   = notMatched;
+      nm.andNotEq(excl);
+      maskOrEq(excl, nm);
+      maskToWords(excl, c.seed.excludedBonds);
+    }
+    matchResultClearCooperative(c.match, lane);
+    if (lane == 0) {
+      c.match.targetAtomIdx[S.qEpU[q]] = S.phase1AtomU[q];
+      c.match.targetAtomIdx[S.qEpV[q]] = S.phase1AtomV[q];
+      c.match.targetBondIdx[q]         = S.phase1TargetBond[q];
+      wordsSet(c.match.visitedTargetAtoms, S.phase1AtomU[q]);
+      wordsSet(c.match.visitedTargetAtoms, S.phase1AtomV[q]);
+      wordsSet(c.match.visitedTargetBonds, S.phase1TargetBond[q]);
+      c.match.matchedAtomSize = c.seed.numAtoms;
+      c.match.matchedBondSize = 1;
+      c.match.empty           = false;
+    }
+    group.sync();
+    warpCopy(group, &S.queue.slot(mi), &c, sizeof(QueuedT));
+    group.sync();
   }
+  __syncthreads();
+  if (tid == 0) {
+    S.queue.setSizeWithinThread(numMatched);
+    if (numMatched > 0)
+      S.bestScore = (1u << 16) | 2u;
+  }
+  __syncthreads();
+  if (numMatched > 0 && groupId == 0) {
+    warpCopy(group, &S.best, &S.queue.slot(0), sizeof(QueuedT));
+  }
+  __syncthreads();
 
-  block.sync();
-  if (block.thread_rank() == 0 && timeoutClocks > 0 && clock64() - startClock > timeoutClocks) {
-    timedOut = true;
-  }
-  block.sync();
+  QueuedT& myCurrent  = S.current[groupId];
+  QueuedT& myBiggest  = S.biggest[groupId];
+  NewBond* myNewBonds = S.newBonds[groupId];
 
   // ---- Phase 2: RDKit Seed::grow() analogue ----
-
-  // Approach 1 uses an atomic LIFO worklist so every warp group can pop and
-  // grow one seed per outer iteration.  This intentionally trades RDKit's
-  // sorted-front scheduling order for useful multi-warp work while preserving
-  // the full checkIfMatchAndAppend-style substructure validation.
+  // An atomic LIFO worklist lets every warp group pop and grow one seed per
+  // outer iteration.  This intentionally trades RDKit's sorted-front
+  // scheduling order for multi-warp work while preserving the full
+  // checkIfMatchAndAppend-style substructure validation.
   while (true) {
-    if (block.thread_rank() == 0)
-      phase2Done = overflowed || timedOut || queue.empty();
+    if (tid == 0) {
+      if (timeoutClocks > 0 && clock64() - S.startClock > timeoutClocks)
+        S.timedOut = true;
+      S.phase2Done = S.overflowed || S.timedOut || S.queue.empty();
+    }
     block.sync();
-    if (phase2Done)
+    if (S.phase2Done)
       break;
 
-    const bool poppedThisGroup = popBackCooperative(group, queue, myCurrent);
-    if (groupRank == 0) {
-      popped[groupId] = poppedThisGroup;
-    }
+    const bool poppedThisGroup = popBackCooperative(group, S.queue, myCurrent);
+    if (lane == 0)
+      S.popped[groupId] = poppedThisGroup;
     group.sync();
     // Complete every pop before any group can reserve and publish new work.
     block.sync();
 
     do {
-      if (!popped[groupId])
+      if (!S.popped[groupId])
         break;
 
-      // RDKit growSeeds() increments TotalSteps before Seed::grow(), then
-      // Seed::grow() first checks canGrowBiggerThan().
-      const unsigned int scoreSnapshot     = readBestScoreCooperative(group, &bestScore);
+      const unsigned int scoreSnapshot     = readBestScoreCooperative(group, &S.bestScore);
       const int          bestBondsSnapshot = static_cast<int>(scoreSnapshot >> 16);
       const int          bestAtomsSnapshot = static_cast<int>(scoreSnapshot & 0xFFFFu);
       if (!seedCanGrowBiggerThanWithinThread(myCurrent.seed, bestBondsSnapshot, bestAtomsSnapshot)) {
         break;
       }
 
-      updateIncumbentCooperative(group, myCurrent, best, &bestScore, &bestCopyLock);
+      updateIncumbentCooperative(group, myCurrent, S.best, &S.bestScore, &S.bestCopyLock);
 
       const bool fillOk = fillNewBondsCooperative(group,
                                                   myCurrent.seed,
-                                                  queryView,
+                                                  S.qEpU,
+                                                  S.qEpV,
+                                                  qNB,
                                                   myNewBonds,
-                                                  &newBondCount[groupId],
-                                                  kMaxNewBondsForTier);
+                                                  &S.newBondCount[groupId],
+                                                  maxBonds);
       group.sync();
       if (!fillOk) {
-        if (groupRank == 0)
-          overflowed = true;
+        if (lane == 0)
+          S.overflowed = true;
         break;
       }
-
-      if (newBondCount[groupId] == 0) {
+      if (S.newBondCount[groupId] == 0) {
         break;
       }
 
       bool runInnerStage = myCurrent.seed.growingStage != kSeedGrowStageOuter;
 
-      // RDKit Seed::grow() stage 0: build the child containing all newly
-      // discovered outgoing bonds and run checkIfMatchAndAppend().  If this
-      // all-bonds child matches and there is more than one new bond, RDKit
-      // returns immediately with the parent left at GrowingStage=1; the next
-      // outer grow loop resumes the parent at the singleton/subset stage.
+      // RDKit Seed::grow() stage 0: the all-bonds child.  If it matches with
+      // more than one new bond, the parent is requeued at the inner stage.
       if (myCurrent.seed.growingStage == kSeedGrowStageOuter) {
         warpCopy(group, &myBiggest, &myCurrent, sizeof(QueuedT));
         group.sync();
-        if (groupRank == 0) {
+        if (lane == 0) {
           seedBeginGrowStepWithinThread(myBiggest.seed);
           myBiggest.seed.growingStage = kSeedGrowStageOuter;
-          for (int i = 0; i < newBondCount[groupId]; ++i) {
+          for (int i = 0; i < S.newBondCount[groupId]; ++i) {
             seedAddNewBondWithinThread(myBiggest.seed, myNewBonds[i]);
           }
         }
         group.sync();
-        seedComputeRemainingSizeRdkitCooperative(group,
-                                                 myBiggest.seed,
-                                                 queryView,
-                                                 myRemainingAtomStack,
-                                                 myRemainingVisitedAtoms,
-                                                 myRemainingVisitedBonds,
-                                                 &remainingStackSize[groupId]);
+        seedComputeRemainingSizeCooperative(group, S, myBiggest.seed);
 
-        const unsigned int childScoreSnapshot = readBestScoreCooperative(group, &bestScore);
-        const int          childBestBonds     = static_cast<int>(childScoreSnapshot >> 16);
-        const int          childBestAtoms     = static_cast<int>(childScoreSnapshot & 0xFFFFu);
-        if (!seedCanGrowBiggerThanWithinThread(myBiggest.seed, childBestBonds, childBestAtoms)) {
+        const unsigned int childScoreSnapshot = readBestScoreCooperative(group, &S.bestScore);
+        if (!seedCanGrowBiggerThanWithinThread(myBiggest.seed,
+                                               static_cast<int>(childScoreSnapshot >> 16),
+                                               static_cast<int>(childScoreSnapshot & 0xFFFFu))) {
           break;
         }
 
-        const bool ok = checkSeedMatchAndAppendCooperative(group,
-                                                           myBiggest,
-                                                           queryView,
-                                                           targetView,
-                                                           pair.tables,
-                                                           mySubstructureScratch);
-        if (groupRank == 0)
-          stage0Ok[groupId] = ok;
-        group.sync();
-
-        if (stage0Ok[groupId]) {
-          updateIncumbentCooperative(group, myBiggest, best, &bestScore, &bestCopyLock);
-          if (!pushBackCooperative(group, queue, myBiggest)) {
-            overflowed = true;
+        const bool ok = checkSeedMatchAndAppendCooperative(group, S, myBiggest, groupId);
+        if (ok) {
+          updateIncumbentCooperative(group, myBiggest, S.best, &S.bestScore, &S.bestCopyLock);
+          if (!pushBackCooperative(group, S.queue, myBiggest) && lane == 0) {
+            S.overflowed = true;
           }
           group.sync();
-          if (newBondCount[groupId] > 1) {
-            if (groupRank == 0) {
+          if (S.newBondCount[groupId] > 1) {
+            if (lane == 0) {
               myCurrent.seed.growingStage = kSeedGrowStageInner;
             }
             group.sync();
-            if (!pushBackCooperative(group, queue, myCurrent)) {
-              overflowed = true;
+            if (!pushBackCooperative(group, S.queue, myCurrent) && lane == 0) {
+              S.overflowed = true;
             }
             group.sync();
           }
           break;
         }
-        if (newBondCount[groupId] == 1)
+        if (S.newBondCount[groupId] == 1)
           break;
         runInnerStage = true;
       }
@@ -315,49 +272,37 @@ __global__ void fmcsKernel(const DevicePerPairInput* __restrict__ pairs,
       if (!runInnerStage)
         break;
 
-      // RDKit Seed::grow() stage 1: try every individual outgoing bond.
-      // A failed individual match excludes that NewBond from later subset
-      // enumeration and increments IndividualBondExcluded.
-      for (int i = 0; i < newBondCount[groupId]; ++i) {
+      // RDKit Seed::grow() stage 1: try every individual outgoing bond.  A
+      // failed individual match excludes that NewBond from later subset
+      // enumeration.
+      for (int i = 0; i < S.newBondCount[groupId]; ++i) {
         if (!myNewBonds[i].alive)
           continue;
 
         warpCopy(group, &myBiggest, &myCurrent, sizeof(QueuedT));
         group.sync();
-
-        if (groupRank == 0) {
+        if (lane == 0) {
           seedBeginGrowStepWithinThread(myBiggest.seed);
           myBiggest.seed.growingStage = kSeedGrowStageOuter;
           seedAddNewBondWithinThread(myBiggest.seed, myNewBonds[i]);
         }
         group.sync();
-        seedComputeRemainingSizeRdkitCooperative(group,
-                                                 myBiggest.seed,
-                                                 queryView,
-                                                 myRemainingAtomStack,
-                                                 myRemainingVisitedAtoms,
-                                                 myRemainingVisitedBonds,
-                                                 &remainingStackSize[groupId]);
+        seedComputeRemainingSizeCooperative(group, S, myBiggest.seed);
 
-        const unsigned int childScoreSnapshot = readBestScoreCooperative(group, &bestScore);
-        const int          childBestBonds     = static_cast<int>(childScoreSnapshot >> 16);
-        const int          childBestAtoms     = static_cast<int>(childScoreSnapshot & 0xFFFFu);
-        if (!seedCanGrowBiggerThanWithinThread(myBiggest.seed, childBestBonds, childBestAtoms)) {
+        const unsigned int childScoreSnapshot = readBestScoreCooperative(group, &S.bestScore);
+        if (!seedCanGrowBiggerThanWithinThread(myBiggest.seed,
+                                               static_cast<int>(childScoreSnapshot >> 16),
+                                               static_cast<int>(childScoreSnapshot & 0xFFFFu))) {
           continue;
         }
 
-        const bool ok = checkSeedMatchAndAppendCooperative(group,
-                                                           myBiggest,
-                                                           queryView,
-                                                           targetView,
-                                                           pair.tables,
-                                                           mySubstructureScratch);
+        const bool ok = checkSeedMatchAndAppendCooperative(group, S, myBiggest, groupId);
         if (ok) {
-          updateIncumbentCooperative(group, myBiggest, best, &bestScore, &bestCopyLock);
-          if (!pushBackCooperative(group, queue, myBiggest)) {
-            overflowed = true;
+          updateIncumbentCooperative(group, myBiggest, S.best, &S.bestScore, &S.bestCopyLock);
+          if (!pushBackCooperative(group, S.queue, myBiggest) && lane == 0) {
+            S.overflowed = true;
           }
-        } else if (groupRank == 0) {
+        } else if (lane == 0) {
           myNewBonds[i].alive = false;
         }
         group.sync();
@@ -366,18 +311,18 @@ __global__ void fmcsKernel(const DevicePerPairInput* __restrict__ pairs,
       // RDKit Seed::grow() stage 2: enumerate all non-singleton subsets of
       // the surviving NewBonds.  Singletons were handled by Stage 1; the
       // all-bonds subset was handled by Stage 0 unless Stage 1 erased one or
-      // more individual bonds, in which case the all-surviving-bonds subset is
-      // new work and must be checked.
+      // more individual bonds, in which case the all-surviving-bonds subset
+      // is new work and must be checked.
       int aliveCount    = 0;
       int aliveOverflow = 0;
-      if (groupRank == 0) {
-        for (int i = 0; i < newBondCount[groupId]; ++i) {
+      if (lane == 0) {
+        for (int i = 0; i < S.newBondCount[groupId]; ++i) {
           if (myNewBonds[i].alive)
             ++aliveCount;
         }
         aliveOverflow = aliveCount > 63 ? 1 : 0;
         if (aliveOverflow)
-          overflowed = true;
+          S.overflowed = true;
       }
       aliveCount    = group.shfl(aliveCount, 0);
       aliveOverflow = group.shfl(aliveOverflow, 0);
@@ -385,8 +330,8 @@ __global__ void fmcsKernel(const DevicePerPairInput* __restrict__ pairs,
         break;
       if (aliveCount > 1) {
         unsigned int erasedCount = 0;
-        if (groupRank == 0) {
-          erasedCount = static_cast<unsigned int>(newBondCount[groupId] - aliveCount);
+        if (lane == 0) {
+          erasedCount = static_cast<unsigned int>(S.newBondCount[groupId] - aliveCount);
         }
         erasedCount                             = group.shfl(erasedCount, 0);
         const unsigned long long maxComposition = (1ULL << aliveCount) - 1ULL;
@@ -398,11 +343,11 @@ __global__ void fmcsKernel(const DevicePerPairInput* __restrict__ pairs,
 
           warpCopy(group, &myBiggest, &myCurrent, sizeof(QueuedT));
           group.sync();
-          if (groupRank == 0) {
+          if (lane == 0) {
             seedBeginGrowStepWithinThread(myBiggest.seed);
             myBiggest.seed.growingStage = kSeedGrowStageOuter;
             int aliveBit                = 0;
-            for (int i = 0; i < newBondCount[groupId]; ++i) {
+            for (int i = 0; i < S.newBondCount[groupId]; ++i) {
               if (!myNewBonds[i].alive)
                 continue;
               if ((composition & (1ULL << aliveBit)) != 0ULL) {
@@ -412,74 +357,54 @@ __global__ void fmcsKernel(const DevicePerPairInput* __restrict__ pairs,
             }
           }
           group.sync();
-          seedComputeRemainingSizeRdkitCooperative(group,
-                                                   myBiggest.seed,
-                                                   queryView,
-                                                   myRemainingAtomStack,
-                                                   myRemainingVisitedAtoms,
-                                                   myRemainingVisitedBonds,
-                                                   &remainingStackSize[groupId]);
+          seedComputeRemainingSizeCooperative(group, S, myBiggest.seed);
 
-          const unsigned int childScoreSnapshot = readBestScoreCooperative(group, &bestScore);
-          const int          childBestBonds     = static_cast<int>(childScoreSnapshot >> 16);
-          const int          childBestAtoms     = static_cast<int>(childScoreSnapshot & 0xFFFFu);
-          if (!seedCanGrowBiggerThanWithinThread(myBiggest.seed, childBestBonds, childBestAtoms)) {
+          const unsigned int childScoreSnapshot = readBestScoreCooperative(group, &S.bestScore);
+          if (!seedCanGrowBiggerThanWithinThread(myBiggest.seed,
+                                                 static_cast<int>(childScoreSnapshot >> 16),
+                                                 static_cast<int>(childScoreSnapshot & 0xFFFFu))) {
             continue;
           }
 
-          const bool ok = checkSeedMatchAndAppendCooperative(group,
-                                                             myBiggest,
-                                                             queryView,
-                                                             targetView,
-                                                             pair.tables,
-                                                             mySubstructureScratch);
+          const bool ok = checkSeedMatchAndAppendCooperative(group, S, myBiggest, groupId);
           if (ok) {
-            updateIncumbentCooperative(group, myBiggest, best, &bestScore, &bestCopyLock);
-            if (!pushBackCooperative(group, queue, myBiggest)) {
-              overflowed = true;
+            updateIncumbentCooperative(group, myBiggest, S.best, &S.bestScore, &S.bestCopyLock);
+            if (!pushBackCooperative(group, S.queue, myBiggest)) {
+              if (lane == 0)
+                S.overflowed = true;
             }
           }
           group.sync();
-          if (readFlagCooperative(group, &overflowed))
+          if (readFlagCooperative(group, &S.overflowed))
             break;
         }
       }
 
     } while (false);
 
-    // End-of-iteration rendezvous: every group must reach here before
-    // group 0 decides whether the sorted queue is empty.
+    // End-of-iteration rendezvous: every group must reach here before the
+    // next pop/termination decision.
     block.sync();
-    if (block.thread_rank() == 0 && timeoutClocks > 0 && clock64() - startClock > timeoutClocks) {
-      timedOut = true;
-    }
-    block.sync();
-
-    if (block.thread_rank() == 0)
-      phase2Done = overflowed || timedOut || queue.empty();
-    block.sync();
-    if (phase2Done)
-      break;
   }
 
   // ---- Phase 3: writeback ----
   block.sync();
-  if (block.thread_rank() == 0) {
+  if (tid == 0) {
     auto& dst             = results[pairIdx];
-    dst.numCommonVertices = best.seed.numAtoms;
-    dst.numCommonEdges    = best.seed.numBonds;
-    dst.timedOut          = timedOut;
-    dst.overflowed        = overflowed;
+    dst.numCommonVertices = S.best.seed.numAtoms;
+    dst.numCommonEdges    = S.best.seed.numBonds;
+    dst.timedOut          = S.timedOut;
+    dst.overflowed        = S.overflowed;
 
-    // Walk set bits of best.seed.atoms (in increasing query atom idx
-    // order, via __ffs/__ffsll) to fill mappingA/B.
-    using BestSeedT                = decltype(best.seed);
+    // Walk set bits of best.seed.atoms (in increasing query atom idx order)
+    // to fill mappingA/B, then best.seed.bonds for bondMapA/B.
+    using BestSeedT                = decltype(S.best.seed);
     using AtomWord                 = typename BestSeedT::atom_word_type;
     constexpr int kAtomBitsPerWord = BestSeedT::kAtomBitsPerWord;
     constexpr int kAtomWords       = BestSeedT::kAtomWords;
     int           outIdx           = 0;
     for (int wordIdx = 0; wordIdx < kAtomWords; ++wordIdx) {
-      AtomWord remaining = best.seed.atoms[wordIdx];
+      AtomWord remaining = S.best.seed.atoms[wordIdx];
       while (remaining != 0) {
         int bitPosInWord;
         if constexpr (sizeof(AtomWord) == 4) {
@@ -490,18 +415,17 @@ __global__ void fmcsKernel(const DevicePerPairInput* __restrict__ pairs,
         const int queryAtomIdx = wordIdx * kAtomBitsPerWord + bitPosInWord;
         remaining &= remaining - 1;
         dst.mappingA[outIdx] = static_cast<std::uint8_t>(queryAtomIdx);
-        dst.mappingB[outIdx] = best.match.targetAtomIdx[queryAtomIdx];
+        dst.mappingB[outIdx] = S.best.match.targetAtomIdx[queryAtomIdx];
         ++outIdx;
       }
     }
 
-    // Walk set bits of best.seed.bonds to fill bondMapA/B.
     using BondWord                 = typename BestSeedT::bond_word_type;
     constexpr int kBondBitsPerWord = BestSeedT::kBondBitsPerWord;
     constexpr int kBondWords       = BestSeedT::kBondWords;
     outIdx                         = 0;
     for (int wordIdx = 0; wordIdx < kBondWords; ++wordIdx) {
-      BondWord remaining = best.seed.bonds[wordIdx];
+      BondWord remaining = S.best.seed.bonds[wordIdx];
       while (remaining != 0) {
         int bitPosInWord;
         if constexpr (sizeof(BondWord) == 4) {
@@ -512,7 +436,7 @@ __global__ void fmcsKernel(const DevicePerPairInput* __restrict__ pairs,
         const int queryBondIdx = wordIdx * kBondBitsPerWord + bitPosInWord;
         remaining &= remaining - 1;
         dst.bondMapA[outIdx] = static_cast<std::uint8_t>(queryBondIdx);
-        dst.bondMapB[outIdx] = best.match.targetBondIdx[queryBondIdx];
+        dst.bondMapB[outIdx] = S.best.match.targetBondIdx[queryBondIdx];
         ++outIdx;
       }
     }

--- a/src/mcs/fmcs_cuda/fmcs_match.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_match.cuh
@@ -13,6 +13,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Seed-in-target matching for the fMCS kernel.
+//
+// The kernel runs one block per pair (see fmcs_kernel.cuh); this header owns
+// the block-shared pair state and the matcher that runs against it.
+// Everything invariant for the pair -- both CSRs (byte-packed), the atom/bond
+// compatibility rows as bitsets, per-atom incident-bond sets, degree buckets,
+// and per-class target adjacency tables -- is loaded or derived once by
+// @ref loadPairSharedCooperative and then shared by every grow group.  Per
+// seed, only the most-constrained-first search order and its back-edge table
+// are built (warp-parallel).
+//
+// The exact check is the shared lane-parallel DFS core
+// (nvMolKit::dfsFromRoots, the same engine the substructure search product
+// runs on), fed by candidate masks read from the per-class adjacency tables
+// (src/subgraph/class_adjacency.cuh) -- the K-class generalisation of the
+// substructure frontend's Uniform/Dual precompute, keyed here on
+// deduplicated bond-compatibility rows.
+//
+// A greedy incremental extension of the parent's recorded witness runs
+// first; a greedy miss is inconclusive and falls through to the exact
+// search.
+
 #ifndef FMCS_CUDA_FMCS_MATCH_CUH
 #define FMCS_CUDA_FMCS_MATCH_CUH
 
@@ -21,905 +43,947 @@
 #include "src/mcs/fmcs_cuda/fmcs.cuh"
 #include "src/mcs/fmcs_cuda/fmcs_match_tables.cuh"
 #include "src/mcs/fmcs_cuda/fmcs_seed.cuh"
+#include "src/mcs/fmcs_cuda/fmcs_seed_queue.cuh"
 #include "src/mcs/fmcs_cuda/fmcs_topology.cuh"
-#include "src/subgraph/candidate_tables.cuh"
+#include "src/subgraph/class_adjacency.cuh"
 #include "src/subgraph/target_mask.cuh"
 #include "src/subgraph/warp_dfs.cuh"
 
 namespace mcs {
 namespace fmcs {
 
-/// Target-atom bitset wide enough for a tier's target capacity.  Tiers 16
-/// and 32 share the 32-bit form.  Deliberately keyed on the target size
-/// alone -- the DFS stack depth is keyed on the query size -- so
-/// rectangular (query size != target size) tiers need no matcher changes.
 /// Largest seed-atom degree the degreeAtLeast buckets distinguish.  Degrees
 /// above this clamp to the last bucket, which only weakens the filter.
-constexpr int kFmcsMaxSeedDegree = kMaxNeighborsPerAtom;
-static_assert(kMaxNeighborsPerAtom == nvMolKit::subgraph::kMaxEdgeSlotsPerAtom);
+constexpr int kFmcsMaxSeedDegree  = kMaxNeighborsPerAtom;
+/// Back-edge slots per search depth; molecular degree is capped at 8.
+constexpr int kFmcsMaxBackEdges   = kMaxNeighborsPerAtom;
+/// Bond-compatibility classes precomputed per pair.  Query bonds beyond this
+/// many distinct compatibility rows fall back to a shared-CSR recompute in
+/// the candidate build.
+constexpr int kFmcsMaxBondClasses = 8;
+/// Cooperative-group (warp) size for the grow groups and the matcher.
+constexpr int kFmcsGroupSize      = 32;
 
+/// Bitset wide enough for a tier's index space (query and target sides are
+/// square).  Tiers 16 and 32 share the 32-bit form.
 template <int maxTargetAtoms>
 constexpr int kFmcsMaskAtoms = (maxTargetAtoms <= 32 ? 32 : (maxTargetAtoms <= 64 ? 64 : 128));
 
 template <int maxTargetAtoms> using FmcsTargetMask = nvMolKit::TargetMask<kFmcsMaskAtoms<maxTargetAtoms>>;
 
-/// Resolved target endpoints for a successful single-(query bond, target
-/// bond, orientation) compatibility check.  Populated by
-/// @ref matchSingleBondWithinThread on success only; contents are
-/// unspecified on failure.  @c targetAtomU is the target atom that the
-/// query bond's u endpoint was mapped to (likewise V).
+/// Per-tier block configuration.  Tiers up to 64 run sixteen grow groups and
+/// cache per-depth candidate masks; tier 128 halves the group count and
+/// recomputes depth candidates on the fly so the block state fits the 64 KB
+/// opt-in shared-memory limit of the smallest supported architectures.
+template <int maxAtoms> struct FmcsKernelConfig {
+  static constexpr bool cacheDepthCandidates = maxAtoms <= 64;
+  static constexpr int  numGroups            = maxAtoms <= 64 ? 16 : 8;
+  static constexpr int  blockThreads         = numGroups * kFmcsGroupSize;
+};
+
+// ---------------------------------------------------------------------------
+// TargetMask <-> Seed/MatchResult bit-word bridging.  Seed and MatchResult
+// keep their word-array layouts (shared with the rest of fmcs_cuda and its
+// tests); the matcher does its bitset math on TargetMask and converts at the
+// boundaries.  All forms are layout-compatible 32/64/2x64-bit words.
+// ---------------------------------------------------------------------------
+
+__device__ __forceinline__ uint32_t maskWord32(const nvMolKit::TargetMask<32>& m, int /*word*/) {
+  return m.bits;
+}
+__device__ __forceinline__ uint32_t maskWord32(const nvMolKit::TargetMask<64>& m, int word) {
+  return static_cast<uint32_t>(m.lo >> (32 * word));
+}
+__device__ __forceinline__ uint32_t maskWord32(const nvMolKit::TargetMask<128>& m, int word) {
+  return static_cast<uint32_t>((word < 2 ? m.lo : m.hi) >> (32 * (word & 1)));
+}
+
+__device__ __forceinline__ bool maskEquals(const nvMolKit::TargetMask<32>& a, const nvMolKit::TargetMask<32>& b) {
+  return a.bits == b.bits;
+}
+__device__ __forceinline__ bool maskEquals(const nvMolKit::TargetMask<64>& a, const nvMolKit::TargetMask<64>& b) {
+  return a.lo == b.lo;
+}
+__device__ __forceinline__ bool maskEquals(const nvMolKit::TargetMask<128>& a, const nvMolKit::TargetMask<128>& b) {
+  return a.lo == b.lo && a.hi == b.hi;
+}
+
+__device__ __forceinline__ void maskOrEq(nvMolKit::TargetMask<32>& a, const nvMolKit::TargetMask<32>& b) {
+  a.bits |= b.bits;
+}
+__device__ __forceinline__ void maskOrEq(nvMolKit::TargetMask<64>& a, const nvMolKit::TargetMask<64>& b) {
+  a.lo |= b.lo;
+}
+__device__ __forceinline__ void maskOrEq(nvMolKit::TargetMask<128>& a, const nvMolKit::TargetMask<128>& b) {
+  a.lo |= b.lo;
+  a.hi |= b.hi;
+}
+
+template <class GroupT>
+__device__ __forceinline__ nvMolKit::TargetMask<32> warpOrMask(const GroupT& group, nvMolKit::TargetMask<32> m) {
+#pragma unroll
+  for (int off = 16; off > 0; off >>= 1)
+    m.bits |= group.shfl_xor(m.bits, off);
+  return m;
+}
+template <class GroupT>
+__device__ __forceinline__ nvMolKit::TargetMask<64> warpOrMask(const GroupT& group, nvMolKit::TargetMask<64> m) {
+#pragma unroll
+  for (int off = 16; off > 0; off >>= 1)
+    m.lo |= group.shfl_xor(m.lo, off);
+  return m;
+}
+template <class GroupT>
+__device__ __forceinline__ nvMolKit::TargetMask<128> warpOrMask(const GroupT& group, nvMolKit::TargetMask<128> m) {
+#pragma unroll
+  for (int off = 16; off > 0; off >>= 1) {
+    m.lo |= group.shfl_xor(m.lo, off);
+    m.hi |= group.shfl_xor(m.hi, off);
+  }
+  return m;
+}
+
+/// Load a Seed/MatchResult bit-word array into the tier's TargetMask form.
+template <std::size_t MaskBits, class Word, int NumWords>
+__device__ __forceinline__ nvMolKit::TargetMask<MaskBits> maskFromWords(const Word (&words)[NumWords]) {
+  nvMolKit::TargetMask<MaskBits> m;
+  m.clear();
+  constexpr int kSub = static_cast<int>(sizeof(Word) / 4);
+#pragma unroll
+  for (int w = 0; w < NumWords; ++w)
+#pragma unroll
+    for (int k = 0; k < kSub; ++k)
+      m.setWord32(w * kSub + k, static_cast<uint32_t>(words[w] >> (32 * k)));
+  return m;
+}
+
+/// Store a TargetMask back into a Seed/MatchResult bit-word array.
+template <class Word, int NumWords, std::size_t MaskBits>
+__device__ __forceinline__ void maskToWords(const nvMolKit::TargetMask<MaskBits>& m, Word (&words)[NumWords]) {
+  constexpr int kSub = static_cast<int>(sizeof(Word) / 4);
+#pragma unroll
+  for (int w = 0; w < NumWords; ++w) {
+    Word v = 0;
+#pragma unroll
+    for (int k = 0; k < kSub; ++k)
+      v |= static_cast<Word>(maskWord32(m, w * kSub + k)) << (32 * k);
+    words[w] = v;
+  }
+}
+
+template <class Word, int NumWords> __device__ __forceinline__ bool wordsTest(const Word (&words)[NumWords], int bit) {
+  constexpr int kBits = static_cast<int>(sizeof(Word) * 8);
+  return ((words[bit / kBits] >> (bit % kBits)) & 1) != 0;
+}
+
+template <class Word, int NumWords> __device__ __forceinline__ void wordsSet(Word (&words)[NumWords], int bit) {
+  constexpr int kBits = static_cast<int>(sizeof(Word) * 8);
+  words[bit / kBits] |= static_cast<Word>(1) << (bit % kBits);
+}
+
+/// Mask with bits [0, bit] set; clear mask for bit < 0.
+template <std::size_t MaskBits> __device__ __forceinline__ nvMolKit::TargetMask<MaskBits> lowMaskThrough(int bit) {
+  nvMolKit::TargetMask<MaskBits> m;
+  m.clear();
+#pragma unroll
+  for (int k = 0; k * 32 < static_cast<int>(MaskBits); ++k) {
+    const int lowBit = k * 32;
+    uint32_t  v      = 0;
+    if (bit >= lowBit + 31) {
+      v = 0xFFFFFFFFu;
+    } else if (bit >= lowBit) {
+      v = (1u << (bit - lowBit + 1)) - 1u;
+    }
+    m.setWord32(k, v);
+  }
+  return m;
+}
+
+// ---------------------------------------------------------------------------
+// Block-shared per-pair state.
+// ---------------------------------------------------------------------------
+
+template <int maxAtoms, int maxBonds> struct FmcsPairShared {
+  using Config   = FmcsKernelConfig<maxAtoms>;
+  using SeedT    = Seed<maxAtoms, maxBonds>;
+  using MatchT   = MatchResult<maxAtoms, maxBonds, maxAtoms, maxBonds>;
+  using QueuedT  = QueuedSeed<maxAtoms, maxBonds, maxAtoms, maxBonds>;
+  using AtomMask = FmcsTargetMask<maxAtoms>;
+  using BondMask = FmcsTargetMask<maxBonds>;
+
+  static constexpr int kNumGroups = Config::numGroups;
+  static constexpr int kAtomRegs  = (maxAtoms + 31) / 32;
+
+  // --- per-group hot state (16B-aligned members first) ---
+  QueuedT current[kNumGroups];
+  QueuedT biggest[kNumGroups];
+  QueuedT best;
+
+  // --- pair invariants ---
+  AtomMask atomRow[maxAtoms];        ///< query atom -> compatible target atoms
+  BondMask incidentBonds[maxAtoms];  ///< query atom -> incident query bonds
+  BondMask bondRow[maxBonds];        ///< query bond -> compatible target bonds
+  AtomMask degreeAtLeast[kFmcsMaxSeedDegree + 1];
+  BondMask classRep[kFmcsMaxBondClasses];  ///< representative bondRow per class
+  /// Per-class target adjacency, shared with src/subgraph.
+  nvMolKit::subgraph::ClassAdjacency<kFmcsMaskAtoms<maxAtoms>, kFmcsMaxBondClasses> classAdj;
+  BondMask                                                                          phase1Matched;
+
+  /// Per-depth candidate masks; recomputed on the fly at tier 128 (see
+  /// FmcsKernelConfig::cacheDepthCandidates), where caching them would push
+  /// the block state past the smallest supported shared-memory limit.
+  AtomMask depthCandidates[kNumGroups][Config::cacheDepthCandidates ? maxAtoms : 1];
+
+  /// Back edge: low byte = earlier order position, high byte = query bond.
+  uint16_t backEdges[kNumGroups][maxAtoms][kFmcsMaxBackEdges];
+  NewBond  newBonds[kNumGroups][maxBonds];
+
+  // Byte-packed CSRs for both graphs.
+  uint8_t qRow[maxAtoms + 1], tRow[maxAtoms + 1];
+  uint8_t qCol[2 * maxBonds], qBnd[2 * maxBonds], tCol[2 * maxBonds], tBnd[2 * maxBonds];
+  uint8_t qEpU[maxBonds], qEpV[maxBonds], tEpU[maxBonds], tEpV[maxBonds];
+  uint8_t bondClass[maxBonds];
+  /// Phase-1 per-query-bond direct match results.
+  uint8_t phase1TargetBond[maxBonds], phase1AtomU[maxBonds], phase1AtomV[maxBonds];
+
+  // Per-group per-seed search tables.
+  uint8_t order[kNumGroups][maxAtoms];     ///< order position -> query atom
+  uint8_t orderPos[kNumGroups][maxAtoms];  ///< inverse of order
+  uint8_t seedDegree[kNumGroups][maxAtoms];
+  uint8_t targetForQuery[kNumGroups][maxAtoms];  ///< winning embedding
+  uint8_t backEdgeCount[kNumGroups][maxAtoms];
+
+  SeedQueue<QueuedT, ThreadBlockScope> queue;
+
+  int  newBondCount[kNumGroups];
+  bool popped[kNumGroups];
+  int  found[kNumGroups];
+
+  unsigned int       bestScore;
+  int                bestCopyLock;
+  bool               overflowed;
+  bool               timedOut;
+  bool               phase2Done;
+  unsigned long long startClock;
+  int                qNA, qNB, tNA, tNB, numClasses, phase1Count;
+};
+
+// ---------------------------------------------------------------------------
+// Per-pair shared-state preload.  Block-cooperative: every thread of the
+// block participates, striding by @p blockThreads; the caller must
+// __syncthreads() after (the final barrier is included here).
+// ---------------------------------------------------------------------------
+template <int maxAtoms, int maxBonds>
+__device__ void loadPairSharedCooperative(FmcsPairShared<maxAtoms, maxBonds>& S,
+                                          const DeviceCsrView&                queryView,
+                                          const DeviceCsrView&                targetView,
+                                          const PairMatchTablesDevice&        tables,
+                                          int                                 tid,
+                                          int                                 blockThreads) {
+  using AtomMask               = typename FmcsPairShared<maxAtoms, maxBonds>::AtomMask;
+  using BondMask               = typename FmcsPairShared<maxAtoms, maxBonds>::BondMask;
+  constexpr int kAtomMaskWords = static_cast<int>(sizeof(AtomMask) / 4);
+  constexpr int kBondMaskWords = static_cast<int>(sizeof(BondMask) / 4);
+
+  const int qNA = queryView.numAtoms;
+  const int qNB = queryView.numBonds;
+  const int tNA = targetView.numAtoms;
+  const int tNB = targetView.numBonds;
+  const int qE  = static_cast<int>(queryView.rowOffsets[qNA]);
+  const int tE  = static_cast<int>(targetView.rowOffsets[tNA]);
+
+  if (tid == 0) {
+    S.qNA          = qNA;
+    S.qNB          = qNB;
+    S.tNA          = tNA;
+    S.tNB          = tNB;
+    S.bestScore    = 0;
+    S.bestCopyLock = 0;
+    S.overflowed   = false;
+    S.timedOut     = false;
+    S.phase2Done   = false;
+  }
+
+  for (int i = tid; i <= qNA; i += blockThreads)
+    S.qRow[i] = static_cast<uint8_t>(queryView.rowOffsets[i]);
+  for (int i = tid; i <= tNA; i += blockThreads)
+    S.tRow[i] = static_cast<uint8_t>(targetView.rowOffsets[i]);
+  for (int i = tid; i < qE; i += blockThreads) {
+    S.qCol[i] = static_cast<uint8_t>(queryView.colIndices[i]);
+    S.qBnd[i] = static_cast<uint8_t>(queryView.bondIndices[i]);
+  }
+  for (int i = tid; i < tE; i += blockThreads) {
+    S.tCol[i] = static_cast<uint8_t>(targetView.colIndices[i]);
+    S.tBnd[i] = static_cast<uint8_t>(targetView.bondIndices[i]);
+  }
+  for (int i = tid; i < qNB; i += blockThreads) {
+    const std::uint32_t e = queryView.bondEndpoints[i];
+    S.qEpU[i]             = static_cast<uint8_t>(e >> kBondEndpointShift);
+    S.qEpV[i]             = static_cast<uint8_t>(e & kBondEndpointMask);
+    BondMask row;
+    row.clear();
+#pragma unroll
+    for (int w = 0; w < kBondMaskWords; ++w)
+      if (w < tables.bonds.wordsPerRow)
+        row.setWord32(w, tables.bonds.data[static_cast<size_t>(i) * tables.bonds.wordsPerRow + w]);
+    S.bondRow[i] = row;
+  }
+  for (int i = tid; i < tNB; i += blockThreads) {
+    const std::uint32_t e = targetView.bondEndpoints[i];
+    S.tEpU[i]             = static_cast<uint8_t>(e >> kBondEndpointShift);
+    S.tEpV[i]             = static_cast<uint8_t>(e & kBondEndpointMask);
+  }
+  for (int i = tid; i < qNA; i += blockThreads) {
+    AtomMask row;
+    row.clear();
+#pragma unroll
+    for (int w = 0; w < kAtomMaskWords; ++w)
+      if (w < tables.atoms.wordsPerRow)
+        row.setWord32(w, tables.atoms.data[static_cast<size_t>(i) * tables.atoms.wordsPerRow + w]);
+    S.atomRow[i] = row;
+  }
+  __syncthreads();
+
+  // Derived per-atom bitsets.
+  for (int a = tid; a < qNA; a += blockThreads) {
+    BondMask inc;
+    inc.clear();
+    const int b0 = S.qRow[a], b1 = S.qRow[a + 1];
+    for (int e = b0; e < b1; ++e)
+      inc.set(S.qBnd[e]);
+    S.incidentBonds[a] = inc;
+  }
+  if (tid <= kFmcsMaxSeedDegree) {
+    AtomMask m;
+    m.clear();
+    for (int a = 0; a < tNA; ++a) {
+      const int d = S.tRow[a + 1] - S.tRow[a];
+      if (d >= tid)
+        m.set(a);
+    }
+    S.degreeAtLeast[tid] = m;
+  }
+  // Bond classes: query bonds with identical compatibility rows share a
+  // class, which is the "equal keys mean identical predicates" contract of
+  // the subgraph frontend.  One thread; qNB <= 128.
+  if (tid == 0) {
+    int nc = 0;
+    for (int b = 0; b < qNB; ++b) {
+      const BondMask row = S.bondRow[b];
+      int            c   = kFmcsMaxBondClasses;
+      for (int k = 0; k < nc; ++k)
+        if (maskEquals(S.classRep[k], row)) {
+          c = k;
+          break;
+        }
+      if (c == kFmcsMaxBondClasses && nc < kFmcsMaxBondClasses) {
+        S.classRep[nc] = row;
+        c              = nc;
+        ++nc;
+      }
+      S.bondClass[b] = static_cast<uint8_t>(c);
+    }
+    S.numClasses = nc;
+  }
+  __syncthreads();
+
+  // Per-class target adjacency, filled through the shared subgraph component.
+  nvMolKit::subgraph::fillClassAdjacency(S.classAdj, S.numClasses, tNA, tid, blockThreads, [&](int atom, int cls) {
+    AtomMask m;
+    m.clear();
+    const BondMask row = S.classRep[cls];
+    const int      b0 = S.tRow[atom], b1 = S.tRow[atom + 1];
+    for (int e = b0; e < b1; ++e)
+      if (row.test(S.tBnd[e]))
+        m.set(S.tCol[e]);
+    return m;
+  });
+  __syncthreads();
+}
+
+// ---------------------------------------------------------------------------
+// Phase-1 direct single-bond match.
+// ---------------------------------------------------------------------------
+
+/// Resolved (target bond, endpoint) assignment for a successful single-bond
+/// match.  @c targetAtomU is the target atom the query bond's u endpoint
+/// mapped to (likewise V).  Contents are unspecified on failure.
 struct SingleBondMatch {
   uint8_t targetAtomU;
   uint8_t targetAtomV;
+  uint8_t targetBond;
 };
 
-/// Scratch for the exact substructure fallback.  One instance per
-/// concurrently-searching group; all fields are written under the caller's
-/// scratch ownership rules (see matchSeedWithSubstructureFallbackCooperative).
-///
-/// The search itself keeps its stack in lane-local registers
-/// (nvMolKit::dfsFromRoots); this scratch only carries the per-seed search
-/// order, the found flag the lanes race on, and the winning atom mapping.
-template <int maxAtoms, int maxTargetAtoms> struct FmcsSubstructureScratch {
-  std::uint8_t seedAtomList[maxAtoms];        ///< Seed's query atoms in index order.
-  std::uint8_t seedAtoms[maxAtoms];           ///< Search order: order position -> query atom.
-  std::uint8_t seedDegree[maxAtoms];          ///< Per query atom, its degree within the seed.
-  std::uint8_t targetDegree[maxTargetAtoms];  ///< Per target atom, its full degree.
-  std::uint8_t orderedQueryAtom[maxAtoms];    ///< 1 if the atom has been placed in the order.
-  std::uint8_t queryOrderPos[maxAtoms];       ///< Inverse of seedAtoms; kUnmappedTargetIdx if not in seed.
-  std::uint8_t targetAtomForQuery[maxAtoms];  ///< The winning embedding, indexed by query atom.
-  int          found;                         ///< Lanes race on this via atomicCAS; also the abort signal.
-
-  /// degreeAtLeast[d] = target atoms whose degree is at least d.  Indexed by a
-  /// seed atom's degree (clamped), it turns "targets this atom could occupy"
-  /// into one mask intersection instead of a scan over every target atom.
-  FmcsTargetMask<maxTargetAtoms> degreeAtLeast[kFmcsMaxSeedDegree + 1];
-
-  /// Back-edge table and per-depth candidates for the shared frontend
-  /// (src/subgraph/candidate_tables.cuh).  One group per instance, hence a single
-  /// warp slot.  No adjacency tables: MCS keys edges on query bond index, so
-  /// keys are all distinct and the plan is always General.
-  nvMolKit::subgraph::WarpSharedState<kFmcsMaskAtoms<maxTargetAtoms>, maxAtoms, 1, false> tables;
-};
-
+/// Within-thread: find the first target bond that embeds query bond
+/// @p queryBondIdx in either orientation.  Whether a one-bond seed embeds
+/// depends only on its bond, so phase 1 tests every query bond with one call
+/// each, in parallel.
 template <int maxAtoms, int maxBonds>
-__device__ __forceinline__ bool seedContainsBondWithinThread(const Seed<maxAtoms, maxBonds>& seed,
-                                                             const int                       queryBondIdx) {
-  using SeedT                    = Seed<maxAtoms, maxBonds>;
-  using BondWord                 = typename SeedT::bond_word_type;
-  constexpr int kBondBitsPerWord = SeedT::kBondBitsPerWord;
-  if (queryBondIdx < 0 || queryBondIdx >= maxBonds)
-    return false;
-  const BondWord word = seed.bonds[queryBondIdx / kBondBitsPerWord];
-  return ((word >> (queryBondIdx % kBondBitsPerWord)) & 1) != 0;
-}
-
-/// Within-thread: per-lane single-(query bond, target bond, orientation)
-/// compatibility check used by Phase 1 initial-seed enumeration.  Writes
-/// resolved target atom indices for the two endpoints of @p queryBondIdx
-/// into @p outMatch and returns true on success; on false the caller
-/// should not read @p outMatch.
-///
-/// @p reversed selects the orientation: when false, the query bond's u
-/// endpoint maps to the target bond's u endpoint; when true, to the
-/// target bond's v endpoint.
-__device__ __forceinline__ bool matchSingleBondWithinThread(const int                    queryBondIdx,
-                                                            const int                    targetBondIdx,
-                                                            const bool                   reversed,
-                                                            const DeviceCsrView&         queryTopology,
-                                                            const DeviceCsrView&         targetTopology,
-                                                            const PairMatchTablesDevice& tables,
-                                                            SingleBondMatch&             outMatch) {
-  // Cheap bond-table check first; if the bond labels are incompatible
-  // we never need to touch the atom table or decode endpoints.
-  if (!tables.bonds.testBit(queryBondIdx, targetBondIdx))
-    return false;
-
-  // Decode the packed (u<<16 | v) endpoint encoding for both bonds.
-  const std::uint32_t queryEndpoints = queryTopology.bondEndpoints[queryBondIdx];
-  const int           queryEndpointU = static_cast<int>(queryEndpoints >> kBondEndpointShift);
-  const int           queryEndpointV = static_cast<int>(queryEndpoints & kBondEndpointMask);
-
-  const std::uint32_t targetEndpoints = targetTopology.bondEndpoints[targetBondIdx];
-  const int           targetEndpointU = static_cast<int>(targetEndpoints >> kBondEndpointShift);
-  const int           targetEndpointV = static_cast<int>(targetEndpoints & kBondEndpointMask);
-
-  // Pick which target endpoint the query's u maps to; v gets the other.
-  // reversed=false: queryU -> targetU, queryV -> targetV.
-  // reversed=true:  queryU -> targetV, queryV -> targetU.
-  const int targetForQueryU = reversed ? targetEndpointV : targetEndpointU;
-  const int targetForQueryV = reversed ? targetEndpointU : targetEndpointV;
-
-  // Both atom-pairings must be label-compatible; either failure rejects
-  // this orientation.
-  if (!tables.atoms.testBit(queryEndpointU, targetForQueryU))
-    return false;
-  if (!tables.atoms.testBit(queryEndpointV, targetForQueryV))
-    return false;
-
-  outMatch.targetAtomU = static_cast<uint8_t>(targetForQueryU);
-  outMatch.targetAtomV = static_cast<uint8_t>(targetForQueryV);
-  return true;
-}
-
-/// Cooperative greedy fast path: try to extend @p match by every query
-/// bond in @p seed.bonds whose @c match.targetBondIdx[q] is still
-/// @ref kUnmappedTargetIdx (i.e., unmapped by the parent's recorded
-/// embedding).  For each such bond:
-///   - Both endpoints already mapped -> ring-closing case.  The lanes
-///     of @p group scan target bonds in parallel for one whose endpoint
-///     pair exactly matches the mapped (queryU, queryV) target atoms
-///     and is unvisited, with the bond-match-table bit set.  First
-///     compatible target bond commits.
-///   - Exactly one endpoint mapped -> atom-adding case.  Lane-parallel
-///     scan for a target bond incident to the mapped target atom whose
-///     other end is unvisited, atom-table-compatible with the unmapped
-///     query atom, and bond-table-compatible.  The first compatible
-///     candidate commits both the new bond mapping and the new atom
-///     mapping, and marks both visited.  This path does not backtrack
-///     if that greedy choice prevents a later bond from matching.
-///   - Both endpoints unmapped -> defensive fail (shouldn't occur on
-///     well-formed seeds, where Phase 1 maps both initial atoms before
-///     pushing).
-/// A true return proves that @p match was extended successfully.  A false
-/// return is inconclusive: the greedy choices may have missed another valid
-/// embedding.  The caller must run the exact substructure fallback before
-/// rejecting the seed or marking a NewBond dead.  On false, @p match is left
-/// in an unspecified state and must not be reused as a valid embedding.
-///
-/// Most seeds fall through to the fallback, so the fallback dominates
-/// matcher time.  Future optimization: build the target's packed adjacency
-/// once per block into shared memory -- it is fixed for the pair and this
-/// kernel is block-per-pair -- so the fallback's candidate build reads shared
-/// memory instead of walking the global CSR on every descent.
-template <int maxAtoms, int maxBonds, int maxTA, int maxTB, class GroupT>
-__device__ __forceinline__ bool tryMatchIncrementalGreedyCooperative(
-  const GroupT&                                  group,
-  const Seed<maxAtoms, maxBonds>&                seed,
-  const DeviceCsrView&                           queryTopology,
-  const DeviceCsrView&                           targetTopology,
-  const PairMatchTablesDevice&                   tables,
-  MatchResult<maxAtoms, maxBonds, maxTA, maxTB>& match) {
-  using SeedT    = Seed<maxAtoms, maxBonds>;
-  using MatchT   = MatchResult<maxAtoms, maxBonds, maxTA, maxTB>;
-  using BondWord = typename SeedT::bond_word_type;
-
-  constexpr int kBondBitsPerWord       = SeedT::kBondBitsPerWord;
-  constexpr int kBondWords             = SeedT::kBondWords;
-  constexpr int kTargetAtomBitsPerWord = MatchT::kTargetAtomBitsPerWord;
-  constexpr int kTargetBondBitsPerWord = MatchT::kTargetBondBitsPerWord;
-  using TargetAtomWord                 = typename MatchT::target_atom_word;
-  using TargetBondWord                 = typename MatchT::target_bond_word;
-
-  const int laneRank  = static_cast<int>(group.thread_rank());
-  const int laneCount = static_cast<int>(group.num_threads());
-
-  // Outer loop walks set bits of seed.bonds via __ffs/__ffsll.  Each
-  // iteration handles one query bond q; if q is already mapped (parent
-  // saw it) we skip, otherwise we extend the match by one bond +
-  // possibly one atom.
-  for (int wordIdx = 0; wordIdx < kBondWords; ++wordIdx) {
-    BondWord remainingBondBits = seed.bonds[wordIdx];
-    while (remainingBondBits != 0) {
-      int bitPosInWord;
-      if constexpr (sizeof(BondWord) == 4) {
-        bitPosInWord = __ffs(static_cast<unsigned int>(remainingBondBits)) - 1;
-      } else {
-        bitPosInWord = __ffsll(static_cast<unsigned long long>(remainingBondBits)) - 1;
-      }
-      const int queryBondIdx = wordIdx * kBondBitsPerWord + bitPosInWord;
-      remainingBondBits &= remainingBondBits - 1;  // clear lowest set bit
-
-      // Keep this control decision uniform across the group; diverging before
-      // the later ballot/shuffle would make the winning lane undefined.
-      int mappedTargetBond = kUnmappedTargetIdx;
-      if (laneRank == 0)
-        mappedTargetBond = match.targetBondIdx[queryBondIdx];
-      mappedTargetBond = group.shfl(mappedTargetBond, 0);
-      if (mappedTargetBond != kUnmappedTargetIdx)
-        continue;
-
-      // Decode this bond's query endpoints from the packed (u<<16 | v).
-      const std::uint32_t queryEndpoints = queryTopology.bondEndpoints[queryBondIdx];
-      const int           queryEndpointU = static_cast<int>(queryEndpoints >> kBondEndpointShift);
-      const int           queryEndpointV = static_cast<int>(queryEndpoints & kBondEndpointMask);
-
-      // Look up the parent's atom mapping for both endpoints; either
-      // may already be mapped (from an earlier bond) or still unmapped
-      // (this bond is the one bringing it in).
-      int targetForQueryU = kUnmappedTargetIdx;
-      int targetForQueryV = kUnmappedTargetIdx;
-      if (laneRank == 0) {
-        targetForQueryU = match.targetAtomIdx[queryEndpointU];
-        targetForQueryV = match.targetAtomIdx[queryEndpointV];
-      }
-      targetForQueryU           = group.shfl(targetForQueryU, 0);
-      targetForQueryV           = group.shfl(targetForQueryV, 0);
-      const bool queryUIsMapped = targetForQueryU != kUnmappedTargetIdx;
-      const bool queryVIsMapped = targetForQueryV != kUnmappedTargetIdx;
-
-      // Both endpoints unmapped means the seed is missing an earlier
-      // bond that should have brought one of them in.  Phase 1 always
-      // anchors both initial atoms before pushing, so this never hits
-      // for well-formed seeds; defensive return false.
-      if (!queryUIsMapped && !queryVIsMapped)
-        return false;
-
-      // Each lane records its first compatible target bond, and (for
-      // the atom-adding case) the resulting new target atom.  After
-      // the per-lane scan, the warp ballots and the lowest-rank winner
-      // is broadcast as the committed extension.
-      int chosenTargetBond            = -1;
-      int chosenTargetAtomForUnmapped = -1;  // -1 means ring-closing.
-
-      if (queryUIsMapped && queryVIsMapped) {
-        // Ring-closing: the new bond connects two atoms that are both
-        // already in the seed's mapping.  Find a target bond whose
-        // endpoints are exactly the pair { targetForQueryU, targetForQueryV }.
-        const int srcTargetAtom = targetForQueryU;
-        const int dstTargetAtom = targetForQueryV;
-        if (srcTargetAtom >= 0 && srcTargetAtom < targetTopology.numAtoms) {
-          const int begin = static_cast<int>(targetTopology.rowOffsets[srcTargetAtom]);
-          const int end   = static_cast<int>(targetTopology.rowOffsets[srcTargetAtom + 1]);
-          for (int adjIdx = begin + laneRank; adjIdx < end && chosenTargetBond < 0; adjIdx += laneCount) {
-            const int otherTargetAtom = static_cast<int>(targetTopology.colIndices[adjIdx]);
-            if (otherTargetAtom != dstTargetAtom)
-              continue;
-            const int targetBondIdx = static_cast<int>(targetTopology.bondIndices[adjIdx]);
-            if (targetBondIdx < 0 || targetBondIdx >= targetTopology.numBonds || targetBondIdx >= maxTB) {
-              continue;
-            }
-            const TargetBondWord visitedBondsWord = match.visitedTargetBonds[targetBondIdx / kTargetBondBitsPerWord];
-            if ((visitedBondsWord >> (targetBondIdx % kTargetBondBitsPerWord)) & 1) {
-              continue;
-            }
-            if (!tables.bonds.testBit(queryBondIdx, targetBondIdx))
-              continue;
-            chosenTargetBond = targetBondIdx;
-          }
-        }
-      } else {
-        // Atom-adding: one query endpoint (`src`) is already mapped to
-        // a target atom; the other (`dst`) is what we're trying to
-        // place.  Scan target bonds incident to srcTargetAtom for one
-        // whose other endpoint is unvisited, atom-table-compatible
-        // with the unmapped query atom, and bond-table-compatible.
-        const int unmappedQueryAtom = queryUIsMapped ? queryEndpointV : queryEndpointU;
-        const int srcTargetAtom     = queryUIsMapped ? targetForQueryU : targetForQueryV;
-        if (srcTargetAtom >= 0 && srcTargetAtom < targetTopology.numAtoms) {
-          const int begin = static_cast<int>(targetTopology.rowOffsets[srcTargetAtom]);
-          const int end   = static_cast<int>(targetTopology.rowOffsets[srcTargetAtom + 1]);
-          for (int adjIdx = begin + laneRank; adjIdx < end && chosenTargetBond < 0; adjIdx += laneCount) {
-            const int targetBondIdx = static_cast<int>(targetTopology.bondIndices[adjIdx]);
-            if (targetBondIdx < 0 || targetBondIdx >= targetTopology.numBonds || targetBondIdx >= maxTB) {
-              continue;
-            }
-            const TargetBondWord visitedBondsWord = match.visitedTargetBonds[targetBondIdx / kTargetBondBitsPerWord];
-            if ((visitedBondsWord >> (targetBondIdx % kTargetBondBitsPerWord)) & 1) {
-              continue;
-            }
-            const int candidateTargetAtom = static_cast<int>(targetTopology.colIndices[adjIdx]);
-            if (candidateTargetAtom < 0 || candidateTargetAtom >= targetTopology.numAtoms ||
-                candidateTargetAtom >= maxTA) {
-              continue;
-            }
-            const TargetAtomWord visitedAtomsWord =
-              match.visitedTargetAtoms[candidateTargetAtom / kTargetAtomBitsPerWord];
-            if ((visitedAtomsWord >> (candidateTargetAtom % kTargetAtomBitsPerWord)) & 1) {
-              continue;
-            }
-            if (!tables.bonds.testBit(queryBondIdx, targetBondIdx))
-              continue;
-            if (!tables.atoms.testBit(unmappedQueryAtom, candidateTargetAtom))
-              continue;
-            chosenTargetBond            = targetBondIdx;
-            chosenTargetAtomForUnmapped = candidateTargetAtom;
-          }
-        }
-      }
-
-      // Warp-wide pick: ballot for any lane with a candidate, broadcast
-      // the lowest-rank winner's choice to all lanes.  No candidate
-      // anywhere -> this bond can't be extended -> abandon the seed.
-      const unsigned ballot = group.ballot(chosenTargetBond >= 0 ? 1u : 0u);
-      if (ballot == 0u)
-        return false;
-      const int firstWinningLane    = __ffs(ballot) - 1;
-      const int committedTargetBond = group.shfl(chosenTargetBond, firstWinningLane);
-      const int committedTargetAtom = group.shfl(chosenTargetAtomForUnmapped, firstWinningLane);
-      if (committedTargetBond < 0 || committedTargetBond >= targetTopology.numBonds || committedTargetBond >= maxTB)
-        return false;
-      if (committedTargetAtom < -1 || committedTargetAtom >= targetTopology.numAtoms || committedTargetAtom >= maxTA)
-        return false;
-
-      // Lane 0 commits the new mapping into the shared MatchResult.
-      // Subsequent bonds in this same call will read the updated
-      // visited bitsets after group.sync below.
-      if (laneRank == 0) {
-        match.targetBondIdx[queryBondIdx] = static_cast<std::uint8_t>(committedTargetBond);
-        match.visitedTargetBonds[committedTargetBond / kTargetBondBitsPerWord] |=
-          static_cast<TargetBondWord>(1) << (committedTargetBond % kTargetBondBitsPerWord);
-        match.matchedBondSize += 1;
-        match.empty = false;
-        if (committedTargetAtom >= 0) {
-          // Atom-adding case: also commit the new atom mapping.
-          const int unmappedQueryAtom            = queryUIsMapped ? queryEndpointV : queryEndpointU;
-          match.targetAtomIdx[unmappedQueryAtom] = static_cast<std::uint8_t>(committedTargetAtom);
-          match.visitedTargetAtoms[committedTargetAtom / kTargetAtomBitsPerWord] |=
-            static_cast<TargetAtomWord>(1) << (committedTargetAtom % kTargetAtomBitsPerWord);
-          match.matchedAtomSize += 1;
-        }
-      }
-      group.sync();
+__device__ __forceinline__ bool matchSingleBondWithinThread(const FmcsPairShared<maxAtoms, maxBonds>& S,
+                                                            const int                                 queryBondIdx,
+                                                            SingleBondMatch&                          outMatch) {
+  using BondMask = typename FmcsPairShared<maxAtoms, maxBonds>::BondMask;
+  const int u = S.qEpU[queryBondIdx], v = S.qEpV[queryBondIdx];
+  BondMask  row = S.bondRow[queryBondIdx];
+  while (!row.empty()) {
+    const int j = row.lowest();
+    row.clearLowest();
+    const int tu = S.tEpU[j], tv = S.tEpV[j];
+    if (S.atomRow[u].test(tu) && S.atomRow[v].test(tv)) {
+      outMatch.targetAtomU = static_cast<uint8_t>(tu);
+      outMatch.targetAtomV = static_cast<uint8_t>(tv);
+      outMatch.targetBond  = static_cast<uint8_t>(j);
+      return true;
     }
-  }
-  return true;
-}
-
-__device__ __forceinline__ bool findTargetBondBetweenAtomsWithinThread(const int                    targetAtomA,
-                                                                       const int                    targetAtomB,
-                                                                       const int                    queryBondIdx,
-                                                                       const DeviceCsrView&         targetTopology,
-                                                                       const PairMatchTablesDevice& tables,
-                                                                       int&                         outTargetBondIdx) {
-  if (targetAtomA < 0 || targetAtomA >= targetTopology.numAtoms) {
-    return false;
-  }
-  const int begin = static_cast<int>(targetTopology.rowOffsets[targetAtomA]);
-  const int end   = static_cast<int>(targetTopology.rowOffsets[targetAtomA + 1]);
-  for (int adjIdx = begin; adjIdx < end; ++adjIdx) {
-    const int otherTargetAtom = static_cast<int>(targetTopology.colIndices[adjIdx]);
-    if (otherTargetAtom != targetAtomB)
-      continue;
-    const int targetBondIdx = static_cast<int>(targetTopology.bondIndices[adjIdx]);
-    if (targetBondIdx < 0 || targetBondIdx >= targetTopology.numBonds) {
-      continue;
+    if (S.atomRow[u].test(tv) && S.atomRow[v].test(tu)) {
+      outMatch.targetAtomU = static_cast<uint8_t>(tv);
+      outMatch.targetAtomV = static_cast<uint8_t>(tu);
+      outMatch.targetBond  = static_cast<uint8_t>(j);
+      return true;
     }
-    if (!tables.bonds.testBit(queryBondIdx, targetBondIdx))
-      continue;
-    outTargetBondIdx = targetBondIdx;
-    return true;
   }
   return false;
 }
 
-template <int maxAtoms, int maxBonds, int maxTA, int maxTB>
-__device__ __forceinline__ bool rebuildMatchFromSubstructureMappingWithinThread(
-  const Seed<maxAtoms, maxBonds>&                seed,
-  const DeviceCsrView&                           queryTopology,
-  const DeviceCsrView&                           targetTopology,
-  const PairMatchTablesDevice&                   tables,
-  MatchResult<maxAtoms, maxBonds, maxTA, maxTB>& match,
-  FmcsSubstructureScratch<maxAtoms, maxTA>&      scratch) {
-  using SeedT          = Seed<maxAtoms, maxBonds>;
-  using MatchT         = MatchResult<maxAtoms, maxBonds, maxTA, maxTB>;
-  using BondWord       = typename SeedT::bond_word_type;
-  using TargetBondWord = typename MatchT::target_bond_word;
-  using TargetAtomWord = typename MatchT::target_atom_word;
+// ---------------------------------------------------------------------------
+// Remaining-size bound (RDKit canGrowBiggerThan support), warp-parallel BFS
+// over the shared query CSR.
+// ---------------------------------------------------------------------------
+template <int maxAtoms, int maxBonds, class GroupT>
+__device__ __forceinline__ void seedComputeRemainingSizeCooperative(const GroupT&                       group,
+                                                                    FmcsPairShared<maxAtoms, maxBonds>& S,
+                                                                    Seed<maxAtoms, maxBonds>&           seed) {
+  using AtomMask          = typename FmcsPairShared<maxAtoms, maxBonds>::AtomMask;
+  using BondMask          = typename FmcsPairShared<maxAtoms, maxBonds>::BondMask;
+  constexpr int kAtomRegs = FmcsPairShared<maxAtoms, maxBonds>::kAtomRegs;
 
-  constexpr int kBondBitsPerWord       = SeedT::kBondBitsPerWord;
-  constexpr int kBondWords             = SeedT::kBondWords;
-  constexpr int kTargetAtomBitsPerWord = MatchT::kTargetAtomBitsPerWord;
-  constexpr int kTargetBondBitsPerWord = MatchT::kTargetBondBitsPerWord;
+  const int lane  = static_cast<int>(group.thread_rank());
+  AtomMask  visA  = maskFromWords<kFmcsMaskAtoms<maxAtoms>>(seed.atoms);
+  BondMask  visB  = maskFromWords<kFmcsMaskAtoms<maxBonds>>(seed.excludedBonds);
+  AtomMask  front = maskFromWords<kFmcsMaskAtoms<maxAtoms>>(seed.lastAddedAtoms);
+  const int baseA = visA.popcount();
+  const int baseB = visB.popcount();
 
-  matchResultClearWithinThread(match);
-  for (int i = 0; i < seed.numAtoms; ++i) {
-    const int queryAtomIdx  = scratch.seedAtomList[i];
-    const int targetAtomIdx = scratch.targetAtomForQuery[queryAtomIdx];
-    if (targetAtomIdx == kUnmappedTargetIdx)
-      return false;
-    match.targetAtomIdx[queryAtomIdx] = static_cast<std::uint8_t>(targetAtomIdx);
-    match.visitedTargetAtoms[targetAtomIdx / kTargetAtomBitsPerWord] |= static_cast<TargetAtomWord>(1)
-                                                                     << (targetAtomIdx % kTargetAtomBitsPerWord);
-  }
-  match.matchedAtomSize = seed.numAtoms;
-
-  int matchedBondCount = 0;
-  for (int wordIdx = 0; wordIdx < kBondWords; ++wordIdx) {
-    BondWord remaining = seed.bonds[wordIdx];
-    while (remaining != 0) {
-      int bitPosInWord;
-      if constexpr (sizeof(BondWord) == 4) {
-        bitPosInWord = __ffs(static_cast<unsigned int>(remaining)) - 1;
-      } else {
-        bitPosInWord = __ffsll(static_cast<unsigned long long>(remaining)) - 1;
-      }
-      const int queryBondIdx = wordIdx * kBondBitsPerWord + bitPosInWord;
-      remaining &= remaining - 1;
-
-      const std::uint32_t queryEndpoints  = queryTopology.bondEndpoints[queryBondIdx];
-      const int           queryEndpointU  = static_cast<int>(queryEndpoints >> kBondEndpointShift);
-      const int           queryEndpointV  = static_cast<int>(queryEndpoints & kBondEndpointMask);
-      const int           targetEndpointU = match.targetAtomIdx[queryEndpointU];
-      const int           targetEndpointV = match.targetAtomIdx[queryEndpointV];
-      if (targetEndpointU == kUnmappedTargetIdx || targetEndpointV == kUnmappedTargetIdx) {
-        matchResultClearWithinThread(match);
-        return false;
-      }
-
-      int targetBondIdx = -1;
-      if (!findTargetBondBetweenAtomsWithinThread(targetEndpointU,
-                                                  targetEndpointV,
-                                                  queryBondIdx,
-                                                  targetTopology,
-                                                  tables,
-                                                  targetBondIdx)) {
-        matchResultClearWithinThread(match);
-        return false;
-      }
-      const TargetBondWord visitedWord = match.visitedTargetBonds[targetBondIdx / kTargetBondBitsPerWord];
-      if ((visitedWord >> (targetBondIdx % kTargetBondBitsPerWord)) & 1) {
-        matchResultClearWithinThread(match);
-        return false;
-      }
-      match.targetBondIdx[queryBondIdx] = static_cast<std::uint8_t>(targetBondIdx);
-      match.visitedTargetBonds[targetBondIdx / kTargetBondBitsPerWord] |= static_cast<TargetBondWord>(1)
-                                                                       << (targetBondIdx % kTargetBondBitsPerWord);
-      ++matchedBondCount;
-    }
-  }
-  match.matchedBondSize = static_cast<std::uint16_t>(matchedBondCount);
-  if (matchedBondCount != seed.numBonds) {
-    matchResultClearWithinThread(match);
-    return false;
-  }
-  match.empty = false;
-  return true;
-}
-
-/// Row @p queryAtomIdx of the atom match table as a target-atom bitset.
-/// Rows are 32-bit-word-packed LSB-first, exactly TargetMask's word layout,
-/// so this is straight word loads.  Bits at or above the table's column
-/// count are never set (rows are zero-initialised on the host).
-template <int maxTA>
-__device__ __forceinline__ FmcsTargetMask<maxTA> atomRowMask(const MatchTableDevice& table, const int queryAtomIdx) {
-  FmcsTargetMask<maxTA> mask;
-  mask.clear();
-  const std::uint32_t* rowWords = table.data + static_cast<size_t>(queryAtomIdx) * table.wordsPerRow;
+  while (!front.empty()) {
+    BondMask bondAcc;
+    AtomMask candAcc;
+    bondAcc.clear();
+    candAcc.clear();
 #pragma unroll
-  for (int wordIdx = 0; wordIdx < static_cast<int>(sizeof(FmcsTargetMask<maxTA>) / 4); ++wordIdx) {
-    if (wordIdx < table.wordsPerRow) {
-      mask.setWord32(wordIdx, rowWords[wordIdx]);
-    }
-  }
-  return mask;
-}
-
-template <int maxAtoms, int maxTA, class GroupT>
-__device__ __forceinline__ void initializeSeedSubstructureScratchCooperative(
-  const GroupT&                             group,
-  const DeviceCsrView&                      targetTopology,
-  FmcsSubstructureScratch<maxAtoms, maxTA>& scratch) {
-  const int laneRank  = static_cast<int>(group.thread_rank());
-  const int laneCount = static_cast<int>(group.num_threads());
-
-  for (int i = laneRank; i < maxAtoms; i += laneCount) {
-    scratch.seedDegree[i]         = 0;
-    scratch.orderedQueryAtom[i]   = 0;
-    scratch.queryOrderPos[i]      = kUnmappedTargetIdx;
-    scratch.targetAtomForQuery[i] = kUnmappedTargetIdx;
-  }
-
-  for (int targetAtomIdx = laneRank; targetAtomIdx < targetTopology.numAtoms; targetAtomIdx += laneCount) {
-    scratch.targetDegree[targetAtomIdx] = static_cast<std::uint8_t>(targetTopology.rowOffsets[targetAtomIdx + 1] -
-                                                                    targetTopology.rowOffsets[targetAtomIdx]);
-  }
-
-  group.sync();
-
-  // One lane per bucket, each scanning the target atoms once.  Cheaper than a
-  // masked reduction and it keeps every bucket's build independent.
-  if (laneRank <= kFmcsMaxSeedDegree) {
-    FmcsTargetMask<maxTA> bucket;
-    bucket.clear();
-    for (int targetAtomIdx = 0; targetAtomIdx < targetTopology.numAtoms && targetAtomIdx < maxTA; ++targetAtomIdx) {
-      if (scratch.targetDegree[targetAtomIdx] >= laneRank) {
-        bucket.set(targetAtomIdx);
-      }
-    }
-    scratch.degreeAtLeast[laneRank] = bucket;
-  }
-
-  if (laneRank == 0) {
-    scratch.found = 0;
-  }
-  group.sync();
-}
-
-template <int maxAtoms, int maxBonds, int maxTA>
-__device__ __forceinline__ bool prepareSeedSubstructureSearchWithinThread(
-  const Seed<maxAtoms, maxBonds>&           seed,
-  const DeviceCsrView&                      queryTopology,
-  const DeviceCsrView&                      targetTopology,
-  const PairMatchTablesDevice&              tables,
-  FmcsSubstructureScratch<maxAtoms, maxTA>& scratch,
-  int&                                      numSeedAtoms) {
-  using SeedT    = Seed<maxAtoms, maxBonds>;
-  using AtomWord = typename SeedT::atom_word_type;
-  using BondWord = typename SeedT::bond_word_type;
-
-  constexpr int kAtomBitsPerWord = SeedT::kAtomBitsPerWord;
-  constexpr int kAtomWords       = SeedT::kAtomWords;
-  constexpr int kBondBitsPerWord = SeedT::kBondBitsPerWord;
-  constexpr int kBondWords       = SeedT::kBondWords;
-
-  if (seed.numAtoms > targetTopology.numAtoms || seed.numBonds > targetTopology.numBonds) {
-    return false;
-  }
-
-  numSeedAtoms = 0;
-  for (int wordIdx = 0; wordIdx < kAtomWords; ++wordIdx) {
-    AtomWord remaining = seed.atoms[wordIdx];
-    while (remaining != 0) {
-      int bitPosInWord;
-      if constexpr (sizeof(AtomWord) == 4) {
-        bitPosInWord = __ffs(static_cast<unsigned int>(remaining)) - 1;
-      } else {
-        bitPosInWord = __ffsll(static_cast<unsigned long long>(remaining)) - 1;
-      }
-      const int queryAtomIdx = wordIdx * kAtomBitsPerWord + bitPosInWord;
-      remaining &= remaining - 1;
-      if (queryAtomIdx < queryTopology.numAtoms) {
-        scratch.seedAtomList[numSeedAtoms++] = static_cast<std::uint8_t>(queryAtomIdx);
-      }
-    }
-  }
-  if (numSeedAtoms != seed.numAtoms)
-    return false;
-
-  for (int wordIdx = 0; wordIdx < kBondWords; ++wordIdx) {
-    BondWord remaining = seed.bonds[wordIdx];
-    while (remaining != 0) {
-      int bitPosInWord;
-      if constexpr (sizeof(BondWord) == 4) {
-        bitPosInWord = __ffs(static_cast<unsigned int>(remaining)) - 1;
-      } else {
-        bitPosInWord = __ffsll(static_cast<unsigned long long>(remaining)) - 1;
-      }
-      const int queryBondIdx = wordIdx * kBondBitsPerWord + bitPosInWord;
-      remaining &= remaining - 1;
-
-      const std::uint32_t queryEndpoints = queryTopology.bondEndpoints[queryBondIdx];
-      const int           queryEndpointU = static_cast<int>(queryEndpoints >> kBondEndpointShift);
-      const int           queryEndpointV = static_cast<int>(queryEndpoints & kBondEndpointMask);
-      ++scratch.seedDegree[queryEndpointU];
-      ++scratch.seedDegree[queryEndpointV];
-    }
-  }
-
-  for (int orderPos = 0; orderPos < numSeedAtoms; ++orderPos) {
-    int bestAtom                = -1;
-    int bestMappedNeighborCount = -1;
-    int bestDegree              = -1;
-    int bestCandidateCount      = maxTA + 1;
-
-    for (int atomListIdx = 0; atomListIdx < numSeedAtoms; ++atomListIdx) {
-      const int queryAtomIdx = scratch.seedAtomList[atomListIdx];
-      if (scratch.orderedQueryAtom[queryAtomIdx])
-        continue;
-
-      int mappedNeighborCount = 0;
-      if (orderPos > 0) {
-        const int begin = static_cast<int>(queryTopology.rowOffsets[queryAtomIdx]);
-        const int end   = static_cast<int>(queryTopology.rowOffsets[queryAtomIdx + 1]);
-        for (int adjIdx = begin; adjIdx < end; ++adjIdx) {
-          const int queryBondIdx = static_cast<int>(queryTopology.bondIndices[adjIdx]);
-          if (queryBondIdx >= queryTopology.numBonds ||
-              !seedContainsBondWithinThread<maxAtoms, maxBonds>(seed, queryBondIdx)) {
+    for (int r = 0; r < kAtomRegs; ++r) {
+      const int a = lane + r * 32;
+      if (a < maxAtoms && front.test(a)) {
+        const int b0 = S.qRow[a], b1 = S.qRow[a + 1];
+        for (int e = b0; e < b1; ++e) {
+          const int b = S.qBnd[e];
+          if (visB.test(b))
             continue;
-          }
-          const int otherQueryAtom = static_cast<int>(queryTopology.colIndices[adjIdx]);
-          if (otherQueryAtom >= 0 && otherQueryAtom < queryTopology.numAtoms &&
-              scratch.orderedQueryAtom[otherQueryAtom]) {
-            ++mappedNeighborCount;
-          }
-        }
-      }
-      if (orderPos > 0 && mappedNeighborCount == 0)
-        continue;
-
-      FmcsTargetMask<maxTA> candidates = atomRowMask<maxTA>(tables.atoms, queryAtomIdx);
-      candidates.andEq(
-        scratch.degreeAtLeast[min(static_cast<int>(scratch.seedDegree[queryAtomIdx]), kFmcsMaxSeedDegree)]);
-      const int candidateCount = candidates.popcount();
-      if (candidateCount == 0)
-        return false;
-
-      const int  degree = scratch.seedDegree[queryAtomIdx];
-      const bool better = bestAtom < 0 || mappedNeighborCount > bestMappedNeighborCount ||
-                          (mappedNeighborCount == bestMappedNeighborCount && degree > bestDegree) ||
-                          (mappedNeighborCount == bestMappedNeighborCount && degree == bestDegree &&
-                           candidateCount < bestCandidateCount) ||
-                          (mappedNeighborCount == bestMappedNeighborCount && degree == bestDegree &&
-                           candidateCount == bestCandidateCount && queryAtomIdx < bestAtom);
-      if (better) {
-        bestAtom                = queryAtomIdx;
-        bestMappedNeighborCount = mappedNeighborCount;
-        bestDegree              = degree;
-        bestCandidateCount      = candidateCount;
-      }
-    }
-
-    if (bestAtom < 0) {
-      for (int atomListIdx = 0; atomListIdx < numSeedAtoms; ++atomListIdx) {
-        const int queryAtomIdx = scratch.seedAtomList[atomListIdx];
-        if (!scratch.orderedQueryAtom[queryAtomIdx]) {
-          bestAtom = queryAtomIdx;
-          break;
+          bondAcc.set(b);
+          candAcc.set(S.qCol[e]);
         }
       }
     }
-    if (bestAtom < 0)
-      return false;
-    scratch.seedAtoms[orderPos]        = static_cast<std::uint8_t>(bestAtom);
-    scratch.orderedQueryAtom[bestAtom] = 1;
-    scratch.queryOrderPos[bestAtom]    = static_cast<std::uint8_t>(orderPos);
+    bondAcc = warpOrMask(group, bondAcc);
+    candAcc = warpOrMask(group, candAcc);
+    maskOrEq(visB, bondAcc);
+    AtomMask newFront = candAcc;
+    newFront.andNotEq(visA);
+    maskOrEq(visA, newFront);
+    front = newFront;
   }
-  return true;
+  if (lane == 0) {
+    seed.remainingBonds = static_cast<uint16_t>(visB.popcount() - baseB);
+    seed.remainingAtoms = static_cast<uint16_t>(visA.popcount() - baseA);
+  }
+  group.sync();
 }
 
-/// Presents a seed inside its query molecule to the shared subgraph frontend
-/// (src/subgraph/candidate_tables.cuh).
-///
-/// Depth is an order position in @c scratch.seedAtoms, the most-constrained-first
-/// permutation over the seed's atoms, so the frontend searches only the seed and
-/// in that order.  Query edges are the seed's bonds: a CSR slot whose bond is
-/// outside the seed, or whose far atom has no order position, reports
-/// @c kNoNeighborDepth and so constrains nothing.
-///
-/// The edge key is the query bond index, and @ref neighborsMatching resolves it
-/// through the (query bond, target bond) match table.  Because every bond index
-/// is distinct the plan is always General, which is why the scratch omits the
-/// adjacency tables.  Keying on the uint16 edge label instead would let
-/// Uniform/Dual precompute fire -- MCS queries carry few distinct labels -- but
-/// needs the labels uploaded to the device, which they are not today.
-///
-/// Precondition: no seed atom exceeds @c kMaxEdgeSlotsPerAtom CSR neighbours,
-/// which holds for molecular graphs (nvMolKit caps packed degree at 8).
-template <int maxAtoms, int maxBonds, int maxTA, int maxTB> struct McsSeedAdapter {
-  using Mask                              = FmcsTargetMask<maxTA>;
-  static constexpr bool kCachesTargetRows = false;
+// ---------------------------------------------------------------------------
+// Exact seed-in-target substructure check.
+// ---------------------------------------------------------------------------
 
-  const Seed<maxAtoms, maxBonds>*                 seed;
-  const DeviceCsrView*                            queryTopology;
-  const DeviceCsrView*                            targetTopology;
-  const PairMatchTablesDevice*                    tables;
-  const FmcsSubstructureScratch<maxAtoms, maxTA>* scratch;
+/// General-fallback candidate term for a query bond beyond the class-table
+/// capacity: target atoms reachable from @p targetAtom over a target bond
+/// the query bond's compatibility row accepts.  Reads only shared memory.
+template <int maxAtoms, int maxBonds>
+__device__ __forceinline__ typename FmcsPairShared<maxAtoms, maxBonds>::AtomMask
+           neighborsMatchingSlow(const FmcsPairShared<maxAtoms, maxBonds>& S, int targetAtom, int queryBond) {
+  using AtomMask = typename FmcsPairShared<maxAtoms, maxBonds>::AtomMask;
+  AtomMask m;
+  m.clear();
+  const auto& row = S.bondRow[queryBond];
+  const int   b0 = S.tRow[targetAtom], b1 = S.tRow[targetAtom + 1];
+  for (int e = b0; e < b1; ++e)
+    if (row.test(S.tBnd[e]))
+      m.set(S.tCol[e]);
+  return m;
+}
 
-  __device__ __forceinline__ int queryAtomAt(int depth) const { return scratch->seedAtoms[depth]; }
-
-  __device__ __forceinline__ int degreeAt(int depth) const {
-    const int queryAtomIdx = queryAtomAt(depth);
-    return static_cast<int>(queryTopology->rowOffsets[queryAtomIdx + 1]) -
-           static_cast<int>(queryTopology->rowOffsets[queryAtomIdx]);
+/// The label+degree candidate term for search depth @p d of group @p g.
+template <int maxAtoms, int maxBonds>
+__device__ __forceinline__ typename FmcsPairShared<maxAtoms, maxBonds>::AtomMask
+           depthCandidateTerm(const FmcsPairShared<maxAtoms, maxBonds>& S, int g, int d) {
+  using Config = FmcsKernelConfig<maxAtoms>;
+  if constexpr (Config::cacheDepthCandidates) {
+    return S.depthCandidates[g][d];
+  } else {
+    const int a  = S.order[g][d];
+    const int dg = S.seedDegree[g][a];
+    auto      c  = S.atomRow[a];
+    c.andEq(S.degreeAtLeast[dg > kFmcsMaxSeedDegree ? kFmcsMaxSeedDegree : dg]);
+    return c;
   }
+}
 
-  __device__ __forceinline__ int neighborDepthAt(int depth, int slot) const {
-    const int adjIdx       = static_cast<int>(queryTopology->rowOffsets[queryAtomAt(depth)]) + slot;
-    const int queryBondIdx = static_cast<int>(queryTopology->bondIndices[adjIdx]);
-    if (queryBondIdx >= queryTopology->numBonds ||
-        !seedContainsBondWithinThread<maxAtoms, maxBonds>(*seed, queryBondIdx)) {
-      return nvMolKit::subgraph::kNoNeighborDepth;
-    }
-    const int otherQueryAtom = static_cast<int>(queryTopology->colIndices[adjIdx]);
-    if (otherQueryAtom < 0 || otherQueryAtom >= queryTopology->numAtoms) {
-      return nvMolKit::subgraph::kNoNeighborDepth;
-    }
-    const int orderPos = scratch->queryOrderPos[otherQueryAtom];
-    return orderPos == kUnmappedTargetIdx ? nvMolKit::subgraph::kNoNeighborDepth : orderPos;
-  }
+/// Build the most-constrained-first search order and back-edge table for
+/// @p seed, warp-parallel.  Returns the number of seed atoms, or -1 if some
+/// seed atom provably has no degree-compatible target.
+template <int maxAtoms, int maxBonds, class GroupT>
+__device__ int prepareSeedSearchCooperative(const GroupT&                       group,
+                                            FmcsPairShared<maxAtoms, maxBonds>& S,
+                                            const Seed<maxAtoms, maxBonds>&     seed,
+                                            int                                 g) {
+  using Config            = FmcsKernelConfig<maxAtoms>;
+  using AtomMask          = typename FmcsPairShared<maxAtoms, maxBonds>::AtomMask;
+  using BondMask          = typename FmcsPairShared<maxAtoms, maxBonds>::BondMask;
+  constexpr int kAtomRegs = FmcsPairShared<maxAtoms, maxBonds>::kAtomRegs;
 
-  __device__ __forceinline__ std::uint32_t edgeKeyAt(int depth, int slot) const {
-    return queryTopology->bondIndices[static_cast<int>(queryTopology->rowOffsets[queryAtomAt(depth)]) + slot];
-  }
+  const int      lane      = static_cast<int>(group.thread_rank());
+  const int      qNA       = S.qNA;
+  const BondMask seedBonds = maskFromWords<kFmcsMaskAtoms<maxBonds>>(seed.bonds);
 
-  __device__ __forceinline__ Mask neighborsMatching(int targetAtom, std::uint32_t queryBondIdx) const {
-    Mask mask;
-    mask.clear();
-    const int begin = static_cast<int>(targetTopology->rowOffsets[targetAtom]);
-    const int end   = static_cast<int>(targetTopology->rowOffsets[targetAtom + 1]);
-    for (int adjIdx = begin; adjIdx < end; ++adjIdx) {
-      const int targetBondIdx = static_cast<int>(targetTopology->bondIndices[adjIdx]);
-      if (targetBondIdx < 0 || targetBondIdx >= targetTopology->numBonds || targetBondIdx >= maxTB) {
-        continue;
+  int      fail = 0;
+  AtomMask neighborReg[kAtomRegs];
+#pragma unroll
+  for (int r = 0; r < kAtomRegs; ++r) {
+    neighborReg[r].clear();
+    const int a = lane + r * 32;
+    if (a < qNA) {
+      const bool inSeed = wordsTest(seed.atoms, a);
+      S.orderPos[g][a]  = kUnmappedTargetIdx;
+      int      deg      = 0;
+      AtomMask ns;
+      ns.clear();
+      if (inSeed) {
+        BondMask incident = S.incidentBonds[a];
+        incident.andEq(seedBonds);
+        deg          = incident.popcount();
+        const int b0 = S.qRow[a], b1 = S.qRow[a + 1];
+        for (int e = b0; e < b1; ++e)
+          if (seedBonds.test(S.qBnd[e]))
+            ns.set(S.qCol[e]);
+        AtomMask cand = S.atomRow[a];
+        cand.andEq(S.degreeAtLeast[deg > kFmcsMaxSeedDegree ? kFmcsMaxSeedDegree : deg]);
+        if (cand.empty())
+          fail = 1;
       }
-      if (!tables->bonds.testBit(static_cast<int>(queryBondIdx), targetBondIdx)) {
-        continue;
-      }
-      const int neighborTargetAtom = static_cast<int>(targetTopology->colIndices[adjIdx]);
-      if (neighborTargetAtom >= 0 && neighborTargetAtom < targetTopology->numAtoms && neighborTargetAtom < maxTA) {
-        mask.set(neighborTargetAtom);
-      }
-    }
-    return mask;
-  }
-};
-
-/// Exact seed-in-target substructure check: a lane-parallel DFS
-/// (nvMolKit::dfsFromRoots) racing for one embedding.
-///
-/// Lane L searches the subtrees rooted at compatible target atoms L,
-/// L+laneCount, ... for the seed atom at order position 0; the search order
-/// over seed atoms is the most-constrained-first permutation computed by
-/// @ref prepareSeedSubstructureSearchWithinThread.  The candidate set is
-/// the canonical intersection (see src/subgraph/warp_dfs.cuh): the query
-/// atom's match-table row, minus used target atoms, intersected per seed
-/// back edge with the neighbours of the mapped target atom reachable over a
-/// bond whose (query bond, target bond) match-table bit is set.
-///
-/// The first lane to complete an embedding wins @c scratch.found by
-/// atomicCAS and records the atom mapping; every other lane stops at its
-/// next abort poll.  Lane 0 then rebuilds @p match (including the bond
-/// mapping) from the recorded atoms.  The search is exhaustive within
-/// bounded memory -- the stack is O(seed atoms) of lane-local registers, with
-/// no partial-mapping buffer to overflow -- so a false return proves the seed
-/// does not embed in the target.
-///
-/// Group-uniform: all lanes of @p group must call this together.  The
-/// caller must own @p scratch for the duration of the call.
-template <int maxAtoms, int maxBonds, int maxTA, int maxTB, class GroupT>
-__device__ __forceinline__ bool matchSeedSubstructureCooperative(const GroupT&                   group,
-                                                                 const Seed<maxAtoms, maxBonds>& seed,
-                                                                 const DeviceCsrView&            queryTopology,
-                                                                 const DeviceCsrView&            targetTopology,
-                                                                 const PairMatchTablesDevice&    tables,
-                                                                 MatchResult<maxAtoms, maxBonds, maxTA, maxTB>& match,
-                                                                 FmcsSubstructureScratch<maxAtoms, maxTA>& scratch) {
-  using Mask = FmcsTargetMask<maxTA>;
-
-  const int laneRank  = static_cast<int>(group.thread_rank());
-  const int laneCount = static_cast<int>(group.num_threads());
-
-  int numSeedAtoms = 0;
-  int prepared     = 0;
-  if (laneRank == 0) {
-    matchResultClearWithinThread(match);
-  }
-  if (seed.numAtoms != 0) {
-    initializeSeedSubstructureScratchCooperative(group, targetTopology, scratch);
-  }
-  if (laneRank == 0) {
-    if (seed.numAtoms == 0) {
-      prepared = (seed.numBonds == 0) ? 2 : -1;
-    } else {
-      prepared =
-        prepareSeedSubstructureSearchWithinThread(seed, queryTopology, targetTopology, tables, scratch, numSeedAtoms) ?
-          1 :
-          -1;
+      S.seedDegree[g][a] = static_cast<uint8_t>(deg);
+      neighborReg[r]     = ns;
     }
   }
   group.sync();
-  prepared     = group.shfl(prepared, 0);
-  numSeedAtoms = group.shfl(numSeedAtoms, 0);
-  if (prepared == 2)
-    return true;
-  if (prepared < 0) {
-    return false;
-  }
+  if (group.any(fail != 0))
+    return -1;
 
-  // Roots: target atoms compatible with the first seed atom in search order,
-  // degree-filtered, striped across the lanes.
-  const int firstQueryAtom = scratch.seedAtoms[0];
-  Mask      laneStripe;
+  // Greedy order: at each position pick the unordered seed atom maximising
+  // (mapped-neighbor count, seed degree, fewest candidates, lowest index),
+  // packed into one warp-max key.  Same heuristic as before, evaluated
+  // warp-parallel.
+  const int n         = seed.numAtoms;
+  AtomMask  unordered = maskFromWords<kFmcsMaskAtoms<maxAtoms>>(seed.atoms);
+  AtomMask  ordered;
+  ordered.clear();
+  for (int d = 0; d < n; ++d) {
+    unsigned bestKey = 0;
+#pragma unroll
+    for (int r = 0; r < kAtomRegs; ++r) {
+      const int a = lane + r * 32;
+      if (a < qNA && unordered.test(a)) {
+        AtomMask mapped = neighborReg[r];
+        mapped.andEq(ordered);
+        const int mappedNeighbors = mapped.popcount();
+        if (d == 0 || mappedNeighbors != 0) {
+          const int deg  = S.seedDegree[g][a];
+          AtomMask  cand = S.atomRow[a];
+          cand.andEq(S.degreeAtLeast[deg > kFmcsMaxSeedDegree ? kFmcsMaxSeedDegree : deg]);
+          const int      cc  = cand.popcount();
+          const unsigned key = (static_cast<unsigned>(mappedNeighbors) << 24) | (static_cast<unsigned>(deg) << 20) |
+                               (static_cast<unsigned>(128 - cc) << 8) | static_cast<unsigned>(127 - a) | 0x80u;
+          bestKey = max(bestKey, key);
+        }
+      }
+    }
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1)
+      bestKey = max(bestKey, group.shfl_xor(bestKey, off));
+    int pick;
+    if (bestKey == 0) {
+      pick = unordered.lowest();  // disconnected fallback (unreached for connected seeds)
+    } else {
+      pick = 127 - static_cast<int>(bestKey & 0x7Fu);
+    }
+    if (lane == 0)
+      S.order[g][d] = static_cast<uint8_t>(pick);
+    S.orderPos[g][pick] = static_cast<uint8_t>(d);
+    ordered.set(pick);
+    unordered.reset(pick);
+  }
+  group.sync();
+
+  // Per depth: candidate term (when cached) and deduplicated back edges.
+  for (int d = lane; d < n; d += kFmcsGroupSize) {
+    const int a = S.order[g][d];
+    if constexpr (Config::cacheDepthCandidates) {
+      const int dg   = S.seedDegree[g][a];
+      AtomMask  cand = S.atomRow[a];
+      cand.andEq(S.degreeAtLeast[dg > kFmcsMaxSeedDegree ? kFmcsMaxSeedDegree : dg]);
+      S.depthCandidates[g][d] = cand;
+    }
+    int       cnt = 0;
+    const int b0 = S.qRow[a], b1 = S.qRow[a + 1];
+    for (int e = b0; e < b1 && cnt < kFmcsMaxBackEdges; ++e) {
+      const int b = S.qBnd[e];
+      if (!seedBonds.test(b))
+        continue;
+      const int o  = S.qCol[e];
+      const int op = S.orderPos[g][o];
+      if (op == kUnmappedTargetIdx || op >= d)
+        continue;
+      // Dedup by earlier order position, scanning the few recorded slots
+      // (order positions exceed 63 at tier 128, so no bit-set shortcut).
+      bool dup = false;
+      for (int i = 0; i < cnt; ++i)
+        if ((S.backEdges[g][d][i] & 0xFFu) == static_cast<unsigned>(op))
+          dup = true;
+      if (dup)
+        continue;
+      S.backEdges[g][d][cnt] = static_cast<uint16_t>(op | (b << 8));
+      ++cnt;
+    }
+    S.backEdgeCount[g][d] = static_cast<uint8_t>(cnt);
+  }
+  group.sync();
+  return n;
+}
+
+/// Candidate set for search depth @p d given the committed @p mapping: the
+/// depth's label+degree term minus used targets, intersected per back edge
+/// with the class-adjacency mask of the mapped earlier atom.
+template <int maxAtoms, int maxBonds>
+__device__ __forceinline__ typename FmcsPairShared<maxAtoms, maxBonds>::AtomMask seedCandidatesAt(
+  const FmcsPairShared<maxAtoms, maxBonds>&                    S,
+  int                                                          g,
+  int                                                          d,
+  const unsigned char*                                         mapping,
+  const typename FmcsPairShared<maxAtoms, maxBonds>::AtomMask& used) {
+  auto c = depthCandidateTerm(S, g, d);
+  c.andNotEq(used);
+  const int k = S.backEdgeCount[g][d];
+  for (int i = 0; i < k && !c.empty(); ++i) {
+    const uint16_t be  = S.backEdges[g][d][i];
+    const int      m   = mapping[be & 0xFFu];
+    const int      b   = be >> 8;
+    const int      cls = S.bondClass[b];
+    if (cls < kFmcsMaxBondClasses) {
+      c.andEq(S.classAdj.neighbors[cls][m]);
+    } else {
+      c.andEq(neighborsMatchingSlow(S, m, b));
+    }
+  }
+  return c;
+}
+
+template <int maxAtoms, int maxBonds, int maxTA, int maxTB>
+__device__ __forceinline__ void matchResultClearCooperative(MatchResult<maxAtoms, maxBonds, maxTA, maxTB>& match,
+                                                            int                                            lane) {
+  for (int i = lane; i < maxAtoms; i += kFmcsGroupSize)
+    match.targetAtomIdx[i] = kUnmappedTargetIdx;
+  for (int i = lane; i < maxBonds; i += kFmcsGroupSize)
+    match.targetBondIdx[i] = kUnmappedTargetIdx;
+  if (lane == 0) {
+    for (int i = 0; i < MatchResult<maxAtoms, maxBonds, maxTA, maxTB>::kTargetAtomWords; ++i)
+      match.visitedTargetAtoms[i] = 0;
+    for (int i = 0; i < MatchResult<maxAtoms, maxBonds, maxTA, maxTB>::kTargetBondWords; ++i)
+      match.visitedTargetBonds[i] = 0;
+    match.matchedAtomSize = 0;
+    match.matchedBondSize = 0;
+    match.empty           = true;
+  }
+  __syncwarp();
+}
+
+/// Lane-parallel DFS racing for one embedding via the shared core.  Lane L
+/// owns roots L, L+32, ...; the first lane to complete an embedding wins
+/// S.found[g] and records targetForQuery.  Losing lanes notice through the
+/// per-root abort poll and a periodic poll inside the candidates callback.
+template <int maxAtoms, int maxBonds, class GroupT>
+__device__ void seedDfsSearchCooperative(const GroupT& group, FmcsPairShared<maxAtoms, maxBonds>& S, int g, int n) {
+  using AtomMask = typename FmcsPairShared<maxAtoms, maxBonds>::AtomMask;
+  const int lane = static_cast<int>(group.thread_rank());
+
+  AtomMask laneStripe;
   laneStripe.clear();
-  for (int targetAtomIdx = laneRank; targetAtomIdx < maxTA; targetAtomIdx += laneCount) {
-    laneStripe.set(targetAtomIdx);
-  }
-  Mask laneRoots = atomRowMask<maxTA>(tables.atoms, firstQueryAtom);
-  laneRoots.andEq(scratch.degreeAtLeast[min(static_cast<int>(scratch.seedDegree[firstQueryAtom]), kFmcsMaxSeedDegree)]);
-  laneRoots.andEq(laneStripe);
+  for (int a = lane; a < maxAtoms; a += kFmcsGroupSize)
+    laneStripe.set(a);
+  AtomMask roots = depthCandidateTerm(S, g, 0);
+  roots.andEq(laneStripe);
 
-  if (numSeedAtoms == 1) {
+  if (n == 1) {
     // No bonds to satisfy: the lowest compatible root is a complete
     // embedding.  Reduce lane-local lowest roots to the group minimum.
-    int lowestRoot = laneRoots.empty() ? maxTA : laneRoots.lowest();
-    for (int offset = laneCount / 2; offset > 0; offset >>= 1) {
-      lowestRoot = min(lowestRoot, group.shfl_xor(lowestRoot, offset));
-    }
-    if (lowestRoot >= maxTA)
-      return false;
-    if (laneRank == 0) {
-      scratch.targetAtomForQuery[firstQueryAtom] = static_cast<std::uint8_t>(lowestRoot);
-      prepared =
-        rebuildMatchFromSubstructureMappingWithinThread(seed, queryTopology, targetTopology, tables, match, scratch) ?
-          1 :
-          -1;
+    int low = roots.empty() ? maxAtoms : roots.lowest();
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1)
+      low = min(low, group.shfl_xor(low, off));
+    if (low >= maxAtoms)
+      return;
+    if (lane == 0) {
+      S.targetForQuery[g][S.order[g][0]] = static_cast<uint8_t>(low);
+      S.found[g]                         = 1;
     }
     group.sync();
-    prepared = group.shfl(prepared, 0);
-    return prepared == 1;
+    return;
   }
 
-  // Hand the seed to the shared frontend: fill the per-depth label term from
-  // the atom match table (already query-major, so no transpose), then build the
-  // back-edge table.  buildTargetAdjacency is a no-op for this adapter (always
-  // General, no row caching) but is called so the contract stays uniform.
-  const McsSeedAdapter<maxAtoms, maxBonds, maxTA, maxTB> adapter{&seed,
-                                                                 &queryTopology,
-                                                                 &targetTopology,
-                                                                 &tables,
-                                                                 &scratch};
-
-  for (int depth = laneRank; depth < numSeedAtoms; depth += laneCount) {
-    scratch.tables.depthCandidates[0][depth] = atomRowMask<maxTA>(tables.atoms, scratch.seedAtoms[depth]);
-  }
-  group.sync();
-
-  const nvMolKit::subgraph::QueryBondPlan plan =
-    nvMolKit::subgraph::analyzeQueryEdges(scratch.tables, 0, laneRank, adapter, numSeedAtoms);
-  nvMolKit::subgraph::buildTargetAdjacency(scratch.tables, 0, laneRank, adapter, targetTopology.numAtoms, plan);
-  group.sync();
-
-  auto candidatesAt = [&](int depth, const unsigned char* mapping, const Mask& used, int prevTargetAtom) -> Mask {
-    return nvMolKit::subgraph::buildCandidates(scratch.tables, 0, depth, mapping, used, adapter, plan, prevTargetAtom);
+  int  poll         = 0;
+  auto candidatesAt = [&](int depth, const unsigned char* mapping, const AtomMask& used, int /*prev*/) -> AtomMask {
+    if (((++poll) & 127) == 0 && *(volatile int*)&S.found[g] != 0) {
+      AtomMask empty;
+      empty.clear();
+      return empty;
+    }
+    return seedCandidatesAt(S, g, depth, mapping, used);
   };
 
-  // First complete embedding wins scratch.found; the winner alone records
-  // the atom mapping, translated from order positions back to query atoms.
-  auto onTerminal = [&](Mask terminals, const unsigned char* mapping) -> nvMolKit::DfsTerminalVerdict {
+  const int lastDepth  = n - 1;
+  auto      onTerminal = [&](AtomMask terminals, const unsigned char* mapping) -> nvMolKit::DfsTerminalVerdict {
     nvMolKit::DfsTerminalVerdict verdict{false, false};
     if (!terminals.empty()) {
-      if (atomicCAS(&scratch.found, 0, 1) == 0) {
-        for (int orderPos = 0; orderPos < numSeedAtoms - 1; ++orderPos) {
-          scratch.targetAtomForQuery[scratch.seedAtoms[orderPos]] = mapping[orderPos];
-        }
-        scratch.targetAtomForQuery[scratch.seedAtoms[numSeedAtoms - 1]] = static_cast<std::uint8_t>(terminals.lowest());
+      if (atomicCAS(&S.found[g], 0, 1) == 0) {
+        for (int p = 0; p < lastDepth; ++p)
+          S.targetForQuery[g][S.order[g][p]] = mapping[p];
+        S.targetForQuery[g][S.order[g][lastDepth]] = static_cast<uint8_t>(terminals.lowest());
       }
       verdict.laneDone = true;
     }
     return verdict;
   };
 
-  auto abortRequested = [&]() -> bool { return atomicAdd(&scratch.found, 0) != 0; };
+  auto abortRequested = [&]() -> bool { return *(volatile int*)&S.found[g] != 0; };
 
-  nvMolKit::dfsFromRoots<maxAtoms>(laneRoots, numSeedAtoms - 1, candidatesAt, onTerminal, abortRequested);
-  group.sync();
-
-  int found = scratch.found;
-  if (found != 0) {
-    if (laneRank == 0) {
-      found =
-        rebuildMatchFromSubstructureMappingWithinThread(seed, queryTopology, targetTopology, tables, match, scratch) ?
-          1 :
-          0;
-    }
-    group.sync();
-    found = group.shfl(found, 0);
-    return found != 0;
-  }
-
-  if (laneRank == 0) {
-    matchResultClearWithinThread(match);
-  }
-  group.sync();
-  return false;
+  nvMolKit::dfsFromRoots<maxAtoms>(roots, lastDepth, candidatesAt, onTerminal, abortRequested);
 }
 
-template <int maxAtoms, int maxBonds, int maxTA, int maxTB, class GroupT>
-__device__ __forceinline__ bool matchSeedWithSubstructureFallbackCooperative(
-  const GroupT&                                  group,
-  const Seed<maxAtoms, maxBonds>&                seed,
-  const DeviceCsrView&                           queryTopology,
-  const DeviceCsrView&                           targetTopology,
-  const PairMatchTablesDevice&                   tables,
-  MatchResult<maxAtoms, maxBonds, maxTA, maxTB>& match,
-  FmcsSubstructureScratch<maxAtoms, maxTA>&      scratch,
-  int*                                           scratchLock) {
-  if (tryMatchIncrementalGreedyCooperative(group, seed, queryTopology, targetTopology, tables, match)) {
-    return true;
-  }
-  if (group.thread_rank() == 0) {
-    while (atomicCAS(scratchLock, 0, 1) != 0) {
+/// Rebuild the full (atom + bond) witness from the embedding recorded in
+/// targetForQuery.
+template <int maxAtoms, int maxBonds, class GroupT>
+__device__ bool rebuildMatchCooperative(const GroupT&                                        group,
+                                        FmcsPairShared<maxAtoms, maxBonds>&                  S,
+                                        const Seed<maxAtoms, maxBonds>&                      seed,
+                                        MatchResult<maxAtoms, maxBonds, maxAtoms, maxBonds>& match,
+                                        int                                                  g) {
+  using AtomMask = typename FmcsPairShared<maxAtoms, maxBonds>::AtomMask;
+  using BondMask = typename FmcsPairShared<maxAtoms, maxBonds>::BondMask;
+  const int lane = static_cast<int>(group.thread_rank());
+  matchResultClearCooperative(match, lane);
+
+  AtomMask visA;
+  visA.clear();
+  int okA = 1;
+  for (int a = lane; a < maxAtoms; a += kFmcsGroupSize) {
+    if (wordsTest(seed.atoms, a)) {
+      const uint8_t t = S.targetForQuery[g][a];
+      if (t == kUnmappedTargetIdx)
+        okA = 0;
+      else {
+        match.targetAtomIdx[a] = t;
+        visA.set(t);
+      }
     }
   }
-  group.sync();
-  const bool ok = matchSeedSubstructureCooperative(group, seed, queryTopology, targetTopology, tables, match, scratch);
-  group.sync();
-  if (group.thread_rank() == 0) {
-    atomicExch(scratchLock, 0);
+  visA = warpOrMask(group, visA);
+  if (group.any(okA == 0) || visA.popcount() != seed.numAtoms) {
+    matchResultClearCooperative(match, lane);
+    return false;
+  }
+
+  BondMask visB;
+  visB.clear();
+  int okB = 1;
+  for (int b = lane; b < maxBonds; b += kFmcsGroupSize) {
+    if (wordsTest(seed.bonds, b)) {
+      const int tu = S.targetForQuery[g][S.qEpU[b]];
+      const int tv = S.targetForQuery[g][S.qEpV[b]];
+      int       tb = -1;
+      if (tu != kUnmappedTargetIdx && tv != kUnmappedTargetIdx) {
+        const auto& row = S.bondRow[b];
+        const int   e0 = S.tRow[tu], e1 = S.tRow[tu + 1];
+        for (int e = e0; e < e1; ++e)
+          if (S.tCol[e] == tv && row.test(S.tBnd[e])) {
+            tb = S.tBnd[e];
+            break;
+          }
+      }
+      if (tb < 0)
+        okB = 0;
+      else {
+        match.targetBondIdx[b] = static_cast<uint8_t>(tb);
+        visB.set(tb);
+      }
+    }
+  }
+  visB = warpOrMask(group, visB);
+  if (group.any(okB == 0) || visB.popcount() != seed.numBonds) {
+    matchResultClearCooperative(match, lane);
+    return false;
+  }
+  if (lane == 0) {
+    maskToWords(visA, match.visitedTargetAtoms);
+    maskToWords(visB, match.visitedTargetBonds);
+    match.matchedAtomSize = seed.numAtoms;
+    match.matchedBondSize = seed.numBonds;
+    match.empty           = false;
   }
   group.sync();
-  return ok;
+  return true;
+}
+
+/// Exact seed-in-target substructure check: a lane-parallel DFS racing for
+/// one embedding.  Exhaustive within bounded memory -- the stack is O(seed
+/// atoms) of lane-local state -- so a false return proves the seed does not
+/// embed in the target.  Group-uniform: all lanes of @p group call together.
+template <int maxAtoms, int maxBonds, class GroupT>
+__device__ __forceinline__ bool matchSeedSubstructureCooperative(
+  const GroupT&                                        group,
+  FmcsPairShared<maxAtoms, maxBonds>&                  S,
+  const Seed<maxAtoms, maxBonds>&                      seed,
+  MatchResult<maxAtoms, maxBonds, maxAtoms, maxBonds>& match,
+  int                                                  g) {
+  const int lane = static_cast<int>(group.thread_rank());
+  if (seed.numAtoms == 0) {
+    matchResultClearCooperative(match, lane);
+    return seed.numBonds == 0;
+  }
+  if (seed.numAtoms > S.tNA || seed.numBonds > S.tNB) {
+    matchResultClearCooperative(match, lane);
+    return false;
+  }
+  if (lane == 0)
+    S.found[g] = 0;
+  group.sync();
+  const int n = prepareSeedSearchCooperative(group, S, seed, g);
+  if (n < 0) {
+    matchResultClearCooperative(match, lane);
+    return false;
+  }
+  seedDfsSearchCooperative(group, S, g, n);
+  group.sync();
+  if (*(volatile int*)&S.found[g] == 0) {
+    matchResultClearCooperative(match, lane);
+    return false;
+  }
+  return rebuildMatchCooperative(group, S, seed, match, g);
+}
+
+/// Greedy incremental extension of the parent's recorded witness by every
+/// still-unmapped seed bond.  A true return proves the extension; false is
+/// inconclusive and @p match must not be reused (the caller runs the exact
+/// fallback).  Serial on lane 0: the whole walk is a handful of
+/// shared-memory reads per bond, so warp coordination would cost more than
+/// it saves.  Group-uniform.
+template <int maxAtoms, int maxBonds, class GroupT>
+__device__ bool tryMatchIncrementalGreedyCooperative(const GroupT&                                        group,
+                                                     const FmcsPairShared<maxAtoms, maxBonds>&            S,
+                                                     const Seed<maxAtoms, maxBonds>&                      seed,
+                                                     MatchResult<maxAtoms, maxBonds, maxAtoms, maxBonds>& match) {
+  using BondMask = typename FmcsPairShared<maxAtoms, maxBonds>::BondMask;
+  const int lane = static_cast<int>(group.thread_rank());
+  int       ok   = 1;
+  if (lane == 0) {
+    BondMask bits = maskFromWords<kFmcsMaskAtoms<maxBonds>>(seed.bonds);
+    while (!bits.empty()) {
+      const int b = bits.lowest();
+      bits.clearLowest();
+      if (match.targetBondIdx[b] != kUnmappedTargetIdx)
+        continue;
+      const int   u = S.qEpU[b], v = S.qEpV[b];
+      const int   tu = match.targetAtomIdx[u], tv = match.targetAtomIdx[v];
+      const auto& row     = S.bondRow[b];
+      int         chosenB = -1, chosenA = -1;
+      if (tu != kUnmappedTargetIdx && tv != kUnmappedTargetIdx) {
+        // Ring-closing: both endpoints mapped; find the connecting bond.
+        const int e0 = S.tRow[tu], e1 = S.tRow[tu + 1];
+        for (int e = e0; e < e1; ++e) {
+          if (S.tCol[e] != tv)
+            continue;
+          const int tb = S.tBnd[e];
+          if (wordsTest(match.visitedTargetBonds, tb))
+            continue;
+          if (!row.test(tb))
+            continue;
+          chosenB = tb;
+          break;
+        }
+      } else if (tu != kUnmappedTargetIdx || tv != kUnmappedTargetIdx) {
+        // Atom-adding: extend from the mapped endpoint to an unvisited,
+        // compatible neighbor.  No backtracking; a miss is inconclusive.
+        const int   src   = (tu != kUnmappedTargetIdx) ? tu : tv;
+        const int   qFree = (tu != kUnmappedTargetIdx) ? v : u;
+        const auto& arow  = S.atomRow[qFree];
+        const int   e0 = S.tRow[src], e1 = S.tRow[src + 1];
+        for (int e = e0; e < e1; ++e) {
+          const int tb = S.tBnd[e];
+          if (wordsTest(match.visitedTargetBonds, tb))
+            continue;
+          const int ta = S.tCol[e];
+          if (wordsTest(match.visitedTargetAtoms, ta))
+            continue;
+          if (!row.test(tb))
+            continue;
+          if (!arow.test(ta))
+            continue;
+          chosenB = tb;
+          chosenA = ta;
+          break;
+        }
+      } else {
+        // Both endpoints unmapped: malformed for well-formed seeds.
+        ok = 0;
+        break;
+      }
+      if (chosenB < 0) {
+        ok = 0;
+        break;
+      }
+      match.targetBondIdx[b] = static_cast<uint8_t>(chosenB);
+      wordsSet(match.visitedTargetBonds, chosenB);
+      match.matchedBondSize += 1;
+      match.empty = false;
+      if (chosenA >= 0) {
+        const int qFree            = (tu != kUnmappedTargetIdx) ? v : u;
+        match.targetAtomIdx[qFree] = static_cast<uint8_t>(chosenA);
+        wordsSet(match.visitedTargetAtoms, chosenA);
+        match.matchedAtomSize += 1;
+      }
+    }
+  }
+  ok = group.shfl(ok, 0);
+  return ok != 0;
+}
+
+/// RDKit checkIfMatchAndAppend analogue: greedy extension of a non-empty
+/// parent witness first, exact substructure fallback otherwise.
+template <int maxAtoms, int maxBonds, class GroupT>
+__device__ __forceinline__ bool checkSeedMatchAndAppendCooperative(
+  const GroupT&                                       group,
+  FmcsPairShared<maxAtoms, maxBonds>&                 S,
+  QueuedSeed<maxAtoms, maxBonds, maxAtoms, maxBonds>& candidate,
+  int                                                 g) {
+  if (!candidate.match.empty) {
+    if (tryMatchIncrementalGreedyCooperative(group, S, candidate.seed, candidate.match))
+      return true;
+  }
+  return matchSeedSubstructureCooperative(group, S, candidate.seed, candidate.match, g);
 }
 
 }  // namespace fmcs

--- a/src/mcs/fmcs_cuda/fmcs_search_support.cuh
+++ b/src/mcs/fmcs_cuda/fmcs_search_support.cuh
@@ -129,37 +129,6 @@ __device__ __forceinline__ void updateIncumbentCooperative(const GroupT&  group,
   group.sync();
 }
 
-template <int maxAtoms, int maxBonds, int maxTA, int maxTB, class GroupT>
-__device__ __forceinline__ bool checkSeedMatchAndAppendCooperative(
-  const GroupT&                                 group,
-  QueuedSeed<maxAtoms, maxBonds, maxTA, maxTB>& candidate,
-  const DeviceCsrView&                          queryTopology,
-  const DeviceCsrView&                          targetTopology,
-  const PairMatchTablesDevice&                  tables,
-  FmcsSubstructureScratch<maxAtoms, maxTA>&     scratch) {
-  bool ok = false;
-  if (!candidate.match.empty) {
-    ok = tryMatchIncrementalGreedyCooperative(group,
-                                              candidate.seed,
-                                              queryTopology,
-                                              targetTopology,
-                                              tables,
-                                              candidate.match);
-  }
-
-  if (!ok) {
-    ok = matchSeedSubstructureCooperative(group,
-                                          candidate.seed,
-                                          queryTopology,
-                                          targetTopology,
-                                          tables,
-                                          candidate.match,
-                                          scratch);
-    group.sync();
-  }
-  return ok;
-}
-
 __device__ __forceinline__ bool isPowerOfTwo64(unsigned long long value) {
   return value != 0ULL && (value & (value - 1ULL)) == 0ULL;
 }
@@ -266,131 +235,10 @@ template <class GroupT> __device__ __forceinline__ bool readFlagCooperative(cons
   return group.shfl(value, 0) != 0;
 }
 
-template <int maxAtoms, int maxBonds, class GroupT>
-__device__ __forceinline__ void seedComputeRemainingSizeRdkitCooperative(
-  const GroupT&                                      group,
-  Seed<maxAtoms, maxBonds>&                          seed,
-  const DeviceCsrView&                               queryTopology,
-  std::uint8_t*                                      atomStack,
-  typename Seed<maxAtoms, maxBonds>::atom_word_type* visitedAtoms,
-  typename Seed<maxAtoms, maxBonds>::bond_word_type* visitedBonds,
-  int*                                               stackSize) {
-  using SeedT                    = Seed<maxAtoms, maxBonds>;
-  using AtomWord                 = typename SeedT::atom_word_type;
-  using BondWord                 = typename SeedT::bond_word_type;
-  constexpr int kAtomBitsPerWord = SeedT::kAtomBitsPerWord;
-  constexpr int kBondBitsPerWord = SeedT::kBondBitsPerWord;
-
-  if (group.thread_rank() == 0) {
-    seed.remainingAtoms = 0;
-    seed.remainingBonds = 0;
-    *stackSize          = 0;
-    for (int i = 0; i < SeedT::kAtomWords; ++i) {
-      visitedAtoms[i] = seed.atoms[i];
-    }
-    for (int i = 0; i < SeedT::kBondWords; ++i) {
-      visitedBonds[i] = seed.excludedBonds[i];
-    }
-
-    for (int wordIdx = 0; wordIdx < SeedT::kAtomWords; ++wordIdx) {
-      AtomWord remaining = seed.lastAddedAtoms[wordIdx];
-      while (remaining != 0) {
-        int bitPosInWord;
-        if constexpr (sizeof(AtomWord) == 4) {
-          bitPosInWord = __ffs(static_cast<unsigned int>(remaining)) - 1;
-        } else {
-          bitPosInWord = __ffsll(static_cast<unsigned long long>(remaining)) - 1;
-        }
-        const int atomIdx = wordIdx * kAtomBitsPerWord + bitPosInWord;
-        remaining &= remaining - 1;
-
-        for (int bondIdx = 0; bondIdx < queryTopology.numBonds; ++bondIdx) {
-          const int      bondWordIdx = bondIdx / kBondBitsPerWord;
-          const BondWord bondMask    = static_cast<BondWord>(1) << (bondIdx % kBondBitsPerWord);
-          if ((visitedBonds[bondWordIdx] & bondMask) != 0)
-            continue;
-
-          const std::uint32_t endpoints = queryTopology.bondEndpoints[bondIdx];
-          const int           endpointU = static_cast<int>(endpoints >> kBondEndpointShift);
-          const int           endpointV = static_cast<int>(endpoints & kBondEndpointMask);
-          int                 otherAtom = -1;
-          if (endpointU == atomIdx) {
-            otherAtom = endpointV;
-          } else if (endpointV == atomIdx) {
-            otherAtom = endpointU;
-          } else {
-            continue;
-          }
-
-          visitedBonds[bondWordIdx] |= bondMask;
-          seed.remainingBonds += 1;
-          const int      atomWordIdx = otherAtom / kAtomBitsPerWord;
-          const AtomWord atomMask    = static_cast<AtomWord>(1) << (otherAtom % kAtomBitsPerWord);
-          if ((visitedAtoms[atomWordIdx] & atomMask) == 0) {
-            visitedAtoms[atomWordIdx] |= atomMask;
-            seed.remainingAtoms += 1;
-            atomStack[(*stackSize)++] = static_cast<std::uint8_t>(otherAtom);
-          }
-        }
-      }
-    }
-
-    while (*stackSize > 0) {
-      const int atomIdx = atomStack[--(*stackSize)];
-      for (int bondIdx = 0; bondIdx < queryTopology.numBonds; ++bondIdx) {
-        const int      bondWordIdx = bondIdx / kBondBitsPerWord;
-        const BondWord bondMask    = static_cast<BondWord>(1) << (bondIdx % kBondBitsPerWord);
-        if ((visitedBonds[bondWordIdx] & bondMask) != 0)
-          continue;
-
-        const std::uint32_t endpoints = queryTopology.bondEndpoints[bondIdx];
-        const int           endpointU = static_cast<int>(endpoints >> kBondEndpointShift);
-        const int           endpointV = static_cast<int>(endpoints & kBondEndpointMask);
-        int                 otherAtom = -1;
-        if (endpointU == atomIdx) {
-          otherAtom = endpointV;
-        } else if (endpointV == atomIdx) {
-          otherAtom = endpointU;
-        } else {
-          continue;
-        }
-
-        visitedBonds[bondWordIdx] |= bondMask;
-        seed.remainingBonds += 1;
-        const int      atomWordIdx = otherAtom / kAtomBitsPerWord;
-        const AtomWord atomMask    = static_cast<AtomWord>(1) << (otherAtom % kAtomBitsPerWord);
-        if ((visitedAtoms[atomWordIdx] & atomMask) == 0) {
-          visitedAtoms[atomWordIdx] |= atomMask;
-          seed.remainingAtoms += 1;
-          atomStack[(*stackSize)++] = static_cast<std::uint8_t>(otherAtom);
-        }
-      }
-    }
-  }
-  group.sync();
-}
-
 /// Per-block seed worklist capacity.  The backing slab lives in global
-/// memory; only the cursor/header lives in shared memory.  Approach 1 uses
-/// atomic LIFO push/pop so multiple warp groups can own grow work
-/// concurrently.
-constexpr int kFmcsQueueCapacity    = 4096;
-/// Block / cooperative-group sizing.  Phase 2 partitions each block into warp
-/// groups; each group pops one seed at a time from the block worklist and
-/// cooperates on matching, remaining-size checks, seed copying, and fallback
-/// substructure search.  Supported block sizes are compile-time kernel
-/// specializations selected at launch time.
-constexpr int kFmcsDefaultBlockSize = 128;
-constexpr int kFmcsGroupSize        = 32;
-static_assert(kFmcsGroupSize <= 32, "kFmcsGroupSize must be <= 32 (warp shuffle / ballot scope)");
-static_assert((kFmcsGroupSize & (kFmcsGroupSize - 1)) == 0, "kFmcsGroupSize must be a power of two");
-
-template <int blockThreads> struct FmcsBlockConfig {
-  static_assert(blockThreads == 64 || blockThreads == 128 || blockThreads == 256 || blockThreads == 512,
-                "fMCS block size must be 64, 128, 256, or 512");
-  static_assert(blockThreads % kFmcsGroupSize == 0, "fMCS block size must be a multiple of kFmcsGroupSize");
-  static constexpr int numGroups = blockThreads / kFmcsGroupSize;
-};
+/// memory; only the cursor/header lives in shared memory.  Atomic LIFO
+/// push/pop lets multiple warp groups own grow work concurrently.
+constexpr int kFmcsQueueCapacity = 4096;
 
 }  // namespace fmcs
 }  // namespace mcs

--- a/src/mcs/mcs_search.cu
+++ b/src/mcs/mcs_search.cu
@@ -395,9 +395,9 @@ void validateSupportedParameters(const MCSParameters& params) {
 }
 
 bool shouldFallbackToRDKit(const RDKit::ROMol& molA, const RDKit::ROMol& molB, std::string& reason) {
-  if (std::max(molA.getNumAtoms(), molB.getNumAtoms()) > 128 ||
-      std::max(molA.getNumBonds(), molB.getNumBonds()) > 128) {
-    reason = "molecule exceeds fMCS tier-128 limits";
+  if (std::max(molA.getNumAtoms(), molB.getNumAtoms()) >= 128 ||
+      std::max(molA.getNumBonds(), molB.getNumBonds()) >= 128) {
+    reason = "molecule exceeds fMCS limit of fewer than 128 atoms and bonds";
     return true;
   }
   for (const auto* atom : molA.atoms()) {

--- a/src/mcs/mcs_search.cu
+++ b/src/mcs/mcs_search.cu
@@ -607,7 +607,6 @@ void runGpuPairs(std::vector<PreparedGpuPair>&           gpuPairs,
 
     mcs::fmcs::Parameters fmcsParams;
     fmcsParams.batchSize          = params.batchSize;
-    fmcsParams.blockSize          = params.blockSize;
     fmcsParams.executorsPerRunner = effectiveExecutorsPerRunner;
     fmcsParams.matchVertexLabels  = usesAtomLabels(params);
     fmcsParams.matchEdgeLabels    = usesBondLabels(params);

--- a/src/mcs/mcs_search.h
+++ b/src/mcs/mcs_search.h
@@ -35,9 +35,9 @@ using MCSPair = std::pair<std::size_t, std::size_t>;
 /// Find an exact, connected, bond-maximizing MCS for every requested pair.
 ///
 /// Each pair indexes into @p mols and results preserve pair order. With
-/// MCSParameters::requireGpu=false, only pair-specific GPU limits (more than
-/// 128 atoms/bonds, atom degree above 8, or GPU search overflow) cause that
-/// pair to be recomputed with RDKit. With requireGpu=true, those cases throw
+/// MCSParameters::requireGpu=false, only pair-specific GPU limits (128 or more
+/// atoms or bonds, atom degree above 8, or GPU search overflow) cause that pair
+/// to be recomputed with RDKit. With requireGpu=true, those cases throw
 /// std::runtime_error. Unsupported batch-wide parameters always throw
 /// std::invalid_argument. Timeouts return canceled partial results and never
 /// fall back.

--- a/src/mcs/mcs_types.h
+++ b/src/mcs/mcs_types.h
@@ -96,9 +96,6 @@ struct MCSParameters {
   /// Pairs per GPU chunk; values <= 0 use all pairs assigned to the runner.
   int batchSize = 0;
 
-  /// CUDA block size; valid values are 64, 128, 256, and 512.
-  int blockSize = 128;
-
   /// Runner threads; -1 selects automatically, otherwise clamped to at least 1.
   int workerThreads = -1;
 

--- a/src/subgraph/class_adjacency.cuh
+++ b/src/subgraph/class_adjacency.cuh
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Per-pair, per-predicate-class target adjacency tables for the warp DFS.
+//
+// This generalises the Uniform/Dual precompute in candidate_tables.cuh to K
+// predicate classes.  A "class" is an equivalence class of query edges whose
+// predicates accept exactly the same target bonds -- for a labelled
+// substructure query that is the edge label; for an MCS pair it is the query
+// bond's row of the (query bond, target bond) compatibility matrix.  Once
+// classes are known, the candidate intersection for a back edge in class k
+// anchored on mapped target atom m is a single table read:
+//
+//   neighbors[k][m] = target atoms reachable from m over a target bond the
+//                     class-k predicate accepts
+//
+// which replaces the General-plan per-descent recompute (a CSR row walk plus a
+// predicate test per adjacency slot) with one shared-memory load and an AND.
+//
+// Scope is the caller's choice and is the point of this component being
+// separate from WarpSharedState: the tables depend only on the (query, target)
+// pair, so a warp-per-pair kernel (substructure search) owns one instance per
+// warp, while a block-per-pair kernel (MCS) owns a single instance per block,
+// fills it once, and shares it across every searching warp group.
+//
+// Classification itself stays with the frontend -- it is the only part that
+// differs between problems -- as does the decision of how many classes to
+// support before falling back to a General-style recompute.  Storage is
+// K * MaxTargetAtoms masks, so K is a real shared-memory/occupancy trade-off:
+// warp-per-pair callers multiply it by warps per block, and should measure
+// before raising K above the Uniform/Dual equivalent of 2.
+
+#ifndef NVMOLKIT_SUBGRAPH_CLASS_ADJACENCY_CUH
+#define NVMOLKIT_SUBGRAPH_CLASS_ADJACENCY_CUH
+
+#include <cstddef>
+
+#include "src/subgraph/target_mask.cuh"
+
+namespace nvMolKit {
+namespace subgraph {
+
+/// Per-class target adjacency masks.  neighbors[k][a] is the set of target
+/// atoms reachable from target atom a over a target bond accepted by the
+/// class-k edge predicate.  Rows at or above the pair's class count are
+/// never written or read.
+template <std::size_t MaxTargetAtoms, int MaxClasses> struct ClassAdjacency {
+  using Mask                       = TargetMask<MaxTargetAtoms>;
+  static constexpr int kMaxClasses = MaxClasses;
+
+  Mask neighbors[MaxClasses][MaxTargetAtoms];
+};
+
+/**
+ * @brief Cooperatively fill @p tables for @p numClasses classes.
+ *
+ * Work is striped (class, target atom)-flat across @p stride threads of rank
+ * @p rank; any thread grouping works as long as every rank in [0, stride)
+ * participates and the caller synchronises that grouping before reading the
+ * tables.
+ *
+ * @tparam NeighborsFn Mask neighborsMatchingClass(int targetAtom, int cls):
+ *         the target atoms reachable from @p targetAtom over a bond the
+ *         class-@p cls predicate accepts.  How the predicate is evaluated
+ *         (packed rows, CSR walk, match-table probe) is the frontend's
+ *         business; it runs once per (class, atom) here instead of once per
+ *         DFS descent.
+ */
+template <std::size_t MaxTargetAtoms, int MaxClasses, class NeighborsFn>
+__device__ __forceinline__ void fillClassAdjacency(ClassAdjacency<MaxTargetAtoms, MaxClasses>& tables,
+                                                   int                                         numClasses,
+                                                   int                                         numTargetAtoms,
+                                                   int                                         rank,
+                                                   int                                         stride,
+                                                   NeighborsFn&&                               neighborsMatchingClass) {
+  const int total = numClasses * numTargetAtoms;
+  for (int idx = rank; idx < total; idx += stride) {
+    const int cls               = idx / numTargetAtoms;
+    const int atom              = idx - cls * numTargetAtoms;
+    tables.neighbors[cls][atom] = neighborsMatchingClass(atom, cls);
+  }
+}
+
+}  // namespace subgraph
+}  // namespace nvMolKit
+
+#endif  // NVMOLKIT_SUBGRAPH_CLASS_ADJACENCY_CUH

--- a/src/subgraph/target_mask.cuh
+++ b/src/subgraph/target_mask.cuh
@@ -43,6 +43,7 @@ template <> struct TargetMask<32> {
 
   __device__ __forceinline__ void clear() { bits = 0; }
   __device__ __forceinline__ bool empty() const { return bits == 0; }
+  __device__ __forceinline__ bool test(int bit) const { return ((bits >> bit) & 1u) != 0; }
   __device__ __forceinline__ void set(int bit) { bits |= 1u << bit; }
   __device__ __forceinline__ void reset(int bit) { bits &= ~(1u << bit); }
   /// Branch-free conditional set: @p value must be 0 or 1.
@@ -61,6 +62,7 @@ template <> struct TargetMask<64> {
 
   __device__ __forceinline__ void clear() { lo = 0; }
   __device__ __forceinline__ bool empty() const { return lo == 0; }
+  __device__ __forceinline__ bool test(int bit) const { return ((lo >> bit) & 1ULL) != 0; }
   __device__ __forceinline__ void set(int bit) { lo |= 1ULL << bit; }
   __device__ __forceinline__ void reset(int bit) { lo &= ~(1ULL << bit); }
   /// Branch-free conditional set: @p value must be 0 or 1.
@@ -82,6 +84,7 @@ template <> struct TargetMask<128> {
 
   __device__ __forceinline__ void clear() { lo = hi = 0; }
   __device__ __forceinline__ bool empty() const { return (lo | hi) == 0; }
+  __device__ __forceinline__ bool test(int bit) const { return (((bit < 64 ? lo : hi) >> (bit & 63)) & 1ULL) != 0; }
   __device__ __forceinline__ void set(int bit) {
     if (bit < 64) {
       lo |= 1ULL << bit;

--- a/tests/test_fmcs_engine_validation.cpp
+++ b/tests/test_fmcs_engine_validation.cpp
@@ -350,29 +350,15 @@ TEST(FMCSTiers, MaxSize128) {
   expectFullSelfPair(r, p);
 }
 
-TEST(FMCSBlockSize, SupportedSpecializationsMatchDefault) {
+// A nonzero timeout routes tiers <= 64 to the production kernel instead of
+// the fast block-per-pair kernel; keep that path covered with a timeout far
+// too generous to actually fire.
+TEST(FMCSTiers, GenerousTimeoutMatchesFastKernelResult) {
   const auto p = path(32);
-  for (int blockSize : {64, 128, 256, 512}) {
-    Parameters params;
-    params.blockSize = blockSize;
-    auto r           = findSingleMCES(p, p, params);
-    expectFullSelfPair(r, p);
-  }
-}
-
-TEST(FMCSBlockSize, Block512SupportsTier128WithGlobalScratch) {
-  const auto p = path(128);
   Parameters params;
-  params.blockSize = 512;
+  params.timeoutMs = 60000.0f;
   auto r           = findSingleMCES(p, p, params);
   expectFullSelfPair(r, p);
-}
-
-TEST(FMCSBlockSize, RejectsOneWarpBlockSize) {
-  const auto p = path(8);
-  Parameters params;
-  params.blockSize = 32;
-  EXPECT_THROW((void)mcs::fmcs::findMCESfMCSBatch({p}, {p}, params), std::invalid_argument);
 }
 
 TEST(FMCSInputValidation, RejectsDegreeAboveEight) {

--- a/tests/test_fmcs_engine_validation.cpp
+++ b/tests/test_fmcs_engine_validation.cpp
@@ -344,10 +344,29 @@ TEST(FMCSTiers, MaxSize64) {
   expectFullSelfPair(r, p);
 }
 
-TEST(FMCSTiers, MaxSize128) {
-  const auto p = path(128);
+TEST(FMCSTiers, MaxSize127) {
+  const auto p = path(127);
   auto       r = findSingleMCES(p, p);
   expectFullSelfPair(r, p);
+}
+
+TEST(FMCSOverflow, RejectsSize128) {
+  const auto atoms128   = path(128);
+  auto       atomResult = findSingleMCES(atoms128, atoms128);
+  EXPECT_TRUE(atomResult.overflowed);
+  EXPECT_EQ(atomResult.numCommonEdges, 0);
+  EXPECT_EQ(atomResult.numCommonVertices, 0);
+
+  std::vector<std::pair<std::size_t, std::size_t>> edges;
+  for (std::size_t atom = 0; atom + 1 < 127; ++atom)
+    edges.emplace_back(atom, atom + 1);
+  edges.emplace_back(0, 126);
+  edges.emplace_back(0, 2);
+  const auto bonds128   = mcs::buildGraphFromEdges(127, std::move(edges));
+  auto       bondResult = findSingleMCES(bonds128, bonds128);
+  EXPECT_TRUE(bondResult.overflowed);
+  EXPECT_EQ(bondResult.numCommonEdges, 0);
+  EXPECT_EQ(bondResult.numCommonVertices, 0);
 }
 
 // A nonzero timeout routes tiers <= 64 to the production kernel instead of
@@ -568,7 +587,7 @@ TEST(FMCSBatch, OverflowPairDoesNotBlockNeighbors) {
 // ---------------------------------------------------------------------------
 
 TEST(FMCSOverflow, GraphTooLargeFlagSet) {
-  // Tier cap is 128 atoms / 128 bonds.  Build a path with 200 atoms
+  // Tier caps are fewer than 128 atoms and bonds. Build a path with 200 atoms
   // (199 bonds) -- exceeds tier 128 in atoms AND bonds.
   const auto p = path(200);
   auto       r = findSingleMCES(p, p);
@@ -587,7 +606,7 @@ TEST(FMCSOverflow, TargetTooLargeFlagSetEvenWhenQueryFits) {
 }
 
 TEST(FMCSTimeout, PartialResultReturned) {
-  const auto p = path(128);
+  const auto p = path(127);
   Parameters params;
   params.timeoutMs = 0.0001f;
 

--- a/tests/test_fmcs_grow.cu
+++ b/tests/test_fmcs_grow.cu
@@ -61,22 +61,25 @@ __device__ __forceinline__ void fillNewBondsRun(SeedSetup&&          setup,
   __shared__ SeedT   seed;
   __shared__ NewBond bonds[kMaxNewBonds];
   __shared__ int     count;
+  __shared__ std::uint8_t epU[16];
+  __shared__ std::uint8_t epV[16];
 
   if (threadIdx.x == 0) {
     mcs::fmcs::seedClearWithinThread(seed);
     setup(seed);
   }
+  // fillNewBondsCooperative reads byte-packed endpoints (block-shared in
+  // the kernel); unpack the test's (u << 16 | v) list the same way.
+  for (int i = static_cast<int>(threadIdx.x); i < qNumBonds; i += static_cast<int>(blockDim.x)) {
+    epU[i] = static_cast<std::uint8_t>(qBondEndpoints[i] >> 16);
+    epV[i] = static_cast<std::uint8_t>(qBondEndpoints[i] & 0xFFFFu);
+  }
+  (void)qNumAtoms;
   __syncthreads();
 
-  auto                     block = cooperative_groups::this_thread_block();
-  auto                     warp  = cooperative_groups::tiled_partition<32>(block);
-  // fillNewBondsCooperative reads only the bond-endpoint side of the
-  // topology, so the CSR arrays stay null here.
-  mcs::fmcs::DeviceCsrView qView{};
-  qView.bondEndpoints = qBondEndpoints;
-  qView.numAtoms      = qNumAtoms;
-  qView.numBonds      = qNumBonds;
-  bool ok             = mcs::fmcs::fillNewBondsCooperative(warp, seed, qView, bonds, &count, maxNewBonds);
+  auto block = cooperative_groups::this_thread_block();
+  auto warp  = cooperative_groups::tiled_partition<32>(block);
+  bool ok    = mcs::fmcs::fillNewBondsCooperative(warp, seed, epU, epV, qNumBonds, bonds, &count, maxNewBonds);
   __syncthreads();
 
   if (threadIdx.x == 0) {

--- a/tests/test_fmcs_integration.cu
+++ b/tests/test_fmcs_integration.cu
@@ -951,6 +951,22 @@ TEST(FMCSFallback, DegreeAboveEightRejectedWhenGpuRequired) {
   EXPECT_THROW((void)nvMolKit::findMCSBatch(mols, pairs, nullptr, params), std::runtime_error);
 }
 
+TEST(FMCSFallback, Size128RejectedWhenGpuRequired) {
+  auto chain = std::unique_ptr<RDKit::ROMol>(RDKit::SmilesToMol(std::string(128, 'C')));
+  ASSERT_NE(chain, nullptr);
+  ASSERT_EQ(chain->getNumAtoms(), 128u);
+  ASSERT_EQ(chain->getNumBonds(), 127u);
+
+  const std::vector<const RDKit::ROMol*> mols{chain.get()};
+  const std::vector<MCSPair>             pairs{
+                {0, 0}
+  };
+  MCSParameters params;
+  params.requireGpu = true;
+
+  EXPECT_THROW((void)nvMolKit::findMCSBatch(mols, pairs, nullptr, params), std::runtime_error);
+}
+
 constexpr RingConfig kNoRing{false, false, "NoRing"};
 
 std::string integrationParamName(const ::testing::TestParamInfo<FmcsIntegrationParams>& info) {

--- a/tests/test_fmcs_match.cu
+++ b/tests/test_fmcs_match.cu
@@ -179,22 +179,29 @@ class TestGraph {
 
 // ---- matchSingleBondWithinThread ----
 
+using PairShared16 = mcs::fmcs::FmcsPairShared<16, 16>;
+
 struct SingleBondTestOut {
   bool            ok;
   SingleBondMatch match;
 };
 
+// One-warp driver: loads the pair into block-shared state, then runs the
+// phase-1 direct single-bond match for @p qBondIdx.  The match scans target
+// bonds in index order and tries both orientations, so tests steer it via
+// the compatibility tables.
 __global__ void matchSingleBondDriver(int                   qBondIdx,
-                                      int                   tBondIdx,
-                                      bool                  reversed,
                                       DeviceCsrView         qView,
                                       DeviceCsrView         tView,
                                       PairMatchTablesDevice tables,
                                       SingleBondTestOut*    out) {
+  __shared__ __align__(16) unsigned char sharedRaw[sizeof(PairShared16)];
+  PairShared16&                          S = *reinterpret_cast<PairShared16*>(sharedRaw);
+  mcs::fmcs::loadPairSharedCooperative(S, qView, tView, tables, static_cast<int>(threadIdx.x), blockDim.x);
   if (threadIdx.x != 0 || blockIdx.x != 0)
     return;
   SingleBondMatch sm{};
-  out->ok    = mcs::fmcs::matchSingleBondWithinThread(qBondIdx, tBondIdx, reversed, qView, tView, tables, sm);
+  out->ok    = mcs::fmcs::matchSingleBondWithinThread(S, qBondIdx, sm);
   out->match = sm;
 }
 
@@ -216,13 +223,7 @@ TEST(FMCSUnit, MatchSingleBondForwardOrientation) {
   tables.setAllBondBits();
 
   AsyncDevicePtr<SingleBondTestOut> d_out;
-  matchSingleBondDriver<<<1, 1>>>(0,
-                                  0,
-                                  /*reversed=*/false,
-                                  query.view(),
-                                  target.view(),
-                                  tables.device(),
-                                  d_out.data());
+  matchSingleBondDriver<<<1, 32>>>(0, query.view(), target.view(), tables.device(), d_out.data());
   ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
   SingleBondTestOut out{};
   d_out.get(out);
@@ -230,6 +231,7 @@ TEST(FMCSUnit, MatchSingleBondForwardOrientation) {
   EXPECT_TRUE(out.ok);
   EXPECT_EQ(out.match.targetAtomU, 0u);  // qU=0 -> tU=0
   EXPECT_EQ(out.match.targetAtomV, 1u);  // qV=1 -> tV=1
+  EXPECT_EQ(out.match.targetBond, 0u);
 }
 
 TEST(FMCSUnit, MatchSingleBondReverseOrientation) {
@@ -243,17 +245,14 @@ TEST(FMCSUnit, MatchSingleBondReverseOrientation) {
   });
   ManagedMatchTables tables;
   tables.allocate(2, 2, 1, 1);
-  tables.setAllAtomBits();
   tables.setAllBondBits();
+  // Atom compatibility only permits the reversed orientation: qU=0 may map
+  // to tV=1 and qV=1 to tU=0.
+  tables.setAtomBit(0, 1);
+  tables.setAtomBit(1, 0);
 
   AsyncDevicePtr<SingleBondTestOut> d_out;
-  matchSingleBondDriver<<<1, 1>>>(0,
-                                  0,
-                                  /*reversed=*/true,
-                                  query.view(),
-                                  target.view(),
-                                  tables.device(),
-                                  d_out.data());
+  matchSingleBondDriver<<<1, 32>>>(0, query.view(), target.view(), tables.device(), d_out.data());
   ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
   SingleBondTestOut out{};
   d_out.get(out);
@@ -261,6 +260,7 @@ TEST(FMCSUnit, MatchSingleBondReverseOrientation) {
   EXPECT_TRUE(out.ok);
   EXPECT_EQ(out.match.targetAtomU, 1u);  // qU=0 -> tV=1 (reversed)
   EXPECT_EQ(out.match.targetAtomV, 0u);  // qV=1 -> tU=0
+  EXPECT_EQ(out.match.targetBond, 0u);
 }
 
 TEST(FMCSUnit, MatchSingleBondBondTableRejection) {
@@ -278,13 +278,7 @@ TEST(FMCSUnit, MatchSingleBondBondTableRejection) {
   // Deliberately leave bondData all zero -> bond-table reject.
 
   AsyncDevicePtr<SingleBondTestOut> d_out;
-  matchSingleBondDriver<<<1, 1>>>(0,
-                                  0,
-                                  /*reversed=*/false,
-                                  query.view(),
-                                  target.view(),
-                                  tables.device(),
-                                  d_out.data());
+  matchSingleBondDriver<<<1, 32>>>(0, query.view(), target.view(), tables.device(), d_out.data());
   ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
   SingleBondTestOut out{};
   d_out.get(out);
@@ -304,21 +298,13 @@ TEST(FMCSUnit, MatchSingleBondAtomTableRejection) {
   ManagedMatchTables tables;
   tables.allocate(2, 2, 1, 1);
   tables.setAllBondBits();
-  // Atom 0 compatible with target atom 0, but atom 1 is incompatible
-  // with target atom 1 -> forward orientation rejects on second atom.
+  // Forward orientation needs (0->0, 1->1) and reverse needs (0->1, 1->0);
+  // permit only (0->0) and (1->0) so both orientations reject on an atom.
   tables.setAtomBit(0, 0);
-  tables.setAtomBit(0, 1);
   tables.setAtomBit(1, 0);
-  // Note: (1, 1) deliberately left unset.
 
   AsyncDevicePtr<SingleBondTestOut> d_out;
-  matchSingleBondDriver<<<1, 1>>>(0,
-                                  0,
-                                  /*reversed=*/false,
-                                  query.view(),
-                                  target.view(),
-                                  tables.device(),
-                                  d_out.data());
+  matchSingleBondDriver<<<1, 32>>>(0, query.view(), target.view(), tables.device(), d_out.data());
   ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
   SingleBondTestOut out{};
   d_out.get(out);
@@ -380,6 +366,9 @@ __global__ void matchIncrementalAtomAddingDriver(DeviceCsrView         qView,
                                                  PairMatchTablesDevice tables,
                                                  IncrementalTestOut*   out) {
   __shared__ QueuedT16 child;
+  __shared__ __align__(16) unsigned char sharedRaw[sizeof(mcs::fmcs::FmcsPairShared<16, 16>)];
+  auto&                                  S = *reinterpret_cast<mcs::fmcs::FmcsPairShared<16, 16>*>(sharedRaw);
+  mcs::fmcs::loadPairSharedCooperative(S, qView, tView, tables, static_cast<int>(threadIdx.x), blockDim.x);
   if (threadIdx.x == 0) {
     mcs::fmcs::seedClearWithinThread(child.seed);
     // Parent: bond (0,1) mapped 0->0, 1->1, bond 0->target bond 0.
@@ -401,7 +390,7 @@ __global__ void matchIncrementalAtomAddingDriver(DeviceCsrView         qView,
 
   auto block = cooperative_groups::this_thread_block();
   auto warp  = cooperative_groups::tiled_partition<32>(block);
-  bool ok    = mcs::fmcs::tryMatchIncrementalGreedyCooperative(warp, child.seed, qView, tView, tables, child.match);
+  bool ok    = mcs::fmcs::tryMatchIncrementalGreedyCooperative(warp, S, child.seed, child.match);
   __syncthreads();
 
   if (threadIdx.x == 0) {
@@ -415,6 +404,9 @@ __global__ void matchIncrementalRingClosingDriver(DeviceCsrView         qView,
                                                   PairMatchTablesDevice tables,
                                                   IncrementalTestOut*   out) {
   __shared__ QueuedT16 child;
+  __shared__ __align__(16) unsigned char sharedRaw[sizeof(mcs::fmcs::FmcsPairShared<16, 16>)];
+  auto&                                  S = *reinterpret_cast<mcs::fmcs::FmcsPairShared<16, 16>*>(sharedRaw);
+  mcs::fmcs::loadPairSharedCooperative(S, qView, tView, tables, static_cast<int>(threadIdx.x), blockDim.x);
   if (threadIdx.x == 0) {
     mcs::fmcs::seedClearWithinThread(child.seed);
     // 4-atom square query: bonds (0,1), (1,2), (2,3), (0,3).  Parent
@@ -434,7 +426,7 @@ __global__ void matchIncrementalRingClosingDriver(DeviceCsrView         qView,
 
   auto block = cooperative_groups::this_thread_block();
   auto warp  = cooperative_groups::tiled_partition<32>(block);
-  bool ok    = mcs::fmcs::tryMatchIncrementalGreedyCooperative(warp, child.seed, qView, tView, tables, child.match);
+  bool ok    = mcs::fmcs::tryMatchIncrementalGreedyCooperative(warp, S, child.seed, child.match);
   __syncthreads();
 
   if (threadIdx.x == 0) {
@@ -448,6 +440,9 @@ __global__ void matchIncrementalVisitedConflictDriver(DeviceCsrView         qVie
                                                       PairMatchTablesDevice tables,
                                                       IncrementalTestOut*   out) {
   __shared__ QueuedT16 child;
+  __shared__ __align__(16) unsigned char sharedRaw[sizeof(mcs::fmcs::FmcsPairShared<16, 16>)];
+  auto&                                  S = *reinterpret_cast<mcs::fmcs::FmcsPairShared<16, 16>*>(sharedRaw);
+  mcs::fmcs::loadPairSharedCooperative(S, qView, tView, tables, static_cast<int>(threadIdx.x), blockDim.x);
   if (threadIdx.x == 0) {
     mcs::fmcs::seedClearWithinThread(child.seed);
     // Query: atoms 0,1,2; bonds (0,1), (0,2).  Target: atoms 0,1; one
@@ -470,7 +465,7 @@ __global__ void matchIncrementalVisitedConflictDriver(DeviceCsrView         qVie
 
   auto block = cooperative_groups::this_thread_block();
   auto warp  = cooperative_groups::tiled_partition<32>(block);
-  bool ok    = mcs::fmcs::tryMatchIncrementalGreedyCooperative(warp, child.seed, qView, tView, tables, child.match);
+  bool ok    = mcs::fmcs::tryMatchIncrementalGreedyCooperative(warp, S, child.seed, child.match);
   __syncthreads();
 
   if (threadIdx.x == 0) {
@@ -484,6 +479,9 @@ __global__ void matchIncrementalTwoBondChainDriver(DeviceCsrView         qView,
                                                    PairMatchTablesDevice tables,
                                                    IncrementalTestOut*   out) {
   __shared__ QueuedT16 child;
+  __shared__ __align__(16) unsigned char sharedRaw[sizeof(mcs::fmcs::FmcsPairShared<16, 16>)];
+  auto&                                  S = *reinterpret_cast<mcs::fmcs::FmcsPairShared<16, 16>*>(sharedRaw);
+  mcs::fmcs::loadPairSharedCooperative(S, qView, tView, tables, static_cast<int>(threadIdx.x), blockDim.x);
   if (threadIdx.x == 0) {
     mcs::fmcs::seedClearWithinThread(child.seed);
     // 4-atom path 0-1-2-3.  Parent has only bond (0,1) mapped.  Child
@@ -506,7 +504,7 @@ __global__ void matchIncrementalTwoBondChainDriver(DeviceCsrView         qView,
 
   auto block = cooperative_groups::this_thread_block();
   auto warp  = cooperative_groups::tiled_partition<32>(block);
-  bool ok    = mcs::fmcs::tryMatchIncrementalGreedyCooperative(warp, child.seed, qView, tView, tables, child.match);
+  bool ok    = mcs::fmcs::tryMatchIncrementalGreedyCooperative(warp, S, child.seed, child.match);
   __syncthreads();
 
   if (threadIdx.x == 0) {

--- a/tests/test_fmcs_substructure.cu
+++ b/tests/test_fmcs_substructure.cu
@@ -243,7 +243,9 @@ __global__ void matchSubstructureMaskDriver(DeviceCsrView         qView,
                                             std::uint32_t         bondMask,
                                             SubstructureTestOut*  out) {
   __shared__ QueuedT16 child;
-  __shared__ mcs::fmcs::FmcsSubstructureScratch<16, 16> scratch;
+  __shared__ __align__(16) unsigned char sharedRaw[sizeof(mcs::fmcs::FmcsPairShared<16, 16>)];
+  auto&                                  S = *reinterpret_cast<mcs::fmcs::FmcsPairShared<16, 16>*>(sharedRaw);
+  mcs::fmcs::loadPairSharedCooperative(S, qView, tView, tables, static_cast<int>(threadIdx.x), blockDim.x);
   if (threadIdx.x == 0) {
     addMaskSeed(child, atomMask, bondMask);
   }
@@ -251,7 +253,7 @@ __global__ void matchSubstructureMaskDriver(DeviceCsrView         qView,
 
   auto block = cooperative_groups::this_thread_block();
   auto warp  = cooperative_groups::tiled_partition<32>(block);
-  bool ok = mcs::fmcs::matchSeedSubstructureCooperative(warp, child.seed, qView, tView, tables, child.match, scratch);
+  bool ok    = mcs::fmcs::matchSeedSubstructureCooperative(warp, S, child.seed, child.match, /*g=*/0);
   __syncthreads();
 
   if (threadIdx.x == 0) {
@@ -265,8 +267,9 @@ __global__ void matchFallbackBadParentDriver(DeviceCsrView         qView,
                                              PairMatchTablesDevice tables,
                                              SubstructureTestOut*  out) {
   __shared__ QueuedT16 child;
-  __shared__ mcs::fmcs::FmcsSubstructureScratch<16, 16> scratch;
-  __shared__ int                                        scratchLock;
+  __shared__ __align__(16) unsigned char sharedRaw[sizeof(mcs::fmcs::FmcsPairShared<16, 16>)];
+  auto&                                  S = *reinterpret_cast<mcs::fmcs::FmcsPairShared<16, 16>*>(sharedRaw);
+  mcs::fmcs::loadPairSharedCooperative(S, qView, tView, tables, static_cast<int>(threadIdx.x), blockDim.x);
   if (threadIdx.x == 0) {
     // Query seed is the 4-edge path inside the triangle-with-leaves
     // repro: query bonds 1,2,3,4 and all five atoms.  The stored parent
@@ -287,20 +290,12 @@ __global__ void matchFallbackBadParentDriver(DeviceCsrView         qView,
     child.match.matchedAtomSize = 2;
     child.match.matchedBondSize = 1;
     child.match.empty           = false;
-    scratchLock                 = 0;
   }
   __syncthreads();
 
   auto block = cooperative_groups::this_thread_block();
   auto warp  = cooperative_groups::tiled_partition<32>(block);
-  bool ok    = mcs::fmcs::matchSeedWithSubstructureFallbackCooperative(warp,
-                                                                    child.seed,
-                                                                    qView,
-                                                                    tView,
-                                                                    tables,
-                                                                    child.match,
-                                                                    scratch,
-                                                                    &scratchLock);
+  bool ok    = mcs::fmcs::checkSeedMatchAndAppendCooperative(warp, S, child, /*g=*/0);
   __syncthreads();
 
   if (threadIdx.x == 0) {


### PR DESCRIPTION
One fmcsKernel for all tiers (16-128) and for timeout and no-timeout searches, replacing the previous per-block-size specialization matrix. The kernel runs one block per pair with every pair invariant -- both CSRs (byte-packed), atom/bond compatibility rows as bitsets, degree buckets, incident-bond sets, and per-class target adjacency -- loaded once into block-shared FmcsPairShared state and shared by all grow groups (16 at tiers <= 64, 8 at tier 128 to fit the 64 KB shared limit of the smallest supported architectures).

The matcher is re-expressed on shared components:
- The exact seed check runs on nvMolKit::dfsFromRoots, the same DFS core as substructure search, with abort polling inside the candidates callback.
- Per-class target adjacency lives in src/subgraph/class_adjacency.cuh, the K-class generalization of the substructure frontend's Uniform/Dual precompute, keyed on deduplicated bond-compatibility rows and filled once per pair at block scope.
- Seed/MatchResult/QueuedSeed, the seed queue, the incumbent protocol, and the grow-stage helpers are the existing ones; the matcher bridges their bit-word arrays to TargetMask at the boundaries, which is also what generalizes the kernel to tier 128.

Phase 1 tests every query bond's one-bond embedding in parallel and reduces RDKit's sequential prefix/failed-bond exclusion bookkeeping to bitmask algebra.  The remaining-size bound and the per-seed search order build are warp-parallel over shared memory; the greedy witness extension reads shared CSR.  Search semantics are unchanged from the RDKit-faithful implementation.

Remove the blockSize parameter end to end (fmcs::Parameters, MCSParameters, Python API, benchmarks, autotune): block size is now a per-tier compile-time constant, and the single specialization per tier cuts fMCS device compile time roughly 8x versus the old 4-block-sizes x 2-policies matrix.