### PR TITLE
Add CI workflow for the docs build, and fix docs for FireOptions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,6 +67,10 @@ jobs:
         run: |
           set -xeuo pipefail
           python -m sphinx -W --keep-going --fresh-env -b html docs docs/_build/html
+          if grep -R -E --include='*.html' '(_NativeExtensionStub|alias of.*Placeholder)' docs/_build/html/api; then
+            echo "Native documentation stubs leaked into the rendered API" >&2
+            exit 1
+          fi
 
       - name: Upload HTML documentation
         uses: actions/upload-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "VERSION"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "VERSION"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build HTML
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out source tree
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install documentation dependencies
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install --index-url https://download.pytorch.org/whl/cpu "torch>=2.1"
+          python -m pip install -r docs/requirements.txt
+
+      - name: Build documentation
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          python -m sphinx -W --keep-going --fresh-env -b html docs docs/_build/html
+
+      - name: Upload HTML documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: nvmolkit-documentation-html
+          path: docs/_build/html
+          if-no-files-found: error

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,11 +21,13 @@ on:
       - main
     paths:
       - "docs/**"
+      - "nvmolkit/**"
       - "VERSION"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
       - "docs/**"
+      - "nvmolkit/**"
       - "VERSION"
       - ".github/workflows/docs.yml"
   workflow_dispatch:

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,10 +17,11 @@ This will install Sphinx and other dependencies required for building the docume
 ### Step 2: Build the documentation
 
 ```bash
-sphinx-build -b html . public
+python -m sphinx -W --keep-going -b html . public
 ```
 
-This will build the documentation in the public directory.
+This will build the documentation in the public directory. Warnings are
+treated as errors, while `--keep-going` reports all warnings in one run.
 
 ### Step 3: Host the documentation locally
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,8 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 import datetime
+import sys
+from types import ModuleType
 
 import nvidia_sphinx_theme  # noqa
 
@@ -65,3 +67,39 @@ napoleon_include_init_with_doc = True
 
 autodoc_member_order = "bysource"
 autodoc_typehints_format = "short"
+
+
+class _NativeExtensionStub(ModuleType):
+    """Provide importable placeholders for unavailable compiled bindings."""
+
+    class Placeholder:
+        pass
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.__file__ = f"<{name}>"
+        self.__all__ = []
+
+    def __getattr__(self, name):
+        return self.Placeholder
+
+
+# API docs inspect the Python wrappers but do not execute GPU operations. Stub
+# the compiled modules so the docs can be built on a hosted CPU runner.
+for _module_name in (
+    "_arrayHelpers",
+    "_batchedForcefield",
+    "_clustering",
+    "_conformerRmsd",
+    "_DataStructs",
+    "_embedMolecules",
+    "_Fingerprints",
+    "_mcs",
+    "_mmffOptimization",
+    "_substructure",
+    "_TFD",
+    "_types",
+    "_uffOptimization",
+):
+    _qualified_name = f"nvmolkit.{_module_name}"
+    sys.modules[_qualified_name] = _NativeExtensionStub(_qualified_name)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,6 @@ autodocsumm
 myst-parser
 jupyter-sphinx
 sphinx-copybutton
+numpy>=1.23
+rdkit
+torch>=2.1

--- a/nvmolkit/batchedForcefield.py
+++ b/nvmolkit/batchedForcefield.py
@@ -449,9 +449,9 @@ class _BatchedForcefieldBase:
                 forceTol,
                 -1 if target_gpu is None else int(target_gpu),
                 minimizer_kind,
-                fireOptions,
+                fireOptions._as_native(),
             )
-        energies, converged = self._native_ff.minimize(maxIters, forceTol, minimizer_kind, fireOptions)
+        energies, converged = self._native_ff.minimize(maxIters, forceTol, minimizer_kind, fireOptions._as_native())
         return energies, converged
 
 

--- a/nvmolkit/mmffOptimization.py
+++ b/nvmolkit/mmffOptimization.py
@@ -228,7 +228,7 @@ def MMFFOptimizeMoleculesConfs(
             targetGpu,
             backend_name,
             minimizer_kind,
-            fireOptions,
+            fireOptions._as_native(),
         )
     return _mmffOptimization.MMFFOptimizeMoleculesConfs(
         molecules,
@@ -237,5 +237,5 @@ def MMFFOptimizeMoleculesConfs(
         native_options,
         backend_name,
         minimizer_kind,
-        fireOptions,
+        fireOptions._as_native(),
     )

--- a/nvmolkit/tests/test_types.py
+++ b/nvmolkit/tests/test_types.py
@@ -105,6 +105,7 @@ def test_coordinate_output_enum_values():
 
 def test_fire_options_exposes_native_defaults_and_mutators():
     options = FireOptions()
+    native = options._as_native()
     assert math.isclose(options.gradTol, 1e-4)
     assert options.stuckDetectionEnabled is False
 
@@ -112,6 +113,8 @@ def test_fire_options_exposes_native_defaults_and_mutators():
     options.useMass = True
     assert math.isclose(options.gradTol, 1e-3)
     assert options.useMass is True
+    assert math.isclose(native.gradTol, 1e-3)
+    assert native.useMass is True
 
 
 def test_device_3d_result_num_conformers_matches_atom_starts():

--- a/nvmolkit/types.py
+++ b/nvmolkit/types.py
@@ -23,7 +23,176 @@ import torch
 
 from nvmolkit import _arrayHelpers  # noqa: F401
 from nvmolkit import _embedMolecules  # type: ignore
-from nvmolkit._types import FireOptions  # noqa: F401
+from nvmolkit import _types
+
+
+class FireOptions:
+    """Configures the FIRE minimizer.
+
+    The native defaults are tuned for nvMolKit GPU workloads. Kernel units are
+    kcal/mol for energy, Angstrom for position, amu for mass, and ps for time.
+    """
+
+    def __init__(self) -> None:
+        """Create FIRE options initialized to the native nvMolKit defaults."""
+        self._native = _types.FireOptions()
+
+    @property
+    def dtInit(self) -> float:
+        """Initial time step in picoseconds."""
+        return self._native.dtInit
+
+    @dtInit.setter
+    def dtInit(self, value: float) -> None:
+        self._native.dtInit = float(value)
+
+    @property
+    def dtMinFactor(self) -> float:
+        """Lower time-step bound as a fraction of :attr:`dtInit`."""
+        return self._native.dtMinFactor
+
+    @dtMinFactor.setter
+    def dtMinFactor(self, value: float) -> None:
+        self._native.dtMinFactor = float(value)
+
+    @property
+    def dtMaxFactor(self) -> float:
+        """Upper time-step bound as a fraction of :attr:`dtInit`."""
+        return self._native.dtMaxFactor
+
+    @dtMaxFactor.setter
+    def dtMaxFactor(self, value: float) -> None:
+        self._native.dtMaxFactor = float(value)
+
+    @property
+    def dMax(self) -> float:
+        """Maximum per-step displacement-vector norm in Angstrom."""
+        return self._native.dMax
+
+    @dMax.setter
+    def dMax(self, value: float) -> None:
+        self._native.dMax = float(value)
+
+    @property
+    def timeStepIncrement(self) -> float:
+        """Time-step multiplier after sustained positive power."""
+        return self._native.timeStepIncrement
+
+    @timeStepIncrement.setter
+    def timeStepIncrement(self, value: float) -> None:
+        self._native.timeStepIncrement = float(value)
+
+    @property
+    def timeStepDecrement(self) -> float:
+        """Time-step multiplier when power becomes negative."""
+        return self._native.timeStepDecrement
+
+    @timeStepDecrement.setter
+    def timeStepDecrement(self, value: float) -> None:
+        self._native.timeStepDecrement = float(value)
+
+    @property
+    def nMinForIncrease(self) -> int:
+        """Positive-power steps required before increasing the time step."""
+        return self._native.nMinForIncrease
+
+    @nMinForIncrease.setter
+    def nMinForIncrease(self, value: int) -> None:
+        self._native.nMinForIncrease = int(value)
+
+    @property
+    def alphaInit(self) -> float:
+        """Initial force-velocity mixing coefficient."""
+        return self._native.alphaInit
+
+    @alphaInit.setter
+    def alphaInit(self, value: float) -> None:
+        self._native.alphaInit = float(value)
+
+    @property
+    def alphaDecrement(self) -> float:
+        """Mixing-coefficient decay while power remains positive."""
+        return self._native.alphaDecrement
+
+    @alphaDecrement.setter
+    def alphaDecrement(self, value: float) -> None:
+        self._native.alphaDecrement = float(value)
+
+    @property
+    def useMass(self) -> bool:
+        """Whether force kicks are weighted by per-atom masses."""
+        return self._native.useMass
+
+    @useMass.setter
+    def useMass(self, value: bool) -> None:
+        self._native.useMass = bool(value)
+
+    @property
+    def gradTol(self) -> float:
+        """Convergence threshold on ``sqrt(sum(grad**2))`` per system."""
+        return self._native.gradTol
+
+    @gradTol.setter
+    def gradTol(self, value: float) -> None:
+        self._native.gradTol = float(value)
+
+    @property
+    def takeHalfStepBack(self) -> bool:
+        """Whether to take an ASE FIRE2 half-step back after negative power."""
+        return self._native.takeHalfStepBack
+
+    @takeHalfStepBack.setter
+    def takeHalfStepBack(self, value: bool) -> None:
+        self._native.takeHalfStepBack = bool(value)
+
+    @property
+    def abcCorrection(self) -> bool:
+        """Whether to apply the Accelerated Bias-Correction multiplier."""
+        return self._native.abcCorrection
+
+    @abcCorrection.setter
+    def abcCorrection(self, value: bool) -> None:
+        self._native.abcCorrection = bool(value)
+
+    @property
+    def stuckDetectionEnabled(self) -> bool:
+        """Whether an energy plateau can declare a system converged."""
+        return self._native.stuckDetectionEnabled
+
+    @stuckDetectionEnabled.setter
+    def stuckDetectionEnabled(self, value: bool) -> None:
+        self._native.stuckDetectionEnabled = bool(value)
+
+    @property
+    def stuckEnergyRelTol(self) -> float:
+        """Relative energy tolerance used for plateau detection."""
+        return self._native.stuckEnergyRelTol
+
+    @stuckEnergyRelTol.setter
+    def stuckEnergyRelTol(self, value: float) -> None:
+        self._native.stuckEnergyRelTol = float(value)
+
+    @property
+    def stuckStreakLength(self) -> int:
+        """Consecutive plateau polls required to declare a system stuck."""
+        return self._native.stuckStreakLength
+
+    @stuckStreakLength.setter
+    def stuckStreakLength(self, value: int) -> None:
+        self._native.stuckStreakLength = int(value)
+
+    @property
+    def stuckEvalEveryNPolls(self) -> int:
+        """Number of convergence polls between plateau-energy samples."""
+        return self._native.stuckEvalEveryNPolls
+
+    @stuckEvalEveryNPolls.setter
+    def stuckEvalEveryNPolls(self, value: int) -> None:
+        self._native.stuckEvalEveryNPolls = int(value)
+
+    def _as_native(self):
+        """Internal: return the underlying native FireOptions object."""
+        return self._native
 
 
 class HardwareOptions:

--- a/nvmolkit/uffOptimization.py
+++ b/nvmolkit/uffOptimization.py
@@ -148,7 +148,7 @@ def UFFOptimizeMoleculesConfs(
             hardwareOptions._as_native(),
             int(targetGpu),
             minimizer_kind,
-            fireOptions,
+            fireOptions._as_native(),
         )
     return _uffOptimization.UFFOptimizeMoleculesConfs(
         molecules,
@@ -157,5 +157,5 @@ def UFFOptimizeMoleculesConfs(
         interfrag_flags,
         hardwareOptions._as_native(),
         minimizer_kind,
-        fireOptions,
+        fireOptions._as_native(),
     )


### PR DESCRIPTION
FireOptions needed a wrapper like our other options structs, before it was being exposed natively through boost python. 

To avoid needing to do a full install of nvmolkit, conf.py stubs out the libraries.