### PR TITLE
Fix unique substructure match counts

### DIFF
--- a/nvmolkit/tests/test_substructure.py
+++ b/nvmolkit/tests/test_substructure.py
@@ -15,10 +15,10 @@
 
 """Tests for GPU-accelerated substructure search."""
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 
+import numpy as np
 import pytest
 from rdkit import Chem
 
@@ -28,7 +28,6 @@ from nvmolkit.substructure import (
     getSubstructMatches,
     hasSubstructMatch,
 )
-
 
 TEST_DATA_DIR = Path(__file__).parent.parent.parent / "tests" / "test_data"
 MAX_ATOMS = 128
@@ -769,6 +768,46 @@ class TestCountSubstructMatch:
 
         assert rdkit_count == 12
         assert results[0, 0] == rdkit_count
+
+    def test_count_uniquify_symmetric_queries(self):
+        """Test unique count API results against RDKit for symmetric queries."""
+        targets = [
+            Chem.MolFromSmiles("C1CCCCC1"),
+            Chem.MolFromSmiles("CCOCC"),
+        ]
+        queries = [
+            Chem.MolFromSmarts("CCC"),
+            Chem.MolFromSmarts("COC"),
+        ]
+        config = SubstructSearchConfig(uniquify=True, preprocessingThreads=1, workerThreads=1)
+
+        results = countSubstructMatches(targets, queries, config)
+
+        expected = np.array(
+            [[len(target.GetSubstructMatches(query, uniquify=True)) for query in queries] for target in targets],
+            dtype=results.dtype,
+        )
+        np.testing.assert_array_equal(results, expected)
+        assert results[0, 0] == 6
+        assert results[1, 1] == 1
+
+    def test_count_uniquify_matches_get_lengths(self):
+        """Test that unique count results equal unique get-result lengths."""
+        targets = [Chem.MolFromSmiles("C1CCCCC1"), Chem.MolFromSmiles("CCOCC")]
+        queries = [Chem.MolFromSmarts("CC"), Chem.MolFromSmarts("CCC"), Chem.MolFromSmarts("COC")]
+        config = SubstructSearchConfig(uniquify=True, preprocessingThreads=1, workerThreads=1)
+
+        counts = countSubstructMatches(targets, queries, config)
+        matches = getSubstructMatches(targets, queries, config)
+
+        expected = np.array(
+            [
+                [len(matches[target_idx][query_idx]) for query_idx in range(matches.shape[1])]
+                for target_idx in range(matches.shape[0])
+            ],
+            dtype=counts.dtype,
+        )
+        np.testing.assert_array_equal(counts, expected)
 
     def test_count_batch(self):
         """Test countSubstructMatches with batch of molecules."""

--- a/src/substruct/substruct_search.cu
+++ b/src/substruct/substruct_search.cu
@@ -1088,7 +1088,20 @@ void countSubstructMatches(const std::vector<const RDKit::ROMol*>& targets,
   SubstructSearchConfig  countConfig = config;
   countConfig.maxMatches             = 0;
 
-  getSubstructMatchesImpl(targets, queries, matchResults, algorithm, stream, countConfig, nullptr, &counts);
+  if (countConfig.uniquify) {
+    // Uniquification requires the atom mappings: the counts-only GPU path only
+    // retains the number of embeddings and cannot identify equivalent matches.
+    getSubstructMatchesImpl(targets, queries, matchResults, algorithm, stream, countConfig, nullptr, nullptr);
+
+    for (int targetIdx = 0; targetIdx < numTargets; ++targetIdx) {
+      for (int queryIdx = 0; queryIdx < numQueries; ++queryIdx) {
+        const size_t pairIdx = static_cast<size_t>(targetIdx) * numQueries + queryIdx;
+        counts[pairIdx]      = matchResults.matchCount(targetIdx, queryIdx);
+      }
+    }
+  } else {
+    getSubstructMatchesImpl(targets, queries, matchResults, algorithm, stream, countConfig, nullptr, &counts);
+  }
 }
 
 void hasSubstructMatch(const std::vector<const RDKit::ROMol*>& targets,

--- a/tests/test_substruct_search.cu
+++ b/tests/test_substruct_search.cu
@@ -1727,6 +1727,32 @@ TEST_P(SubstructureSearchTest, CountSubstructMatchesBasic) {
   EXPECT_EQ(counts[idx(1, 2)], 4);
 }
 
+TEST_P(SubstructureSearchTest, CountSubstructMatchesUniquifySymmetricQueries) {
+  std::vector<std::unique_ptr<RDKit::ROMol>> targetMols;
+  std::vector<std::unique_ptr<RDKit::ROMol>> queryMols;
+
+  parseMolecules({"C1CCCCC1", "CCOCC"}, {"CCC", "COC"}, targetMols, queryMols);
+
+  SubstructSearchConfig config;
+  config.uniquify = true;
+
+  std::vector<int> counts;
+  countSubstructMatches(getRawPtrs(targetMols), getRawPtrs(queryMols), counts, algorithm(), stream_.stream(), config);
+
+  const int numQueries = static_cast<int>(queryMols.size());
+  for (int targetIdx = 0; targetIdx < static_cast<int>(targetMols.size()); ++targetIdx) {
+    for (int queryIdx = 0; queryIdx < numQueries; ++queryIdx) {
+      const auto rdkitMatches = getRDKitSubstructMatches(*targetMols[targetIdx], *queryMols[queryIdx], true);
+      const auto pairIdx      = static_cast<size_t>(targetIdx) * numQueries + queryIdx;
+      EXPECT_EQ(counts[pairIdx], static_cast<int>(rdkitMatches.size()))
+        << "Mismatch at target " << targetIdx << ", query " << queryIdx;
+    }
+  }
+
+  EXPECT_EQ(counts[0], 6) << "CCC on cyclohexane should count unique atom sets";
+  EXPECT_EQ(counts[3], 1) << "COC on diethyl ether should count unique atom sets";
+}
+
 // =============================================================================
 // Uniquify Tests
 // =============================================================================


### PR DESCRIPTION
Falls back to the non-count get-all version with counts after the fact, when uniquify is true. Fixes #275 