### PR TITLE
Add conformer RMSD alignment modes

### DIFF
--- a/nvmolkit/conformerRmsd.cpp
+++ b/nvmolkit/conformerRmsd.cpp
@@ -37,7 +37,8 @@ boost::python::object toOwnedPyArray(nvMolKit::PyArray* array) {
 BOOST_PYTHON_MODULE(_conformerRmsd) {
   boost::python::def(
     "GetConformerRMSMatrixBatch",
-    +[](boost::python::list& mols, const bool prealigned, std::uintptr_t streamPtr) -> boost::python::object {
+    +[](boost::python::list& mols, const bool prealigned, const bool alignToFirstConformer, std::uintptr_t streamPtr)
+      -> boost::python::object {
       auto streamOpt = nvMolKit::acquireExternalStream(streamPtr);
       if (!streamOpt) {
         throw std::invalid_argument("Invalid CUDA stream");
@@ -56,7 +57,7 @@ BOOST_PYTHON_MODULE(_conformerRmsd) {
         }
       }
 
-      auto buffers = nvMolKit::conformerRmsdBatchMatrixMol(molsVec, prealigned, *streamOpt);
+      auto buffers = nvMolKit::conformerRmsdBatchMatrixMol(molsVec, prealigned, *streamOpt, alignToFirstConformer);
 
       boost::python::list results;
       for (int m = 0; m < numMols; ++m) {
@@ -66,11 +67,15 @@ BOOST_PYTHON_MODULE(_conformerRmsd) {
       }
       return results;
     },
-    (boost::python::arg("mols"), boost::python::arg("prealigned") = false, boost::python::arg("stream") = 0));
+    (boost::python::arg("mols"),
+     boost::python::arg("prealigned")            = false,
+     boost::python::arg("alignToFirstConformer") = false,
+     boost::python::arg("stream")                = 0));
 
   boost::python::def(
     "GetConformerRMSMatrix",
-    +[](RDKit::ROMol& mol, const bool prealigned, std::uintptr_t streamPtr) -> boost::python::object {
+    +[](RDKit::ROMol& mol, const bool prealigned, const bool alignToFirstConformer, std::uintptr_t streamPtr)
+      -> boost::python::object {
       auto streamOpt = nvMolKit::acquireExternalStream(streamPtr);
       if (!streamOpt) {
         throw std::invalid_argument("Invalid CUDA stream");
@@ -78,8 +83,11 @@ BOOST_PYTHON_MODULE(_conformerRmsd) {
 
       const int     numConfs = mol.getNumConformers();
       const int64_t numPairs = numConfs >= 2 ? static_cast<int64_t>(numConfs) * (numConfs - 1) / 2 : 0;
-      auto          buffer   = nvMolKit::conformerRmsdMatrixMol(mol, prealigned, *streamOpt);
+      auto          buffer   = nvMolKit::conformerRmsdMatrixMol(mol, prealigned, *streamOpt, alignToFirstConformer);
       return toOwnedPyArray(nvMolKit::makePyArray(buffer, boost::python::make_tuple(numPairs)));
     },
-    (boost::python::arg("mol"), boost::python::arg("prealigned") = false, boost::python::arg("stream") = 0));
+    (boost::python::arg("mol"),
+     boost::python::arg("prealigned")            = false,
+     boost::python::arg("alignToFirstConformer") = false,
+     boost::python::arg("stream")                = 0));
 }

--- a/nvmolkit/conformerRmsd.py
+++ b/nvmolkit/conformerRmsd.py
@@ -29,11 +29,17 @@ __all__ = ["GetConformerRMSMatrix", "GetConformerRMSMatrixBatch"]
 
 
 _VALID_OUTPUT_FORMATS = frozenset({"condensed", "square"})
+_VALID_ALIGNMENT_MODES = frozenset({"first-conformer", "pairwise"})
 
 
 def _check_output_format(output_format: str) -> None:
     if output_format not in _VALID_OUTPUT_FORMATS:
         raise ValueError(f"output_format must be one of {sorted(_VALID_OUTPUT_FORMATS)}, got {output_format!r}")
+
+
+def _check_alignment_mode(alignment_mode: str) -> None:
+    if alignment_mode not in _VALID_ALIGNMENT_MODES:
+        raise ValueError(f"alignment_mode must be one of {sorted(_VALID_ALIGNMENT_MODES)}, got {alignment_mode!r}")
 
 
 def _condensed_to_square(rmsd: AsyncGpuResult, num_confs: int) -> torch.Tensor:
@@ -53,14 +59,30 @@ def GetConformerRMSMatrix(
     stream: torch.cuda.Stream | None = None,
     *,
     output_format: str = "condensed",
+    alignment_mode: str = "pairwise",
 ) -> AsyncGpuResult | torch.Tensor:
     """Compute the pairwise RMSD matrix between all conformers of a molecule on GPU.
 
-    GPU-accelerated equivalent of ``AllChem.GetConformerRMSMatrix(mol,
-    prealigned=prealigned)``.  For N conformers with M atoms, computes N*(N-1)/2
-    pairwise RMSD values using one GPU thread-block per pair.  When ``prealigned``
-    is False (default), each pair is optimally superimposed via the Kabsch algorithm
-    before computing RMSD.
+    For N conformers with M atoms, computes N*(N-1)/2 pairwise RMSD values using
+    one GPU thread-block per pair.  When ``prealigned`` is False (default), the
+    alignment behavior is selected by ``alignment_mode``.
+
+    The default ``alignment_mode="pairwise"`` optimally superimposes every pair
+    independently via the Kabsch algorithm.  Its alignment semantics are similar
+    to using :func:`rdkit.Chem.rdMolAlign.GetAllConformerBestRMS` with an identity
+    atom map and ``symmetrizeConjugatedTerminalGroups=False``::
+
+        identity_map = [[(i, i) for i in range(mol.GetNumAtoms())]]
+        rdMolAlign.GetAllConformerBestRMS(
+            mol,
+            map=identity_map,
+            symmetrizeConjugatedTerminalGroups=False,
+        )
+
+    ``alignment_mode="first-conformer"`` follows
+    :func:`rdkit.Chem.AllChem.GetConformerRMSMatrix`: each conformer is aligned
+    to conformer 0, then RMSDs are computed between those aligned coordinates.
+    The input molecule is not modified in either mode.
 
     **Differences from RDKit:**
 
@@ -79,12 +101,16 @@ def GetConformerRMSMatrix(
              (``Chem.RemoveHs``) if you want heavy-atom RMSD, as this function
              operates on all atoms present in the molecule.
         prealigned: If True, skip Kabsch alignment and compute RMSD on raw
-                    coordinates.  If False (default), optimally align each pair.
+                    coordinates.  If False (default), use ``alignment_mode``.
         stream: CUDA stream to use.  If None, uses the current stream.
         output_format: ``"condensed"`` returns an :class:`AsyncGpuResult` wrapping
                        a 1-D RDKit-style lower-triangle vector.  ``"square"``
                        returns a symmetric ``torch.Tensor`` of shape ``(N, N)``
                        on the GPU with zeros on the diagonal.
+        alignment_mode: ``"pairwise"`` (default) optimally aligns each conformer
+                        pair independently.  ``"first-conformer"`` aligns every
+                        conformer to conformer 0 before computing pairwise RMSDs.
+                        Ignored when ``prealigned=True``.
 
     Returns:
         With ``output_format="condensed"``, an :class:`AsyncGpuResult` wrapping a
@@ -96,7 +122,8 @@ def GetConformerRMSMatrix(
         shape ``(N, N)``.
 
     Raises:
-        ValueError: If ``mol`` is None or has conformers but no atoms.
+        ValueError: If ``mol`` is None, has conformers but no atoms, or an
+                    unsupported ``alignment_mode`` is requested.
         TypeError: If ``stream`` is not a ``torch.cuda.Stream`` or None.
 
     Example:
@@ -109,8 +136,10 @@ def GetConformerRMSMatrix(
         >>> rdDistGeom.EmbedMultipleConfs(mol, numConfs=50)
         >>> no_h = Chem.RemoveHs(mol)
         >>>
-        >>> # GPU equivalent of: AllChem.GetConformerRMSMatrix(no_h)
+        >>> # Independently align each conformer pair
         >>> rmsd_matrix = GetConformerRMSMatrix(no_h)
+        >>> # Match AllChem.GetConformerRMSMatrix alignment semantics
+        >>> rdkit_style = GetConformerRMSMatrix(no_h, alignment_mode="first-conformer")
         >>>
         >>> # Request square output for GPU Butina clustering
         >>> square = GetConformerRMSMatrix(no_h, output_format="square")
@@ -121,10 +150,13 @@ def GetConformerRMSMatrix(
     if stream is not None and not isinstance(stream, torch.cuda.Stream):
         raise TypeError(f"stream must be a torch.cuda.Stream or None, got {type(stream).__name__}")
     _check_output_format(output_format)
+    _check_alignment_mode(alignment_mode)
 
     execution_stream = stream if stream is not None else torch.cuda.current_stream()
     stream_ptr = execution_stream.cuda_stream
-    result = AsyncGpuResult(_conformerRmsd.GetConformerRMSMatrix(mol, prealigned, stream_ptr))
+    result = AsyncGpuResult(
+        _conformerRmsd.GetConformerRMSMatrix(mol, prealigned, alignment_mode == "first-conformer", stream_ptr)
+    )
     if output_format == "square":
         with torch.cuda.stream(execution_stream):
             return _condensed_to_square(result, mol.GetNumConformers())
@@ -137,24 +169,35 @@ def GetConformerRMSMatrixBatch(
     stream: torch.cuda.Stream | None = None,
     *,
     output_format: str = "condensed",
+    alignment_mode: str = "pairwise",
 ) -> list[AsyncGpuResult] | list[torch.Tensor]:
     """Compute pairwise RMSD matrices for a batch of molecules on GPU.
 
     All molecules are processed in a single kernel launch, so their conformer
     pairs execute concurrently.  This improves GPU saturation over repeated
     single-molecule calls, particularly for molecules with few conformers.
+    ``alignment_mode="pairwise"`` independently aligns each pair and is
+    equivalent to the default single-molecule behavior.
+    ``alignment_mode="first-conformer"`` follows
+    :func:`rdkit.Chem.AllChem.GetConformerRMSMatrix` by aligning every conformer
+    to conformer 0 before computing pairwise RMSDs.  Input molecules are not
+    modified.
 
     Args:
         mols: List of RDKit molecules, each with zero or more conformers.
               Strip hydrogens first (``Chem.RemoveHs``) for heavy-atom RMSD.
               Molecules with fewer than 2 conformers return an empty result.
         prealigned: If True, skip Kabsch alignment and compute RMSD on raw
-                    coordinates.  If False (default), optimally align each pair.
+                    coordinates.  If False (default), use ``alignment_mode``.
         stream: CUDA stream to use.  If None, uses the current stream.
         output_format: ``"condensed"`` returns one :class:`AsyncGpuResult` per
                        molecule, each wrapping a 1-D RDKit-style lower-triangle
                        vector.  ``"square"`` returns one symmetric CUDA
                        ``torch.Tensor`` of shape ``(N, N)`` per molecule.
+        alignment_mode: ``"pairwise"`` (default) optimally aligns each conformer
+                        pair independently.  ``"first-conformer"`` aligns every
+                        conformer to conformer 0 before computing pairwise RMSDs.
+                        Ignored when ``prealigned=True``.
 
     Returns:
         With ``output_format="condensed"``, a list of :class:`AsyncGpuResult`,
@@ -168,7 +211,8 @@ def GetConformerRMSMatrixBatch(
         ``torch.Tensor`` objects with shapes ``(N, N)``.
 
     Raises:
-        ValueError: If any element of ``mols`` is None.
+        ValueError: If any element of ``mols`` is None or an unsupported
+                    ``alignment_mode`` is requested.
         TypeError: If ``stream`` is not a ``torch.cuda.Stream`` or None.
 
     Example:
@@ -187,6 +231,7 @@ def GetConformerRMSMatrixBatch(
     if stream is not None and not isinstance(stream, torch.cuda.Stream):
         raise TypeError(f"stream must be a torch.cuda.Stream or None, got {type(stream).__name__}")
     _check_output_format(output_format)
+    _check_alignment_mode(alignment_mode)
 
     for i, mol in enumerate(mols):
         if mol is None:
@@ -194,7 +239,7 @@ def GetConformerRMSMatrixBatch(
 
     execution_stream = stream if stream is not None else torch.cuda.current_stream()
     stream_ptr = execution_stream.cuda_stream
-    raw = _conformerRmsd.GetConformerRMSMatrixBatch(mols, prealigned, stream_ptr)
+    raw = _conformerRmsd.GetConformerRMSMatrixBatch(mols, prealigned, alignment_mode == "first-conformer", stream_ptr)
     results = [AsyncGpuResult(r) for r in raw]
     if output_format == "square":
         with torch.cuda.stream(execution_stream):

--- a/nvmolkit/tests/test_conformer_rmsd.py
+++ b/nvmolkit/tests/test_conformer_rmsd.py
@@ -144,6 +144,31 @@ def test_rmsd_explicit_condensed_output_matches_default():
     assert torch.allclose(condensed_result.torch(), default_result.torch(), atol=1e-10)
 
 
+@pytest.mark.parametrize("smiles", ["CCCCCC", "c1ccccc1", "CC(=O)Oc1ccccc1C(=O)O"])
+def test_rmsd_first_conformer_alignment_matches_rdkit_without_mutating_input(smiles):
+    """First-conformer alignment matches RDKit's conformer-0 behavior."""
+    mol = Chem.RemoveHs(_embed_mol(smiles, num_confs=10))
+    original_coords = [np.array(conf.GetPositions()) for conf in mol.GetConformers()]
+    rdkit_mol = Chem.Mol(mol)
+    rdkit_rms = _rdkit_rmsd_matrix(rdkit_mol)
+
+    gpu_rms = GetConformerRMSMatrix(mol, alignment_mode="first-conformer").numpy()
+
+    np.testing.assert_allclose(gpu_rms, rdkit_rms, atol=0.01)
+    for conf, expected in zip(mol.GetConformers(), original_coords):
+        np.testing.assert_array_equal(conf.GetPositions(), expected)
+
+
+def test_rmsd_first_conformer_and_pairwise_alignment_are_distinct():
+    """First-conformer alignment does not independently minimize every pair."""
+    mol = Chem.RemoveHs(_embed_mol("CCCCCC", num_confs=10))
+
+    pairwise = GetConformerRMSMatrix(mol, alignment_mode="pairwise").numpy()
+    first_conformer = GetConformerRMSMatrix(mol, alignment_mode="first-conformer").numpy()
+
+    assert np.any(first_conformer > pairwise + 0.01)
+
+
 def test_rmsd_square_output_matches_condensed():
     """Square output expands the default RDKit-style condensed vector."""
     mol = _embed_mol("CCCCCC", num_confs=10)
@@ -209,6 +234,18 @@ def test_rmsd_explicit_stream():
         assert abs(g - r) < 0.01
 
 
+def test_rmsd_first_conformer_explicit_stream():
+    """First-conformer alignment and RMSD execute on the explicit stream."""
+    mol = Chem.RemoveHs(_embed_mol("CCCCCC", num_confs=10))
+    rdkit_rms = _rdkit_rmsd_matrix(Chem.Mol(mol))
+
+    stream = torch.cuda.Stream()
+    gpu_result = GetConformerRMSMatrix(mol, alignment_mode="first-conformer", stream=stream)
+    stream.synchronize()
+
+    np.testing.assert_allclose(gpu_result.numpy(), rdkit_rms, atol=0.01)
+
+
 def test_rmsd_square_output_explicit_stream():
     """Square conversion is enqueued on the caller-provided stream."""
     mol = _embed_mol("CCCCCC", num_confs=10)
@@ -255,6 +292,13 @@ def test_rmsd_invalid_output_format():
     no_h = Chem.RemoveHs(mol)
     with pytest.raises(ValueError, match="output_format must be one of"):
         GetConformerRMSMatrix(no_h, output_format="matrix")
+
+
+def test_rmsd_invalid_alignment_mode():
+    """Unknown alignment_mode should fail before dispatch."""
+    mol = Chem.RemoveHs(_embed_mol("CCCC", num_confs=2))
+    with pytest.raises(ValueError, match="alignment_mode must be one of"):
+        GetConformerRMSMatrix(mol, alignment_mode="first")
 
 
 def test_rmsd_output_format_is_keyword_only():
@@ -315,6 +359,37 @@ def test_batch_explicit_condensed_output_matches_default():
     for default_result, condensed_result in zip(default_results, condensed_results):
         assert isinstance(condensed_result, AsyncGpuResult)
         assert torch.allclose(condensed_result.torch(), default_result.torch(), atol=1e-10)
+
+
+def test_batch_first_conformer_alignment_matches_single_and_rdkit():
+    """Batch first-conformer alignment matches single dispatch and RDKit."""
+    mols = [Chem.RemoveHs(_embed_mol(s, num_confs=6)) for s in ["CCCC", "CCCCCC"]]
+
+    batch_results = GetConformerRMSMatrixBatch(mols, alignment_mode="first-conformer")
+
+    for mol, batch_result in zip(mols, batch_results):
+        single_result = GetConformerRMSMatrix(mol, alignment_mode="first-conformer")
+        rdkit_rms = _rdkit_rmsd_matrix(Chem.Mol(mol))
+        np.testing.assert_allclose(batch_result.numpy(), single_result.numpy(), atol=1e-10)
+        np.testing.assert_allclose(batch_result.numpy(), rdkit_rms, atol=0.01)
+
+
+def test_batch_first_conformer_alignment_with_mixed_conformer_counts():
+    """First-conformer batch routing handles duplicate conformer offsets."""
+    mols = [
+        Chem.MolFromSmiles("CCO"),
+        Chem.RemoveHs(_embed_mol("CCCCCC", num_confs=6)),
+        Chem.RemoveHs(_embed_mol("CCO", num_confs=1)),
+        Chem.RemoveHs(_embed_mol("CCCC", num_confs=4)),
+    ]
+
+    results = GetConformerRMSMatrixBatch(mols, alignment_mode="first-conformer")
+
+    assert results[0].numpy().size == 0
+    assert results[2].numpy().size == 0
+    for index in [1, 3]:
+        rdkit_rms = _rdkit_rmsd_matrix(Chem.Mol(mols[index]))
+        np.testing.assert_allclose(results[index].numpy(), rdkit_rms, atol=0.01)
 
 
 def test_batch_square_output():
@@ -381,6 +456,13 @@ def test_batch_invalid_output_format():
         GetConformerRMSMatrixBatch([mol], output_format="matrix")
 
 
+def test_batch_invalid_alignment_mode():
+    """Unknown batch alignment_mode should fail before dispatch."""
+    mol = Chem.RemoveHs(_embed_mol("CCCC", num_confs=2))
+    with pytest.raises(ValueError, match="alignment_mode must be one of"):
+        GetConformerRMSMatrixBatch([mol], alignment_mode="first")
+
+
 def test_batch_output_format_is_keyword_only():
     """Batch output_format is keyword-only to avoid ambiguous positional calls."""
     mol = Chem.RemoveHs(_embed_mol("CCCC", num_confs=2))
@@ -403,6 +485,19 @@ def test_batch_explicit_stream():
             assert abs(g - r) < 0.01
 
 
+def test_batch_first_conformer_explicit_stream():
+    """Batch first-conformer alignment executes on the explicit stream."""
+    mols = [Chem.RemoveHs(_embed_mol(s, num_confs=5)) for s in ["CCCC", "CCCCCC"]]
+    references = [_rdkit_rmsd_matrix(Chem.Mol(mol)) for mol in mols]
+
+    stream = torch.cuda.Stream()
+    results = GetConformerRMSMatrixBatch(mols, alignment_mode="first-conformer", stream=stream)
+    stream.synchronize()
+
+    for result, reference in zip(results, references):
+        np.testing.assert_allclose(result.numpy(), reference, atol=0.01)
+
+
 def test_batch_square_output_explicit_stream():
     """Batch square conversion is enqueued on the caller-provided stream."""
     mols = [Chem.RemoveHs(_embed_mol(s, num_confs=5)) for s in ["CCCC", "CCCCC"]]
@@ -422,7 +517,8 @@ def test_batch_square_output_explicit_stream():
         assert torch.allclose(square, expected, atol=0.01)
 
 
-def test_rmsd_zero_atoms():
+@pytest.mark.parametrize("alignment_mode", ["pairwise", "first-conformer"])
+def test_rmsd_zero_atoms(alignment_mode):
     """0-atom molecule with multiple conformers raises ValueError.
 
     nvMolKit intentionally diverges from RDKit here: RDKit returns [nan] for
@@ -434,4 +530,4 @@ def test_rmsd_zero_atoms():
     mol.AddConformer(Chem.Conformer(0), assignId=True)
     mol.AddConformer(Chem.Conformer(0), assignId=True)
     with pytest.raises(ValueError):
-        GetConformerRMSMatrix(mol.GetMol())
+        GetConformerRMSMatrix(mol.GetMol(), alignment_mode=alignment_mode)

--- a/src/conformer_rmsd.cu
+++ b/src/conformer_rmsd.cu
@@ -79,29 +79,355 @@ __device__ __forceinline__ void symmetricEigenvalues3x3(const double a00,
   }
 }
 
-/// Compute determinant of a 3x3 matrix stored row-major.
-__device__ __forceinline__ double det3x3(const double* H) {
-  return H[0] * (H[4] * H[8] - H[5] * H[7]) - H[1] * (H[3] * H[8] - H[5] * H[6]) + H[2] * (H[3] * H[7] - H[4] * H[6]);
+/// Compute determinant of a 3x3 matrix stored as scalar elements.
+__device__ __forceinline__ double det3x3(const double h00,
+                                         const double h01,
+                                         const double h02,
+                                         const double h10,
+                                         const double h11,
+                                         const double h12,
+                                         const double h20,
+                                         const double h21,
+                                         const double h22) {
+  return h00 * (h11 * h22 - h12 * h21) - h01 * (h10 * h22 - h12 * h20) + h02 * (h10 * h21 - h11 * h20);
 }
 
 // ---------------------------------------------------------------------------
-// Per-pair RMSD helper
+// Rigid-alignment helpers
 //
-// Called by both kernels after they resolve coordI, coordJ, and outRmsd from
-// their respective index schemes.  All shared memory is managed internally.
-//
-// Each block computes:
-//   1. Centroids of both conformers            (cub::BlockReduce, results broadcast)
-//   2. Centered inner products  Sp, Sq         (cub::BlockReduce, thread 0 only)
-//   3. Cross-covariance matrix  H = Pc^T Qc    (cub::BlockReduce, thread 0 only)
-//   4. Singular values of H via eigenvalues of H^T H  (thread 0, analytical)
-//   5. RMSD with optional Kabsch alignment      (thread 0)
+// Both alignment modes need centroids and H = Pc^T Qc. Pairwise RMSD consumes
+// H's singular values; first-conformer alignment consumes its rotation.
 // ---------------------------------------------------------------------------
 
 constexpr int kRmsdBlockSize = 128;
 constexpr int kRmsdWarps     = kRmsdBlockSize / 32;  // 4 warps per block
 
 using RmsdWarpReduce = cub::WarpReduce<double>;
+
+struct RigidAlignmentMoments {
+  double movingCenterX;
+  double movingCenterY;
+  double movingCenterZ;
+  double fixedCenterX;
+  double fixedCenterY;
+  double fixedCenterZ;
+  double movingSquaredNorm;
+  double fixedSquaredNorm;
+  double h00;
+  double h01;
+  double h02;
+  double h10;
+  double h11;
+  double h12;
+  double h20;
+  double h21;
+  double h22;
+};
+
+/// Accumulate the centroids and cross-covariance shared by both rigid-alignment
+/// consumers. Pairwise RMSD additionally requests the two centered norms.
+template <bool ComputeSquaredNorms>
+__device__ __forceinline__ void accumulateRigidAlignmentMoments(const double* __restrict__ movingCoords,
+                                                                const double* __restrict__ fixedCoords,
+                                                                const int                             numAtoms,
+                                                                typename RmsdWarpReduce::TempStorage* warpReduceTemp,
+                                                                double*                               warpBuf,
+                                                                RigidAlignmentMoments*                moments) {
+  constexpr int kNumFields = ComputeSquaredNorms ? 11 : 9;
+  const int     tid        = threadIdx.x;
+  const int     warpId     = tid / 32;
+  const int     laneId     = tid % 32;
+
+  double sumMx = 0.0, sumMy = 0.0, sumMz = 0.0;
+  double sumFx = 0.0, sumFy = 0.0, sumFz = 0.0;
+  for (int atom = tid; atom < numAtoms; atom += kRmsdBlockSize) {
+    sumMx += movingCoords[atom * 3 + 0];
+    sumMy += movingCoords[atom * 3 + 1];
+    sumMz += movingCoords[atom * 3 + 2];
+    sumFx += fixedCoords[atom * 3 + 0];
+    sumFy += fixedCoords[atom * 3 + 1];
+    sumFz += fixedCoords[atom * 3 + 2];
+  }
+  sumMx = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumMx);
+  sumMy = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumMy);
+  sumMz = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumMz);
+  sumFx = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumFx);
+  sumFy = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumFy);
+  sumFz = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumFz);
+  if (laneId == 0) {
+    warpBuf[warpId * kNumFields + 0] = sumMx;
+    warpBuf[warpId * kNumFields + 1] = sumMy;
+    warpBuf[warpId * kNumFields + 2] = sumMz;
+    warpBuf[warpId * kNumFields + 3] = sumFx;
+    warpBuf[warpId * kNumFields + 4] = sumFy;
+    warpBuf[warpId * kNumFields + 5] = sumFz;
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+    double mx = 0.0, my = 0.0, mz = 0.0;
+    double fx = 0.0, fy = 0.0, fz = 0.0;
+    for (int warp = 0; warp < kRmsdWarps; ++warp) {
+      mx += warpBuf[warp * kNumFields + 0];
+      my += warpBuf[warp * kNumFields + 1];
+      mz += warpBuf[warp * kNumFields + 2];
+      fx += warpBuf[warp * kNumFields + 3];
+      fy += warpBuf[warp * kNumFields + 4];
+      fz += warpBuf[warp * kNumFields + 5];
+    }
+    const double invN      = 1.0 / static_cast<double>(numAtoms);
+    moments->movingCenterX = mx * invN;
+    moments->movingCenterY = my * invN;
+    moments->movingCenterZ = mz * invN;
+    moments->fixedCenterX  = fx * invN;
+    moments->fixedCenterY  = fy * invN;
+    moments->fixedCenterZ  = fz * invN;
+  }
+  __syncthreads();
+
+  const double cmx               = moments->movingCenterX;
+  const double cmy               = moments->movingCenterY;
+  const double cmz               = moments->movingCenterZ;
+  const double cfx               = moments->fixedCenterX;
+  const double cfy               = moments->fixedCenterY;
+  const double cfz               = moments->fixedCenterZ;
+  double       movingSquaredNorm = 0.0, fixedSquaredNorm = 0.0;
+  double       h00 = 0.0, h01 = 0.0, h02 = 0.0;
+  double       h10 = 0.0, h11 = 0.0, h12 = 0.0;
+  double       h20 = 0.0, h21 = 0.0, h22 = 0.0;
+  for (int atom = tid; atom < numAtoms; atom += kRmsdBlockSize) {
+    const double mx = movingCoords[atom * 3 + 0] - cmx;
+    const double my = movingCoords[atom * 3 + 1] - cmy;
+    const double mz = movingCoords[atom * 3 + 2] - cmz;
+    const double fx = fixedCoords[atom * 3 + 0] - cfx;
+    const double fy = fixedCoords[atom * 3 + 1] - cfy;
+    const double fz = fixedCoords[atom * 3 + 2] - cfz;
+    if constexpr (ComputeSquaredNorms) {
+      movingSquaredNorm += mx * mx + my * my + mz * mz;
+      fixedSquaredNorm += fx * fx + fy * fy + fz * fz;
+    }
+    h00 += mx * fx;
+    h01 += mx * fy;
+    h02 += mx * fz;
+    h10 += my * fx;
+    h11 += my * fy;
+    h12 += my * fz;
+    h20 += mz * fx;
+    h21 += mz * fy;
+    h22 += mz * fz;
+  }
+  if constexpr (ComputeSquaredNorms) {
+    movingSquaredNorm = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(movingSquaredNorm);
+    fixedSquaredNorm  = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(fixedSquaredNorm);
+  }
+  h00 = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(h00);
+  h01 = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(h01);
+  h02 = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(h02);
+  h10 = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(h10);
+  h11 = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(h11);
+  h12 = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(h12);
+  h20 = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(h20);
+  h21 = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(h21);
+  h22 = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(h22);
+  if (laneId == 0) {
+    constexpr int kCovarianceOffset = ComputeSquaredNorms ? 2 : 0;
+    if constexpr (ComputeSquaredNorms) {
+      warpBuf[warpId * kNumFields + 0] = movingSquaredNorm;
+      warpBuf[warpId * kNumFields + 1] = fixedSquaredNorm;
+    }
+    warpBuf[warpId * kNumFields + kCovarianceOffset + 0] = h00;
+    warpBuf[warpId * kNumFields + kCovarianceOffset + 1] = h01;
+    warpBuf[warpId * kNumFields + kCovarianceOffset + 2] = h02;
+    warpBuf[warpId * kNumFields + kCovarianceOffset + 3] = h10;
+    warpBuf[warpId * kNumFields + kCovarianceOffset + 4] = h11;
+    warpBuf[warpId * kNumFields + kCovarianceOffset + 5] = h12;
+    warpBuf[warpId * kNumFields + kCovarianceOffset + 6] = h20;
+    warpBuf[warpId * kNumFields + kCovarianceOffset + 7] = h21;
+    warpBuf[warpId * kNumFields + kCovarianceOffset + 8] = h22;
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+    constexpr int kCovarianceOffset = ComputeSquaredNorms ? 2 : 0;
+    moments->movingSquaredNorm      = 0.0;
+    moments->fixedSquaredNorm       = 0.0;
+    moments->h00 = moments->h01 = moments->h02 = 0.0;
+    moments->h10 = moments->h11 = moments->h12 = 0.0;
+    moments->h20 = moments->h21 = moments->h22 = 0.0;
+    for (int warp = 0; warp < kRmsdWarps; ++warp) {
+      if constexpr (ComputeSquaredNorms) {
+        moments->movingSquaredNorm += warpBuf[warp * kNumFields + 0];
+        moments->fixedSquaredNorm += warpBuf[warp * kNumFields + 1];
+      }
+      moments->h00 += warpBuf[warp * kNumFields + kCovarianceOffset + 0];
+      moments->h01 += warpBuf[warp * kNumFields + kCovarianceOffset + 1];
+      moments->h02 += warpBuf[warp * kNumFields + kCovarianceOffset + 2];
+      moments->h10 += warpBuf[warp * kNumFields + kCovarianceOffset + 3];
+      moments->h11 += warpBuf[warp * kNumFields + kCovarianceOffset + 4];
+      moments->h12 += warpBuf[warp * kNumFields + kCovarianceOffset + 5];
+      moments->h20 += warpBuf[warp * kNumFields + kCovarianceOffset + 6];
+      moments->h21 += warpBuf[warp * kNumFields + kCovarianceOffset + 7];
+      moments->h22 += warpBuf[warp * kNumFields + kCovarianceOffset + 8];
+    }
+  }
+  __syncthreads();
+}
+
+__device__ __forceinline__ void jacobiRotate4x4(double* matrix, double* eigenvectors, const int p, const int q) {
+  const double apq = matrix[p * 4 + q];
+  if (apq == 0.0)
+    return;
+
+  const double app = matrix[p * 4 + p];
+  const double aqq = matrix[q * 4 + q];
+  const double tau = (aqq - app) / (2.0 * apq);
+  const double t   = copysign(1.0 / (fabs(tau) + sqrt(1.0 + tau * tau)), tau);
+  const double c   = 1.0 / sqrt(1.0 + t * t);
+  const double s   = t * c;
+
+  for (int k = 0; k < 4; ++k) {
+    if (k == p || k == q)
+      continue;
+    const double akp  = matrix[k * 4 + p];
+    const double akq  = matrix[k * 4 + q];
+    matrix[k * 4 + p] = c * akp - s * akq;
+    matrix[p * 4 + k] = matrix[k * 4 + p];
+    matrix[k * 4 + q] = s * akp + c * akq;
+    matrix[q * 4 + k] = matrix[k * 4 + q];
+  }
+  matrix[p * 4 + p] = app - t * apq;
+  matrix[q * 4 + q] = aqq + t * apq;
+  matrix[p * 4 + q] = 0.0;
+  matrix[q * 4 + p] = 0.0;
+
+  for (int k = 0; k < 4; ++k) {
+    const double vkp        = eigenvectors[k * 4 + p];
+    const double vkq        = eigenvectors[k * 4 + q];
+    eigenvectors[k * 4 + p] = c * vkp - s * vkq;
+    eigenvectors[k * 4 + q] = s * vkp + c * vkq;
+  }
+}
+
+__device__ __forceinline__ void computeOptimalRotation(const RigidAlignmentMoments& moments,
+                                                       double*                      quaternionMatrix,
+                                                       double*                      eigenvectors,
+                                                       double*                      rotation) {
+  quaternionMatrix[0]  = moments.h00 + moments.h11 + moments.h22;
+  quaternionMatrix[1]  = moments.h12 - moments.h21;
+  quaternionMatrix[2]  = moments.h20 - moments.h02;
+  quaternionMatrix[3]  = moments.h01 - moments.h10;
+  quaternionMatrix[4]  = quaternionMatrix[1];
+  quaternionMatrix[5]  = moments.h00 - moments.h11 - moments.h22;
+  quaternionMatrix[6]  = moments.h01 + moments.h10;
+  quaternionMatrix[7]  = moments.h20 + moments.h02;
+  quaternionMatrix[8]  = quaternionMatrix[2];
+  quaternionMatrix[9]  = quaternionMatrix[6];
+  quaternionMatrix[10] = -moments.h00 + moments.h11 - moments.h22;
+  quaternionMatrix[11] = moments.h12 + moments.h21;
+  quaternionMatrix[12] = quaternionMatrix[3];
+  quaternionMatrix[13] = quaternionMatrix[7];
+  quaternionMatrix[14] = quaternionMatrix[11];
+  quaternionMatrix[15] = -moments.h00 - moments.h11 + moments.h22;
+
+  for (int row = 0; row < 4; ++row)
+    for (int col = 0; col < 4; ++col)
+      eigenvectors[row * 4 + col] = row == col ? 1.0 : 0.0;
+  // A fixed 4x4 cyclic Jacobi solve converges to double precision in far
+  // fewer than 16 sweeps; the fixed bound keeps execution deterministic.
+  constexpr int kJacobiSweeps = 16;
+  for (int sweep = 0; sweep < kJacobiSweeps; ++sweep) {
+    for (int p = 0; p < 3; ++p)
+      for (int q = p + 1; q < 4; ++q)
+        jacobiRotate4x4(quaternionMatrix, eigenvectors, p, q);
+  }
+
+  int largest = 0;
+  for (int i = 1; i < 4; ++i)
+    if (quaternionMatrix[i * 4 + i] > quaternionMatrix[largest * 4 + largest])
+      largest = i;
+  double       qw      = eigenvectors[largest];
+  double       qx      = eigenvectors[4 + largest];
+  double       qy      = eigenvectors[8 + largest];
+  double       qz      = eigenvectors[12 + largest];
+  const double invNorm = 1.0 / sqrt(qw * qw + qx * qx + qy * qy + qz * qz);
+  qw *= invNorm;
+  qx *= invNorm;
+  qy *= invNorm;
+  qz *= invNorm;
+
+  rotation[0] = qw * qw + qx * qx - qy * qy - qz * qz;
+  rotation[1] = 2.0 * (qx * qy - qw * qz);
+  rotation[2] = 2.0 * (qx * qz + qw * qy);
+  rotation[3] = 2.0 * (qx * qy + qw * qz);
+  rotation[4] = qw * qw - qx * qx + qy * qy - qz * qz;
+  rotation[5] = 2.0 * (qy * qz - qw * qx);
+  rotation[6] = 2.0 * (qx * qz - qw * qy);
+  rotation[7] = 2.0 * (qy * qz + qw * qx);
+  rotation[8] = qw * qw - qx * qx - qy * qy + qz * qz;
+}
+
+__device__ __forceinline__ void alignConformerToFirst(const double* __restrict__ movingCoords,
+                                                      const double* __restrict__ firstCoords,
+                                                      double* __restrict__ alignedCoords,
+                                                      const int numAtoms) {
+  const int tid = threadIdx.x;
+
+  if (movingCoords == firstCoords) {
+    for (int i = tid; i < numAtoms * 3; i += kRmsdBlockSize)
+      alignedCoords[i] = movingCoords[i];
+    return;
+  }
+
+  __shared__ typename RmsdWarpReduce::TempStorage warpReduceTemp[kRmsdWarps];
+  __shared__ double                               warpBuf[kRmsdWarps * 9];
+  __shared__ RigidAlignmentMoments                moments;
+  __shared__ double                               quaternionMatrix[16];
+  __shared__ double                               eigenvectors[16];
+  __shared__ double                               rotation[9];
+
+  accumulateRigidAlignmentMoments<false>(movingCoords, firstCoords, numAtoms, warpReduceTemp, warpBuf, &moments);
+  if (tid == 0)
+    computeOptimalRotation(moments, quaternionMatrix, eigenvectors, rotation);
+  __syncthreads();
+
+  for (int atom = tid; atom < numAtoms; atom += kRmsdBlockSize) {
+    const double x              = movingCoords[atom * 3 + 0] - moments.movingCenterX;
+    const double y              = movingCoords[atom * 3 + 1] - moments.movingCenterY;
+    const double z              = movingCoords[atom * 3 + 2] - moments.movingCenterZ;
+    alignedCoords[atom * 3 + 0] = rotation[0] * x + rotation[1] * y + rotation[2] * z + moments.fixedCenterX;
+    alignedCoords[atom * 3 + 1] = rotation[3] * x + rotation[4] * y + rotation[5] * z + moments.fixedCenterY;
+    alignedCoords[atom * 3 + 2] = rotation[6] * x + rotation[7] * y + rotation[8] * z + moments.fixedCenterZ;
+  }
+}
+
+__device__ __forceinline__ double computeOptimalRmsd(const RigidAlignmentMoments& moments, const double invN) {
+  // G = H^T H (3x3 symmetric positive semi-definite).
+  const double g00 = moments.h00 * moments.h00 + moments.h10 * moments.h10 + moments.h20 * moments.h20;
+  const double g01 = moments.h00 * moments.h01 + moments.h10 * moments.h11 + moments.h20 * moments.h21;
+  const double g02 = moments.h00 * moments.h02 + moments.h10 * moments.h12 + moments.h20 * moments.h22;
+  const double g11 = moments.h01 * moments.h01 + moments.h11 * moments.h11 + moments.h21 * moments.h21;
+  const double g12 = moments.h01 * moments.h02 + moments.h11 * moments.h12 + moments.h21 * moments.h22;
+  const double g22 = moments.h02 * moments.h02 + moments.h12 * moments.h12 + moments.h22 * moments.h22;
+
+  double ev0, ev1, ev2;
+  symmetricEigenvalues3x3(g00, g01, g02, g11, g12, g22, ev0, ev1, ev2);
+  const double s0 = sqrt(fmax(ev0, 0.0));
+  const double s1 = sqrt(fmax(ev1, 0.0));
+  double       s2 = sqrt(fmax(ev2, 0.0));
+  if (det3x3(moments.h00,
+             moments.h01,
+             moments.h02,
+             moments.h10,
+             moments.h11,
+             moments.h12,
+             moments.h20,
+             moments.h21,
+             moments.h22) < 0.0)
+    s2 = -s2;
+
+  const double rmsdSq = fmax((moments.movingSquaredNorm + moments.fixedSquaredNorm - 2.0 * (s0 + s1 + s2)) * invN, 0.0);
+  return sqrt(rmsdSq);
+}
 
 __device__ __forceinline__ void computePairRmsd(const double* __restrict__ coordI,
                                                 const double* __restrict__ coordJ,
@@ -112,16 +438,9 @@ __device__ __forceinline__ void computePairRmsd(const double* __restrict__ coord
   const int warpId = tid / 32;
   const int laneId = tid % 32;
 
-  // Shared buffers for warp→block reduction.
-  //   warpReduceTemp[w]: CUB WarpReduce scratch for warp w (empty for full 32-thread warps).
-  //   warpBuf[w][f]:     field f's warp-partial sum for warp w.
-  //   sCent[6]:          broadcast centroid buffer written by thread 0 after sync 1.
-  // prealigned path uses only warpBuf[w][0].
-  // Alignment path phase-1 uses fields 0-5 (centroid sums);
-  //              phase-2 uses fields 0-10 (Sp, Sq, H[0..8]).
   __shared__ typename RmsdWarpReduce::TempStorage warpReduceTemp[kRmsdWarps];
-  __shared__ double                               warpBuf[kRmsdWarps][11];
-  __shared__ double                               sCent[6];
+  __shared__ double                               warpBuf[kRmsdWarps * 11];
+  __shared__ RigidAlignmentMoments                moments;
 
   if (prealigned) {
     // ---- Simple RMSD without alignment (no centering, matches RDKit behavior) ----
@@ -134,149 +453,76 @@ __device__ __forceinline__ void computePairRmsd(const double* __restrict__ coord
     }
     sumSqDiff = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumSqDiff);
     if (laneId == 0)
-      warpBuf[warpId][0] = sumSqDiff;
+      warpBuf[warpId * 11] = sumSqDiff;
     __syncthreads();
     if (tid == 0) {
       double total = 0.0;
       for (int w = 0; w < kRmsdWarps; ++w)
-        total += warpBuf[w][0];
+        total += warpBuf[w * 11];
       *outRmsd = sqrt(total / static_cast<double>(numAtoms));
     }
     return;
   }
 
-  // ---- Kabsch alignment path ----
-  // Phase 1: accumulate centroid sums, warp-reduce into warpBuf (sync 1),
-  //          thread 0 computes and broadcasts centroids via sCent (sync 2).
-  double sumIx = 0.0, sumIy = 0.0, sumIz = 0.0;
-  double sumJx = 0.0, sumJy = 0.0, sumJz = 0.0;
-  for (int a = tid; a < numAtoms; a += kRmsdBlockSize) {
-    sumIx += coordI[a * 3 + 0];
-    sumIy += coordI[a * 3 + 1];
-    sumIz += coordI[a * 3 + 2];
-    sumJx += coordJ[a * 3 + 0];
-    sumJy += coordJ[a * 3 + 1];
-    sumJz += coordJ[a * 3 + 2];
-  }
-  sumIx = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumIx);
-  sumIy = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumIy);
-  sumIz = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumIz);
-  sumJx = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumJx);
-  sumJy = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumJy);
-  sumJz = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(sumJz);
-
-  if (laneId == 0) {
-    warpBuf[warpId][0] = sumIx;
-    warpBuf[warpId][1] = sumIy;
-    warpBuf[warpId][2] = sumIz;
-    warpBuf[warpId][3] = sumJx;
-    warpBuf[warpId][4] = sumJy;
-    warpBuf[warpId][5] = sumJz;
-  }
-  __syncthreads();  // sync 1: warpBuf[*][0..5] visible; thread 0 reduces below.
-
   const double invN = 1.0 / static_cast<double>(numAtoms);
-  if (tid == 0) {
-    double sIx = 0.0, sIy = 0.0, sIz = 0.0, sJx = 0.0, sJy = 0.0, sJz = 0.0;
-    for (int w = 0; w < kRmsdWarps; ++w) {
-      sIx += warpBuf[w][0];
-      sIy += warpBuf[w][1];
-      sIz += warpBuf[w][2];
-      sJx += warpBuf[w][3];
-      sJy += warpBuf[w][4];
-      sJz += warpBuf[w][5];
-    }
-    sCent[0] = sIx * invN;
-    sCent[1] = sIy * invN;
-    sCent[2] = sIz * invN;
-    sCent[3] = sJx * invN;
-    sCent[4] = sJy * invN;
-    sCent[5] = sJz * invN;
-  }
-  __syncthreads();  // sync 2: sCent visible to all threads.
-
-  const double cIx = sCent[0], cIy = sCent[1], cIz = sCent[2];
-  const double cJx = sCent[3], cJy = sCent[4], cJz = sCent[5];
-
-  // Phase 2: accumulate Sp, Sq, and H = P^T Q (11 values), warp-reduce into
-  //          warpBuf (sync 3), thread 0 sums and computes RMSD.
-  // Sp = sum ||pi - centI||^2,  Sq = sum ||qj - centJ||^2
-  double localSp = 0.0, localSq = 0.0;
-  double localH[9] = {0.0};
-
-  for (int a = tid; a < numAtoms; a += kRmsdBlockSize) {
-    const double px = coordI[a * 3 + 0] - cIx;
-    const double py = coordI[a * 3 + 1] - cIy;
-    const double pz = coordI[a * 3 + 2] - cIz;
-    const double qx = coordJ[a * 3 + 0] - cJx;
-    const double qy = coordJ[a * 3 + 1] - cJy;
-    const double qz = coordJ[a * 3 + 2] - cJz;
-
-    localSp += px * px + py * py + pz * pz;
-    localSq += qx * qx + qy * qy + qz * qz;
-
-    localH[0] += px * qx;
-    localH[1] += px * qy;
-    localH[2] += px * qz;
-    localH[3] += py * qx;
-    localH[4] += py * qy;
-    localH[5] += py * qz;
-    localH[6] += pz * qx;
-    localH[7] += pz * qy;
-    localH[8] += pz * qz;
-  }
-
-  localSp = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(localSp);
-  localSq = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(localSq);
-  for (int i = 0; i < 9; ++i)
-    localH[i] = RmsdWarpReduce(warpReduceTemp[warpId]).Sum(localH[i]);
-
-  if (laneId == 0) {
-    warpBuf[warpId][0] = localSp;
-    warpBuf[warpId][1] = localSq;
-    for (int i = 0; i < 9; ++i)
-      warpBuf[warpId][2 + i] = localH[i];
-  }
-  __syncthreads();  // sync 3: warpBuf[*][0..10] visible; thread 0 computes RMSD.
-
-  if (tid == 0) {
-    double Sp = 0.0, Sq = 0.0, H[9] = {0.0};
-    for (int w = 0; w < kRmsdWarps; ++w) {
-      Sp += warpBuf[w][0];
-      Sq += warpBuf[w][1];
-      for (int i = 0; i < 9; ++i)
-        H[i] += warpBuf[w][2 + i];
-    }
-
-    // G = H^T H  (3x3 symmetric positive semi-definite)
-    const double g00 = H[0] * H[0] + H[3] * H[3] + H[6] * H[6];
-    const double g01 = H[0] * H[1] + H[3] * H[4] + H[6] * H[7];
-    const double g02 = H[0] * H[2] + H[3] * H[5] + H[6] * H[8];
-    const double g11 = H[1] * H[1] + H[4] * H[4] + H[7] * H[7];
-    const double g12 = H[1] * H[2] + H[4] * H[5] + H[7] * H[8];
-    const double g22 = H[2] * H[2] + H[5] * H[5] + H[8] * H[8];
-
-    // Eigenvalues of G = squared singular values of H
-    double ev0, ev1, ev2;
-    symmetricEigenvalues3x3(g00, g01, g02, g11, g12, g22, ev0, ev1, ev2);
-
-    // Singular values (clamp negatives from numerical noise)
-    const double s0 = sqrt(fmax(ev0, 0.0));
-    const double s1 = sqrt(fmax(ev1, 0.0));
-    double       s2 = sqrt(fmax(ev2, 0.0));
-
-    // Handle reflection: if det(H) < 0, negate the smallest singular value
-    if (det3x3(H) < 0.0)
-      s2 = -s2;
-
-    // RMSD^2 = (Sp + Sq - 2*(s0 + s1 + s2)) / N
-    const double rmsdSq = fmax((Sp + Sq - 2.0 * (s0 + s1 + s2)) * invN, 0.0);
-    *outRmsd            = sqrt(rmsdSq);
-  }
+  accumulateRigidAlignmentMoments<true>(coordI, coordJ, numAtoms, warpReduceTemp, warpBuf, &moments);
+  if (tid == 0)
+    *outRmsd = computeOptimalRmsd(moments, invN);
 }
 
 // ---------------------------------------------------------------------------
-// Kernel: one thread-block per conformer pair
+// Alignment kernels: one thread-block per conformer
+// ---------------------------------------------------------------------------
+
+__global__ void alignConformersToFirstKernel(const double* __restrict__ coords,
+                                             double* __restrict__ alignedCoords,
+                                             const int numConformers,
+                                             const int numAtoms) {
+  const int conformer = blockIdx.x;
+  if (conformer >= numConformers)
+    return;
+
+  const int     stride       = numAtoms * 3;
+  const double* movingCoords = coords + conformer * stride;
+  double*       outputCoords = alignedCoords + conformer * stride;
+  alignConformerToFirst(movingCoords, coords, outputCoords, numAtoms);
+}
+
+__global__ void alignConformersToFirstBatchKernel(const double* __restrict__ coords,
+                                                  double* __restrict__ alignedCoords,
+                                                  const int* __restrict__ conformerOffsets,
+                                                  const size_t* __restrict__ coordOffsets,
+                                                  const int* __restrict__ numConfsPerMol,
+                                                  const int* __restrict__ numAtomsPerMol,
+                                                  const int numMols) {
+  if (numMols <= 0)
+    return;
+
+  const int globalConformer = blockIdx.x;
+  int       lo = 0, hi = numMols - 1;
+  while (lo < hi) {
+    const int mid = (lo + hi + 1) / 2;
+    if (globalConformer >= conformerOffsets[mid])
+      lo = mid;
+    else
+      hi = mid - 1;
+  }
+  const int mol            = lo;
+  const int localConformer = globalConformer - conformerOffsets[mol];
+  if (localConformer < 0 || localConformer >= numConfsPerMol[mol])
+    return;
+
+  const int     numAtoms     = numAtomsPerMol[mol];
+  const int     stride       = numAtoms * 3;
+  const size_t  coordOffset  = coordOffsets[mol];
+  const double* firstCoords  = coords + static_cast<ptrdiff_t>(coordOffset);
+  const double* movingCoords = firstCoords + localConformer * stride;
+  double*       outputCoords = alignedCoords + static_cast<ptrdiff_t>(coordOffset) + localConformer * stride;
+  alignConformerToFirst(movingCoords, firstCoords, outputCoords, numAtoms);
+}
+
+// ---------------------------------------------------------------------------
+// RMSD kernel: one thread-block per conformer pair
 // ---------------------------------------------------------------------------
 
 __global__ void conformerRmsdKernel(const double* __restrict__ coords,
@@ -360,6 +606,41 @@ __global__ void conformerRmsdBatchKernel(const double* __restrict__ coords,
 // ---------------------------------------------------------------------------
 // Host entry points
 // ---------------------------------------------------------------------------
+
+void alignConformersToFirstGpu(cuda::std::span<const double> coords,
+                               cuda::std::span<double>       alignedCoords,
+                               const int                     numConformers,
+                               const int                     numAtoms,
+                               cudaStream_t                  stream) {
+  if (numConformers <= 0)
+    return;
+  alignConformersToFirstKernel<<<numConformers, kRmsdBlockSize, 0, stream>>>(coords.data(),
+                                                                             alignedCoords.data(),
+                                                                             numConformers,
+                                                                             numAtoms);
+  cudaCheckError(cudaGetLastError());
+}
+
+void alignConformersToFirstBatchGpu(cuda::std::span<const double> coords,
+                                    cuda::std::span<double>       alignedCoords,
+                                    cuda::std::span<const int>    conformerOffsets,
+                                    cuda::std::span<const size_t> coordOffsets,
+                                    cuda::std::span<const int>    numConfsPerMol,
+                                    cuda::std::span<const int>    numAtomsPerMol,
+                                    const int                     numMols,
+                                    const int                     totalConformers,
+                                    cudaStream_t                  stream) {
+  if (totalConformers <= 0)
+    return;
+  alignConformersToFirstBatchKernel<<<totalConformers, kRmsdBlockSize, 0, stream>>>(coords.data(),
+                                                                                    alignedCoords.data(),
+                                                                                    conformerOffsets.data(),
+                                                                                    coordOffsets.data(),
+                                                                                    numConfsPerMol.data(),
+                                                                                    numAtomsPerMol.data(),
+                                                                                    numMols);
+  cudaCheckError(cudaGetLastError());
+}
 
 void conformerRmsdMatrixGpu(cuda::std::span<const double> coords,
                             cuda::std::span<double>       rmsdOut,

--- a/src/conformer_rmsd.h
+++ b/src/conformer_rmsd.h
@@ -21,6 +21,48 @@
 namespace nvMolKit {
 
 /**
+ * @brief Align every conformer to conformer 0 on the GPU.
+ *
+ * Computes one optimal rigid-body transform per conformer and writes the
+ * transformed coordinates to a separate device buffer.  Conformer 0 is copied
+ * unchanged.
+ *
+ * @param coords Input coordinates in conformer-major layout.
+ * @param alignedCoords Output buffer with the same shape as coords.
+ * @param numConformers Number of conformers.
+ * @param numAtoms Number of atoms per conformer.
+ * @param stream CUDA stream to execute operations on.
+ */
+void alignConformersToFirstGpu(cuda::std::span<const double> coords,
+                               cuda::std::span<double>       alignedCoords,
+                               int                           numConformers,
+                               int                           numAtoms,
+                               cudaStream_t                  stream = nullptr);
+
+/**
+ * @brief Align every conformer in a molecule batch to its conformer 0.
+ *
+ * @param coords Input coordinates for all molecules.
+ * @param alignedCoords Output buffer with the same shape as coords.
+ * @param conformerOffsets Prefix-sum of conformer counts, size numMols+1.
+ * @param coordOffsets Start of each molecule's coordinates, in doubles.
+ * @param numConfsPerMol Number of conformers per molecule.
+ * @param numAtomsPerMol Number of atoms per molecule.
+ * @param numMols Number of molecules.
+ * @param totalConformers Total number of conformers across the batch.
+ * @param stream CUDA stream to execute operations on.
+ */
+void alignConformersToFirstBatchGpu(cuda::std::span<const double> coords,
+                                    cuda::std::span<double>       alignedCoords,
+                                    cuda::std::span<const int>    conformerOffsets,
+                                    cuda::std::span<const size_t> coordOffsets,
+                                    cuda::std::span<const int>    numConfsPerMol,
+                                    cuda::std::span<const int>    numAtomsPerMol,
+                                    int                           numMols,
+                                    int                           totalConformers,
+                                    cudaStream_t                  stream);
+
+/**
  * @brief Compute pairwise RMSD between all conformers, returning a condensed lower-triangle matrix.
  *
  * For N conformers with M atoms each, computes N*(N-1)/2 pairwise RMSD values.

--- a/src/conformer_rmsd_mol.cpp
+++ b/src/conformer_rmsd_mol.cpp
@@ -26,7 +26,10 @@
 
 namespace nvMolKit {
 
-AsyncDeviceVector<double> conformerRmsdMatrixMol(const RDKit::ROMol& mol, const bool prealigned, cudaStream_t stream) {
+AsyncDeviceVector<double> conformerRmsdMatrixMol(const RDKit::ROMol& mol,
+                                                 const bool          prealigned,
+                                                 cudaStream_t        stream,
+                                                 const bool          alignToFirstConformer) {
   const int numConfs = mol.getNumConformers();
   if (numConfs <= 1) {
     return AsyncDeviceVector<double>(0);
@@ -69,16 +72,24 @@ AsyncDeviceVector<double> conformerRmsdMatrixMol(const RDKit::ROMol& mol, const 
   }
 
   hostCoords.copyToDevice(devCoords, stream);
-  conformerRmsdMatrixGpu(toSpan(devCoords), toSpan(devRmsd), numConfs, numAtoms, prealigned, stream);
+  if (!prealigned && alignToFirstConformer) {
+    AsyncDeviceVector<double> devAlignedCoords(numCoords, stream);
+    alignConformersToFirstGpu(toSpan(devCoords), toSpan(devAlignedCoords), numConfs, numAtoms, stream);
+    conformerRmsdMatrixGpu(toSpan(devAlignedCoords), toSpan(devRmsd), numConfs, numAtoms, true, stream);
+  } else {
+    conformerRmsdMatrixGpu(toSpan(devCoords), toSpan(devRmsd), numConfs, numAtoms, prealigned, stream);
+  }
   return devRmsd;
 }
 
 std::vector<AsyncDeviceVector<double>> conformerRmsdBatchMatrixMol(const std::vector<const RDKit::ROMol*>& mols,
                                                                    const bool                              prealigned,
-                                                                   cudaStream_t                            stream) {
+                                                                   cudaStream_t                            stream,
+                                                                   const bool alignToFirstConformer) {
   const int numMols = static_cast<int>(mols.size());
   if (numMols == 0)
     return {};
+  const bool needsFirstConformerAlignment = !prealigned && alignToFirstConformer;
 
   // --- Validate inputs and compute per-molecule metadata ---
   // pairOffsets and totalPairs are intentionally 32-bit: the kernel launches one
@@ -88,9 +99,12 @@ std::vector<AsyncDeviceVector<double>> conformerRmsdBatchMatrixMol(const std::ve
   // to the wrong molecule or write out of bounds.
   std::vector<int>    numConfsVec(numMols), numAtomsVec(numMols);
   std::vector<int>    pairOffsetsVec(numMols + 1);
+  std::vector<int>    conformerOffsetsVec(needsFirstConformerAlignment ? numMols + 1 : 0);
   std::vector<size_t> coordOffsetsVec(numMols);
 
-  pairOffsetsVec[0]  = 0;
+  pairOffsetsVec[0] = 0;
+  if (needsFirstConformerAlignment)
+    conformerOffsetsVec[0] = 0;
   size_t totalCoords = 0;
   for (int m = 0; m < numMols; ++m) {
     if (!mols[m]) {
@@ -112,15 +126,27 @@ std::vector<AsyncDeviceVector<double>> conformerRmsdBatchMatrixMol(const std::ve
       throw std::overflow_error("Cumulative conformer pairs exceed int range by molecule index " + std::to_string(m));
     }
     pairOffsetsVec[m + 1] = static_cast<int>(newOffset);
+    if (needsFirstConformerAlignment) {
+      const int64_t newConformerOffset = static_cast<int64_t>(conformerOffsetsVec[m]) + nc;
+      if (newConformerOffset > static_cast<int64_t>(std::numeric_limits<int>::max())) {
+        throw std::overflow_error("Cumulative conformer count exceeds int range by molecule index " +
+                                  std::to_string(m));
+      }
+      conformerOffsetsVec[m + 1] = static_cast<int>(newConformerOffset);
+    }
   }
-  const int totalPairs = pairOffsetsVec[numMols];
+  const int totalPairs      = pairOffsetsVec[numMols];
+  const int totalConformers = needsFirstConformerAlignment ? conformerOffsetsVec[numMols] : 0;
 
   // --- Allocate device buffers first so GPU allocation overlaps CPU work below ---
   AsyncDeviceVector<double> devCoords(totalCoords > 0 ? totalCoords : 1, stream);
   AsyncDeviceVector<int>    devNumConfs(numMols, stream);
   AsyncDeviceVector<int>    devNumAtoms(numMols, stream);
   AsyncDeviceVector<int>    devPairOffsets(numMols + 1, stream);
+  AsyncDeviceVector<int>    devConformerOffsets;
   AsyncDeviceVector<size_t> devCoordOffsets(numMols, stream);
+  if (needsFirstConformerAlignment)
+    devConformerOffsets = AsyncDeviceVector<int>(numMols + 1, stream);
 
   // Per-molecule output buffers.  Always allocate at least 1 element so that
   // devRmsdPtrs never contains a null — zero-pair molecules dispatch 0 blocks
@@ -138,13 +164,16 @@ std::vector<AsyncDeviceVector<double>> conformerRmsdBatchMatrixMol(const std::ve
   PinnedHostVector<int>     numConfsArr(numMols);
   PinnedHostVector<int>     numAtomsArr(numMols);
   PinnedHostVector<int>     pairOffsetsArr(numMols + 1);
+  PinnedHostVector<int>     conformerOffsetsArr(needsFirstConformerAlignment ? numMols + 1 : 0);
   PinnedHostVector<size_t>  coordOffsetsArr(numMols);
   PinnedHostVector<double*> hostRmsdPtrs(numMols);
 
   for (int m = 0; m < numMols; ++m) {
-    numConfsArr[m]     = numConfsVec[m];
-    numAtomsArr[m]     = numAtomsVec[m];
-    pairOffsetsArr[m]  = pairOffsetsVec[m];
+    numConfsArr[m]    = numConfsVec[m];
+    numAtomsArr[m]    = numAtomsVec[m];
+    pairOffsetsArr[m] = pairOffsetsVec[m];
+    if (needsFirstConformerAlignment)
+      conformerOffsetsArr[m] = conformerOffsetsVec[m];
     coordOffsetsArr[m] = coordOffsetsVec[m];
     hostRmsdPtrs[m]    = devRmsdVecs[m].data();
 
@@ -162,6 +191,8 @@ std::vector<AsyncDeviceVector<double>> conformerRmsdBatchMatrixMol(const std::ve
     }
   }
   pairOffsetsArr[numMols] = pairOffsetsVec[numMols];
+  if (needsFirstConformerAlignment)
+    conformerOffsetsArr[numMols] = conformerOffsetsVec[numMols];
 
   // --- Transfer to device and launch ---
   if (totalCoords > 0)
@@ -169,11 +200,28 @@ std::vector<AsyncDeviceVector<double>> conformerRmsdBatchMatrixMol(const std::ve
   numConfsArr.copyToDevice(devNumConfs, stream);
   numAtomsArr.copyToDevice(devNumAtoms, stream);
   pairOffsetsArr.copyToDevice(devPairOffsets, stream);
+  if (needsFirstConformerAlignment)
+    conformerOffsetsArr.copyToDevice(devConformerOffsets, stream);
   coordOffsetsArr.copyToDevice(devCoordOffsets, stream);
   hostRmsdPtrs.copyToDevice(devRmsdPtrs, stream);
 
   if (totalPairs > 0) {
-    conformerRmsdBatchMatrixGpu(toSpan(devCoords),
+    AsyncDeviceVector<double>     devAlignedCoords;
+    cuda::std::span<const double> rmsdCoords = toSpan(devCoords);
+    if (needsFirstConformerAlignment) {
+      devAlignedCoords = AsyncDeviceVector<double>(totalCoords, stream);
+      alignConformersToFirstBatchGpu(toSpan(devCoords),
+                                     toSpan(devAlignedCoords),
+                                     toSpan(devConformerOffsets),
+                                     toSpan(devCoordOffsets),
+                                     toSpan(devNumConfs),
+                                     toSpan(devNumAtoms),
+                                     numMols,
+                                     totalConformers,
+                                     stream);
+      rmsdCoords = toSpan(devAlignedCoords);
+    }
+    conformerRmsdBatchMatrixGpu(rmsdCoords,
                                 toSpan(devRmsdPtrs),
                                 toSpan(devPairOffsets),
                                 toSpan(devCoordOffsets),
@@ -181,7 +229,7 @@ std::vector<AsyncDeviceVector<double>> conformerRmsdBatchMatrixMol(const std::ve
                                 toSpan(devNumAtoms),
                                 numMols,
                                 totalPairs,
-                                prealigned,
+                                prealigned || alignToFirstConformer,
                                 stream);
   }
 

--- a/src/conformer_rmsd_mol.h
+++ b/src/conformer_rmsd_mol.h
@@ -35,14 +35,17 @@ namespace nvMolKit {
  * @param mol       RDKit molecule with two or more conformers.
  * @param prealigned If true, skip Kabsch alignment.
  * @param stream    CUDA stream.
+ * @param alignToFirstConformer If true and prealigned is false, align every
+ *                              conformer to conformer 0 before computing RMSDs.
  * @return Device buffer of N*(N-1)/2 doubles in lower-triangle condensed order.
  *         Returns an empty (size 0) buffer if mol has fewer than 2 conformers.
  * @throws std::invalid_argument if the molecule has conformers but no atoms.
  * @throws std::overflow_error   if the number of pairs exceeds INT_MAX.
  */
 AsyncDeviceVector<double> conformerRmsdMatrixMol(const RDKit::ROMol& mol,
-                                                 bool                prealigned = false,
-                                                 cudaStream_t        stream     = nullptr);
+                                                 bool                prealigned            = false,
+                                                 cudaStream_t        stream                = nullptr,
+                                                 bool                alignToFirstConformer = false);
 
 /**
  * @brief Compute pairwise RMSD matrices for a batch of molecules on GPU.
@@ -54,6 +57,8 @@ AsyncDeviceVector<double> conformerRmsdMatrixMol(const RDKit::ROMol& mol,
  * @param mols      Non-null RDKit molecule pointers.
  * @param prealigned If true, skip Kabsch alignment.
  * @param stream    CUDA stream.
+ * @param alignToFirstConformer If true and prealigned is false, align each
+ *                              molecule's conformers to its conformer 0.
  * @return Per-molecule device buffers in the same order as mols.
  *         Buffer m holds N_m*(N_m-1)/2 doubles; size 0 if mol m has < 2 conformers.
  * @throws std::invalid_argument if any pointer is null or any molecule has conformers
@@ -61,8 +66,9 @@ AsyncDeviceVector<double> conformerRmsdMatrixMol(const RDKit::ROMol& mol,
  * @throws std::overflow_error   if cumulative pair count exceeds INT_MAX.
  */
 std::vector<AsyncDeviceVector<double>> conformerRmsdBatchMatrixMol(const std::vector<const RDKit::ROMol*>& mols,
-                                                                   bool         prealigned = false,
-                                                                   cudaStream_t stream     = nullptr);
+                                                                   bool         prealigned            = false,
+                                                                   cudaStream_t stream                = nullptr,
+                                                                   bool         alignToFirstConformer = false);
 
 }  // namespace nvMolKit
 


### PR DESCRIPTION
Distinguishes between two different common RDKit RMSD paths - the conformer RMSD matrix we were allegedly replacing in the first place aligns on a single conformer, whereas a true pairwise RMSD aligns individually.

Since the previous RMSD implementation worked by computing RMSD without **actually** aligning mols, we needed significant code to match. We could have done this via the original kabsch mechanism, but would give up an O(n) for O(n^2) path for the align on 0 mechanism.