### PR TITLE
Avoid flaky authenticated Git fetch for nanobench

### DIFF
--- a/.github/workflows/cpp-build-test.yml
+++ b/.github/workflows/cpp-build-test.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Check out source tree
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         shell: bash

--- a/cmake/nanobench.cmake
+++ b/cmake/nanobench.cmake
@@ -16,8 +16,8 @@
 include(FetchContent)
 FetchContent_Declare(
   nanobench
-  GIT_REPOSITORY https://github.com/martinus/nanobench.git
-  GIT_TAG v4.1.0
-  GIT_SHALLOW TRUE)
+  URL https://github.com/martinus/nanobench/archive/refs/tags/v4.1.0.tar.gz
+  URL_HASH
+    SHA256=5a2836797cfdfa729eefc60505f9e1603da44bd6965425fc89decae3b6dddfeb)
 
 FetchContent_MakeAvailable(nanobench)


### PR DESCRIPTION

- fetch nanobench v4.1.0 from a checksummed source archive instead of a nested Git clone
- disable persisted checkout credentials in the C++ build workflow, which does not perform later authenticated Git operations


The C++ configure job intermittently receives an authentication challenge while cloning the public nanobench repository. The checkout action persists a GitHub-wide authorization header in the checkout Git config, and CMake runs the dependency clone beneath that checkout. Using an archive removes the Git smart-HTTP and credential-inheritance path entirely; disabling credential persistence prevents similar unintended authentication in later commands.
