### PR TITLE
Unify Butina outputs for device and RDKit compatibility mode. 

### DIFF
--- a/benchmarks/butina_clustering_bench.py
+++ b/benchmarks/butina_clustering_bench.py
@@ -25,7 +25,7 @@ from rdkit.Chem import AllChem
 from rdkit.DataStructs import BulkTanimotoSimilarity
 from rdkit.ML.Cluster.Butina import ClusterData
 
-from nvmolkit.clustering import ButinaOutput, fused_butina
+from nvmolkit.clustering import ButinaOutputMode, fused_butina
 from nvmolkit.clustering import butina as butina_nvmol
 from nvmolkit.fingerprints import MorganFingerprintGenerator as nvmolMorganGen
 from nvmolkit.similarity import crossTanimotoSimilarity
@@ -277,7 +277,7 @@ if __name__ == "__main__":
                             fps_mat,
                             cutoff=cutoff,
                             metric="tanimoto",
-                            output=ButinaOutput.DEVICE,
+                            output=ButinaOutputMode.DEVICE,
                         ),
                         gpu_sync=True,
                         runs=n_runs,

--- a/benchmarks/butina_clustering_bench.py
+++ b/benchmarks/butina_clustering_bench.py
@@ -25,8 +25,8 @@ from rdkit.Chem import AllChem
 from rdkit.DataStructs import BulkTanimotoSimilarity
 from rdkit.ML.Cluster.Butina import ClusterData
 
+from nvmolkit.clustering import ButinaOutput, fused_butina
 from nvmolkit.clustering import butina as butina_nvmol
-from nvmolkit.clustering import fused_butina
 from nvmolkit.fingerprints import MorganFingerprintGenerator as nvmolMorganGen
 from nvmolkit.similarity import crossTanimotoSimilarity
 
@@ -273,7 +273,12 @@ if __name__ == "__main__":
                 if "fused" in runs:
                     print(f"Running fused_butina size {size} cutoff {cutoff}")
                     fused_result = time_it(
-                        lambda: fused_butina(fps_mat, cutoff=cutoff, metric="tanimoto"),
+                        lambda: fused_butina(
+                            fps_mat,
+                            cutoff=cutoff,
+                            metric="tanimoto",
+                            output=ButinaOutput.DEVICE,
+                        ),
                         gpu_sync=True,
                         runs=n_runs,
                     )

--- a/docs/api/nvmolkit.rst
+++ b/docs/api/nvmolkit.rst
@@ -86,7 +86,7 @@ Butina Clustering
    :toctree: generated/
    :template: class_template.rst
 
-   clustering.ButinaOutput
+   clustering.ButinaOutputMode
    clustering.ButinaDeviceResult
 
 Maximum Common Substructure (MCS)

--- a/docs/api/nvmolkit.rst
+++ b/docs/api/nvmolkit.rst
@@ -82,6 +82,13 @@ Butina Clustering
    clustering.butina
    clustering.fused_butina
 
+.. autosummary::
+   :toctree: generated/
+   :template: class_template.rst
+
+   clustering.ButinaOutput
+   clustering.ButinaDeviceResult
+
 Maximum Common Substructure (MCS)
 ---------------------------------
 

--- a/nvmolkit/clustering.py
+++ b/nvmolkit/clustering.py
@@ -45,12 +45,10 @@ _RDKitClusters = tuple[tuple[int, ...], ...]
 
 
 class ButinaOutput(Enum):
-    """Selects how Butina clustering results are returned.
+    """Output format for :func:`butina` and :func:`fused_butina`.
 
-    - ``RDKIT`` returns the same tuple-of-tuples representation as RDKit's
-      ``Butina.ClusterData``. The centroid is the first item in each cluster.
-    - ``DEVICE`` keeps the result on the GPU and returns a
-      :class:`ButinaDeviceResult`.
+    ``RDKIT`` returns the same tuple of clusters as RDKit's
+    ``Butina.ClusterData``. ``DEVICE`` returns a :class:`ButinaDeviceResult`.
     """
 
     RDKIT = "rdkit"
@@ -59,14 +57,12 @@ class ButinaOutput(Enum):
 
 @dataclass(frozen=True)
 class ButinaDeviceResult:
-    """GPU-resident result shared by ``butina`` and ``fused_butina``.
+    """GPU-resident Butina clustering result.
 
-    ``cluster_ids`` is int32 with shape ``(N,)`` and has one cluster ID per
-    input item. ``centroids`` is int32 with shape ``(num_clusters,)``.
-    ``cluster_sizes`` is int64 with shape ``(num_clusters,)``. Both latter
-    fields are indexed by cluster ID, and ``cluster_sizes`` contains per-cluster
-    counts, not the cumulative offsets returned by nvMolKit 0.5's legacy
-    ``fused_butina`` API.
+    Attributes:
+        cluster_ids: One int32 cluster ID per input item, shape ``(N,)``.
+        centroids: Centroid indices by cluster ID, int32 and shape ``(num_clusters,)``.
+        cluster_sizes: Member counts by cluster ID, int64 and shape ``(num_clusters,)``.
     """
 
     cluster_ids: AsyncGpuResult
@@ -196,24 +192,20 @@ def butina(
                               optimization. Must be 8, 16, 24, 32, 64, or 128. Larger values
                               allow parallel processing of larger clusters but use more
                               shared memory. Ignored when reordering is False.
-        return_centroids: Whether the historical omitted-output path also returns
-                          centroid indices. Cannot be combined with ``output``.
+        return_centroids: When ``output`` is None, return centroids alongside
+                          the cluster IDs. Cannot be combined with ``output``.
         reordering: Whether to update neighbor counts among unassigned items
                     after each cluster is formed. Defaults to True, while
                     RDKit's ``Butina.ClusterData`` defaults to False.
         stream: CUDA stream to use. If None, uses the current stream.
-        output: Explicit result representation. ``ButinaOutput.RDKIT`` returns
-                RDKit-style host clusters; ``ButinaOutput.DEVICE`` returns a
-                :class:`ButinaDeviceResult`. If omitted, preserves the original
-                non-fused nvMolKit return behavior controlled by
-                ``return_centroids``.
+        output: Output format. None selects the compatibility return described below.
 
     Returns:
-        With ``output=ButinaOutput.RDKIT``, the RDKit tuple-of-tuples cluster
-        representation. With ``output=ButinaOutput.DEVICE``, a
-        :class:`ButinaDeviceResult`. If ``output`` is omitted, an
-        ``AsyncGpuResult`` of cluster IDs, or ``(cluster_ids, centroids)`` when
-        ``return_centroids=True``, preserving the historical non-fused API.
+        ``ButinaOutput.RDKIT`` returns RDKit clusters as
+        ``tuple[tuple[int, ...], ...]``, with the centroid first in each cluster.
+        ``ButinaOutput.DEVICE`` returns :class:`ButinaDeviceResult`. When
+        ``output`` is None, returns cluster IDs as :class:`AsyncGpuResult`, or
+        ``(cluster_ids, centroids)`` when ``return_centroids=True``.
 
     Note:
         The distance matrix should be symmetric and have zeros on the diagonal.
@@ -303,22 +295,20 @@ def fused_butina(
            CPU tensors and NumPy arrays are copied to CUDA.
         cutoff: Distance threshold for clustering. Items are neighbors if their
                 distance is at most this cutoff (i.e. similarity >= 1 - cutoff).
-        return_centroids: Whether the historical omitted-output path includes
-                          the centroid list. Cannot be combined with ``output``.
+        return_centroids: When ``output`` is None, include centroids in the
+                          return tuple. Cannot be combined with ``output``.
         metric: Metric to use for similarity computation. Currently only "tanimoto"
                 and "cosine" are supported.
         stream: CUDA stream to use. If None, uses the current stream.
-        output: Explicit result representation. ``ButinaOutput.RDKIT`` returns
-                RDKit-style host clusters; ``ButinaOutput.DEVICE`` returns a
-                :class:`ButinaDeviceResult`. If omitted, reproduces the nvMolKit
-                0.5 fused return contract controlled by ``return_centroids``.
+        output: Output format. None selects the compatibility return described below.
 
     Returns:
-        With ``output=ButinaOutput.RDKIT``, the RDKit tuple-of-tuples cluster
-        representation. With ``output=ButinaOutput.DEVICE``, a
-        :class:`ButinaDeviceResult`. If ``output`` is omitted, returns the
-        nvMolKit 0.5 ``(clusters, cumulative_offsets)`` tuple, plus a centroid
-        list when ``return_centroids=True``.
+        ``ButinaOutput.RDKIT`` returns RDKit clusters as
+        ``tuple[tuple[int, ...], ...]``, with the centroid first in each cluster.
+        ``ButinaOutput.DEVICE`` returns :class:`ButinaDeviceResult`. When
+        ``output`` is None, returns ``(clusters, cumulative_offsets)``, or
+        ``(clusters, cumulative_offsets, centroids)`` when
+        ``return_centroids=True``.
     """
     _validate_output(output, return_centroids)
     if metric not in ("tanimoto", "cosine"):

--- a/nvmolkit/clustering.py
+++ b/nvmolkit/clustering.py
@@ -44,7 +44,7 @@ _VALID_NEIGHBORLIST_SIZES = (8, 16, 24, 32, 64, 128)
 _RDKitClusters = tuple[tuple[int, ...], ...]
 
 
-class ButinaOutput(Enum):
+class ButinaOutputMode(Enum):
     """Output format for :func:`butina` and :func:`fused_butina`.
 
     ``RDKIT`` returns the same tuple of clusters as RDKit's
@@ -102,15 +102,15 @@ def _to_rdkit_clusters(cluster_ids: AsyncGpuResult, centroids: AsyncGpuResult) -
     return tuple(clusters)
 
 
-def _resolve_output(result, output: ButinaOutput) -> _RDKitClusters | ButinaDeviceResult:
-    if output is ButinaOutput.DEVICE:
+def _resolve_output(result, output: ButinaOutputMode) -> _RDKitClusters | ButinaDeviceResult:
+    if output is ButinaOutputMode.DEVICE:
         return _wrap_device_result(result)
     return _to_rdkit_clusters(*_wrap_cluster_arrays(result))
 
 
-def _validate_output(output: ButinaOutput | None, return_centroids: bool) -> None:
-    if output is not None and not isinstance(output, ButinaOutput):
-        raise TypeError(f"output must be a ButinaOutput or None, got {type(output).__name__}")
+def _validate_output(output: ButinaOutputMode | None, return_centroids: bool) -> None:
+    if output is not None and not isinstance(output, ButinaOutputMode):
+        raise TypeError(f"output must be a ButinaOutputMode or None, got {type(output).__name__}")
     if output is not None and return_centroids:
         raise ValueError("return_centroids cannot be used with output; explicit output modes have fixed return types")
 
@@ -145,7 +145,7 @@ def butina(
     reordering: bool = True,
     stream: torch.cuda.Stream | None = None,
     *,
-    output: Literal[ButinaOutput.RDKIT],
+    output: Literal[ButinaOutputMode.RDKIT],
 ) -> _RDKitClusters: ...
 
 
@@ -158,7 +158,7 @@ def butina(
     reordering: bool = True,
     stream: torch.cuda.Stream | None = None,
     *,
-    output: Literal[ButinaOutput.DEVICE],
+    output: Literal[ButinaOutputMode.DEVICE],
 ) -> ButinaDeviceResult: ...
 
 
@@ -170,7 +170,7 @@ def butina(
     reordering: bool = True,
     stream: torch.cuda.Stream | None = None,
     *,
-    output: ButinaOutput | None = None,
+    output: ButinaOutputMode | None = None,
 ) -> AsyncGpuResult | tuple[AsyncGpuResult, AsyncGpuResult] | _RDKitClusters | ButinaDeviceResult:
     """Perform Butina clustering on a distance matrix.
 
@@ -201,9 +201,9 @@ def butina(
         output: Output format. None selects the compatibility return described below.
 
     Returns:
-        ``ButinaOutput.RDKIT`` returns RDKit clusters as
+        ``ButinaOutputMode.RDKIT`` returns RDKit clusters as
         ``tuple[tuple[int, ...], ...]``, with the centroid first in each cluster.
-        ``ButinaOutput.DEVICE`` returns :class:`ButinaDeviceResult`. When
+        ``ButinaOutputMode.DEVICE`` returns :class:`ButinaDeviceResult`. When
         ``output`` is None, returns cluster IDs as :class:`AsyncGpuResult`, or
         ``(cluster_ids, centroids)`` when ``return_centroids=True``.
 
@@ -253,7 +253,7 @@ def fused_butina(
     metric: str = "tanimoto",
     stream: torch.cuda.Stream | None = None,
     *,
-    output: Literal[ButinaOutput.RDKIT],
+    output: Literal[ButinaOutputMode.RDKIT],
 ) -> _RDKitClusters: ...
 
 
@@ -265,7 +265,7 @@ def fused_butina(
     metric: str = "tanimoto",
     stream: torch.cuda.Stream | None = None,
     *,
-    output: Literal[ButinaOutput.DEVICE],
+    output: Literal[ButinaOutputMode.DEVICE],
 ) -> ButinaDeviceResult: ...
 
 
@@ -276,7 +276,7 @@ def fused_butina(
     metric: str = "tanimoto",
     stream: torch.cuda.Stream | None = None,
     *,
-    output: ButinaOutput | None = None,
+    output: ButinaOutputMode | None = None,
 ) -> (
     tuple[list[tuple[int, ...]], list[int]]
     | tuple[list[tuple[int, ...]], list[int], list[int]]
@@ -303,9 +303,9 @@ def fused_butina(
         output: Output format. None selects the compatibility return described below.
 
     Returns:
-        ``ButinaOutput.RDKIT`` returns RDKit clusters as
+        ``ButinaOutputMode.RDKIT`` returns RDKit clusters as
         ``tuple[tuple[int, ...], ...]``, with the centroid first in each cluster.
-        ``ButinaOutput.DEVICE`` returns :class:`ButinaDeviceResult`. When
+        ``ButinaOutputMode.DEVICE`` returns :class:`ButinaDeviceResult`. When
         ``output`` is None, returns ``(clusters, cumulative_offsets)``, or
         ``(clusters, cumulative_offsets, centroids)`` when
         ``return_centroids=True``.

--- a/nvmolkit/clustering.py
+++ b/nvmolkit/clustering.py
@@ -28,6 +28,11 @@ drastically lower memory: usage is O(N) rather than O(N^2), making it the
 better choice for large N where the full matrix would be prohibitively large.
 """
 
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal, overload
+
+import numpy as np
 import torch
 
 from nvmolkit import _clustering
@@ -36,12 +41,82 @@ from nvmolkit.types import ArrayInput, AsyncGpuResult, _as_cuda_tensor, _resolve
 
 _VALID_NEIGHBORLIST_SIZES = (8, 16, 24, 32, 64, 128)
 
+_RDKitClusters = tuple[tuple[int, ...], ...]
+
+
+class ButinaOutput(Enum):
+    """Selects how Butina clustering results are returned.
+
+    - ``RDKIT`` returns the same tuple-of-tuples representation as RDKit's
+      ``Butina.ClusterData``. The centroid is the first item in each cluster.
+    - ``DEVICE`` keeps the result on the GPU and returns a
+      :class:`ButinaDeviceResult`.
+    """
+
+    RDKIT = "rdkit"
+    DEVICE = "device"
+
+
+@dataclass(frozen=True)
+class ButinaDeviceResult:
+    """GPU-resident result shared by ``butina`` and ``fused_butina``.
+
+    ``cluster_ids`` is int32 with shape ``(N,)`` and has one cluster ID per
+    input item. ``centroids`` is int32 with shape ``(num_clusters,)``.
+    ``cluster_sizes`` is int64 with shape ``(num_clusters,)``. Both latter
+    fields are indexed by cluster ID, and ``cluster_sizes`` contains per-cluster
+    counts, not the cumulative offsets returned by nvMolKit 0.5's legacy
+    ``fused_butina`` API.
+    """
+
+    cluster_ids: AsyncGpuResult
+    centroids: AsyncGpuResult
+    cluster_sizes: AsyncGpuResult
+
 
 def _wrap_result(result, return_centroids: bool):
     if return_centroids:
         cluster_ids, centroids = result
         return AsyncGpuResult(cluster_ids), AsyncGpuResult(centroids)
     return AsyncGpuResult(result)
+
+
+def _wrap_cluster_arrays(result) -> tuple[AsyncGpuResult, AsyncGpuResult]:
+    cluster_ids_obj, centroids_obj = result
+    return AsyncGpuResult(cluster_ids_obj), AsyncGpuResult(centroids_obj)
+
+
+def _wrap_device_result(result) -> ButinaDeviceResult:
+    cluster_ids, centroids = _wrap_cluster_arrays(result)
+    cluster_sizes = torch.bincount(
+        cluster_ids.torch().to(torch.int64),
+        minlength=centroids.torch().numel(),
+    )
+    return ButinaDeviceResult(cluster_ids, centroids, AsyncGpuResult(cluster_sizes))
+
+
+def _to_rdkit_clusters(cluster_ids: AsyncGpuResult, centroids: AsyncGpuResult) -> _RDKitClusters:
+    cluster_ids_array = cluster_ids.numpy()
+    centroids_array = centroids.numpy()
+    clusters = []
+    for cluster_id, centroid_value in enumerate(centroids_array):
+        centroid = int(centroid_value)
+        members = np.flatnonzero(cluster_ids_array == cluster_id)
+        clusters.append(tuple([centroid] + [int(member) for member in members if member != centroid]))
+    return tuple(clusters)
+
+
+def _resolve_output(result, output: ButinaOutput) -> _RDKitClusters | ButinaDeviceResult:
+    if output is ButinaOutput.DEVICE:
+        return _wrap_device_result(result)
+    return _to_rdkit_clusters(*_wrap_cluster_arrays(result))
+
+
+def _validate_output(output: ButinaOutput | None, return_centroids: bool) -> None:
+    if output is not None and not isinstance(output, ButinaOutput):
+        raise TypeError(f"output must be a ButinaOutput or None, got {type(output).__name__}")
+    if output is not None and return_centroids:
+        raise ValueError("return_centroids cannot be used with output; explicit output modes have fixed return types")
 
 
 def _check_distance_matrix(name: str, x: torch.Tensor) -> torch.Tensor:
@@ -52,6 +127,7 @@ def _check_distance_matrix(name: str, x: torch.Tensor) -> torch.Tensor:
     return x.contiguous()
 
 
+@overload
 def butina(
     distance_matrix: ArrayInput,
     cutoff: float,
@@ -59,7 +135,47 @@ def butina(
     return_centroids: bool = False,
     reordering: bool = True,
     stream: torch.cuda.Stream | None = None,
-) -> AsyncGpuResult | tuple[AsyncGpuResult, AsyncGpuResult]:
+    *,
+    output: None = None,
+) -> AsyncGpuResult | tuple[AsyncGpuResult, AsyncGpuResult]: ...
+
+
+@overload
+def butina(
+    distance_matrix: ArrayInput,
+    cutoff: float,
+    neighborlist_max_size: int = 64,
+    return_centroids: Literal[False] = False,
+    reordering: bool = True,
+    stream: torch.cuda.Stream | None = None,
+    *,
+    output: Literal[ButinaOutput.RDKIT],
+) -> _RDKitClusters: ...
+
+
+@overload
+def butina(
+    distance_matrix: ArrayInput,
+    cutoff: float,
+    neighborlist_max_size: int = 64,
+    return_centroids: Literal[False] = False,
+    reordering: bool = True,
+    stream: torch.cuda.Stream | None = None,
+    *,
+    output: Literal[ButinaOutput.DEVICE],
+) -> ButinaDeviceResult: ...
+
+
+def butina(
+    distance_matrix: ArrayInput,
+    cutoff: float,
+    neighborlist_max_size: int = 64,
+    return_centroids: bool = False,
+    reordering: bool = True,
+    stream: torch.cuda.Stream | None = None,
+    *,
+    output: ButinaOutput | None = None,
+) -> AsyncGpuResult | tuple[AsyncGpuResult, AsyncGpuResult] | _RDKitClusters | ButinaDeviceResult:
     """Perform Butina clustering on a distance matrix.
 
     The Butina algorithm is a deterministic clustering method that groups items based
@@ -80,22 +196,29 @@ def butina(
                               optimization. Must be 8, 16, 24, 32, 64, or 128. Larger values
                               allow parallel processing of larger clusters but use more
                               shared memory. Ignored when reordering is False.
-        return_centroids: Whether to return centroid indices for each cluster.
+        return_centroids: Whether the historical omitted-output path also returns
+                          centroid indices. Cannot be combined with ``output``.
         reordering: Whether to update neighbor counts among unassigned items
                     after each cluster is formed. Defaults to True, while
                     RDKit's ``Butina.ClusterData`` defaults to False.
         stream: CUDA stream to use. If None, uses the current stream.
+        output: Explicit result representation. ``ButinaOutput.RDKIT`` returns
+                RDKit-style host clusters; ``ButinaOutput.DEVICE`` returns a
+                :class:`ButinaDeviceResult`. If omitted, preserves the original
+                non-fused nvMolKit return behavior controlled by
+                ``return_centroids``.
 
     Returns:
-        AsyncGpuResult of shape ``(N,)`` with cluster IDs (cluster 0 is the
-        largest) when ``return_centroids`` is False. When ``return_centroids``
-        is True, returns a tuple ``(cluster_ids, centroids)`` where *centroids* is
-        an AsyncGpuResult of shape ``(num_clusters,)`` containing the centroid
-        index for each cluster ID.
+        With ``output=ButinaOutput.RDKIT``, the RDKit tuple-of-tuples cluster
+        representation. With ``output=ButinaOutput.DEVICE``, a
+        :class:`ButinaDeviceResult`. If ``output`` is omitted, an
+        ``AsyncGpuResult`` of cluster IDs, or ``(cluster_ids, centroids)`` when
+        ``return_centroids=True``, preserving the historical non-fused API.
 
     Note:
         The distance matrix should be symmetric and have zeros on the diagonal.
     """
+    _validate_output(output, return_centroids)
     if neighborlist_max_size not in _VALID_NEIGHBORLIST_SIZES:
         raise ValueError(
             f"neighborlist_max_size must be one of {_VALID_NEIGHBORLIST_SIZES}, got {neighborlist_max_size}"
@@ -104,15 +227,54 @@ def butina(
     with torch.cuda.stream(active_stream):
         distance_matrix_tensor = _as_cuda_tensor("distance_matrix", distance_matrix, stream=active_stream)
         distance_matrix_tensor = _check_distance_matrix("distance_matrix", distance_matrix_tensor)
+        native_return_centroids = return_centroids or output is not None
         result = _clustering.butina(
             distance_matrix_tensor.__cuda_array_interface__,
             cutoff,
             neighborlist_max_size,
-            return_centroids,
+            native_return_centroids,
             reordering,
             active_stream.cuda_stream,
         )
-        return _wrap_result(result, return_centroids)
+        if output is None:
+            return _wrap_result(result, return_centroids)
+        return _resolve_output(result, output)
+
+
+@overload
+def fused_butina(
+    x: ArrayInput,
+    cutoff: float,
+    return_centroids: bool = False,
+    metric: str = "tanimoto",
+    stream: torch.cuda.Stream | None = None,
+    *,
+    output: None = None,
+) -> tuple[list[tuple[int, ...]], list[int]] | tuple[list[tuple[int, ...]], list[int], list[int]]: ...
+
+
+@overload
+def fused_butina(
+    x: ArrayInput,
+    cutoff: float,
+    return_centroids: Literal[False] = False,
+    metric: str = "tanimoto",
+    stream: torch.cuda.Stream | None = None,
+    *,
+    output: Literal[ButinaOutput.RDKIT],
+) -> _RDKitClusters: ...
+
+
+@overload
+def fused_butina(
+    x: ArrayInput,
+    cutoff: float,
+    return_centroids: Literal[False] = False,
+    metric: str = "tanimoto",
+    stream: torch.cuda.Stream | None = None,
+    *,
+    output: Literal[ButinaOutput.DEVICE],
+) -> ButinaDeviceResult: ...
 
 
 def fused_butina(
@@ -121,7 +283,14 @@ def fused_butina(
     return_centroids: bool = False,
     metric: str = "tanimoto",
     stream: torch.cuda.Stream | None = None,
-) -> AsyncGpuResult | tuple[AsyncGpuResult, AsyncGpuResult]:
+    *,
+    output: ButinaOutput | None = None,
+) -> (
+    tuple[list[tuple[int, ...]], list[int]]
+    | tuple[list[tuple[int, ...]], list[int], list[int]]
+    | _RDKitClusters
+    | ButinaDeviceResult
+):
     """Perform fused Butina clustering on a set of fingerprints.
 
     This function uses a fused implementation of Butina clustering that computes
@@ -134,17 +303,24 @@ def fused_butina(
            CPU tensors and NumPy arrays are copied to CUDA.
         cutoff: Distance threshold for clustering. Items are neighbors if their
                 distance is at most this cutoff (i.e. similarity >= 1 - cutoff).
-        return_centroids: Whether to return centroid indices for each cluster.
+        return_centroids: Whether the historical omitted-output path includes
+                          the centroid list. Cannot be combined with ``output``.
         metric: Metric to use for similarity computation. Currently only "tanimoto"
                 and "cosine" are supported.
         stream: CUDA stream to use. If None, uses the current stream.
+        output: Explicit result representation. ``ButinaOutput.RDKIT`` returns
+                RDKit-style host clusters; ``ButinaOutput.DEVICE`` returns a
+                :class:`ButinaDeviceResult`. If omitted, reproduces the nvMolKit
+                0.5 fused return contract controlled by ``return_centroids``.
 
     Returns:
-        AsyncGpuResult of shape ``(N,)`` containing one cluster ID per input item
-        when ``return_centroids`` is False. When ``return_centroids`` is True,
-        returns ``(cluster_ids, centroids)``, where *centroids* contains the input
-        index selected as the centroid for each cluster ID.
+        With ``output=ButinaOutput.RDKIT``, the RDKit tuple-of-tuples cluster
+        representation. With ``output=ButinaOutput.DEVICE``, a
+        :class:`ButinaDeviceResult`. If ``output`` is omitted, returns the
+        nvMolKit 0.5 ``(clusters, cumulative_offsets)`` tuple, plus a centroid
+        list when ``return_centroids=True``.
     """
+    _validate_output(output, return_centroids)
     if metric not in ("tanimoto", "cosine"):
         raise ValueError(f"metric must be one of ['tanimoto', 'cosine'], got {metric}")
 
@@ -153,7 +329,15 @@ def fused_butina(
 
     (x,), active_stream = _prepare_packed_fingerprints(("x", x), stream=stream)
     with torch.cuda.stream(active_stream):
-        result = _clustering.fused_butina(
-            x.__cuda_array_interface__, cutoff, return_centroids, metric, active_stream.cuda_stream
-        )
-        return _wrap_result(result, return_centroids)
+        result = _clustering.fused_butina(x.__cuda_array_interface__, cutoff, True, metric, active_stream.cuda_stream)
+        if output is not None:
+            return _resolve_output(result, output)
+
+        clusters = list(_to_rdkit_clusters(*_wrap_cluster_arrays(result)))
+        cluster_offsets = [0]
+        for cluster in clusters:
+            cluster_offsets.append(cluster_offsets[-1] + len(cluster))
+        if return_centroids:
+            centroids = [cluster[0] for cluster in clusters]
+            return clusters, cluster_offsets, centroids
+        return clusters, cluster_offsets

--- a/nvmolkit/clustering.py
+++ b/nvmolkit/clustering.py
@@ -201,11 +201,31 @@ def butina(
         output: Output format. None selects the compatibility return described below.
 
     Returns:
-        ``ButinaOutputMode.RDKIT`` returns RDKit clusters as
-        ``tuple[tuple[int, ...], ...]``, with the centroid first in each cluster.
-        ``ButinaOutputMode.DEVICE`` returns :class:`ButinaDeviceResult`. When
-        ``output`` is None, returns cluster IDs as :class:`AsyncGpuResult`, or
-        ``(cluster_ids, centroids)`` when ``return_centroids=True``.
+        The representation selected by ``output``.
+
+        ``ButinaOutputMode.RDKIT`` returns a tuple containing one tuple per
+        cluster. Each cluster tuple contains input indices, with the centroid
+        first. Constructing this representation synchronizes the CUDA work and
+        copies the clustering result to the host.
+
+        ``ButinaOutputMode.DEVICE`` returns a :class:`ButinaDeviceResult`
+        containing three :class:`AsyncGpuResult` objects on the active CUDA
+        device. ``cluster_ids`` is int32 with shape ``(N,)`` and maps each input
+        index to a cluster ID. Cluster IDs are contiguous from zero through
+        ``num_clusters - 1``. ``centroids`` is int32 with shape
+        ``(num_clusters,)``; element ``k`` is an input index whose cluster ID is
+        ``k``. ``cluster_sizes`` is int64 with shape ``(num_clusters,)``;
+        element ``k`` equals the number of entries in ``cluster_ids`` that are
+        equal to ``k``, and the sizes sum to ``N``. The return is
+        asynchronous: each field's ``.torch()`` method exposes its CUDA tensor
+        without a host copy, while ``.numpy()`` synchronizes and copies that
+        field to the host.
+
+        When ``output`` is None, the function preserves its original return
+        type. It returns ``cluster_ids`` as an :class:`AsyncGpuResult` of shape
+        ``(N,)``. If ``return_centroids=True``, it instead returns
+        ``(cluster_ids, centroids)``, where ``centroids`` is an
+        :class:`AsyncGpuResult` of shape ``(num_clusters,)``.
 
     Note:
         The distance matrix should be symmetric and have zeros on the diagonal.
@@ -303,12 +323,36 @@ def fused_butina(
         output: Output format. None selects the compatibility return described below.
 
     Returns:
-        ``ButinaOutputMode.RDKIT`` returns RDKit clusters as
-        ``tuple[tuple[int, ...], ...]``, with the centroid first in each cluster.
-        ``ButinaOutputMode.DEVICE`` returns :class:`ButinaDeviceResult`. When
-        ``output`` is None, returns ``(clusters, cumulative_offsets)``, or
-        ``(clusters, cumulative_offsets, centroids)`` when
-        ``return_centroids=True``.
+        The representation selected by ``output``.
+
+        ``ButinaOutputMode.RDKIT`` returns a tuple containing one tuple per
+        cluster. Each cluster tuple contains input indices, with the centroid
+        first. Constructing this representation synchronizes the CUDA work and
+        copies the clustering result to the host.
+
+        ``ButinaOutputMode.DEVICE`` returns a :class:`ButinaDeviceResult`
+        containing three :class:`AsyncGpuResult` objects on the active CUDA
+        device. ``cluster_ids`` is int32 with shape ``(N,)`` and maps each input
+        index to a cluster ID. Cluster IDs are contiguous from zero through
+        ``num_clusters - 1``. ``centroids`` is int32 with shape
+        ``(num_clusters,)``; element ``k`` is an input index whose cluster ID is
+        ``k``. ``cluster_sizes`` is int64 with shape ``(num_clusters,)``;
+        element ``k`` equals the number of entries in ``cluster_ids`` that are
+        equal to ``k``, and the sizes sum to ``N``. The return is
+        asynchronous: each field's ``.torch()`` method exposes its CUDA tensor
+        without a host copy, while ``.numpy()`` synchronizes and copies that
+        field to the host.
+
+        When ``output`` is None, the function preserves the nvMolKit 0.5
+        return type. ``clusters`` is a list of cluster tuples in the same form
+        described for RDKit output. ``cumulative_offsets`` has length
+        ``len(clusters) + 1``, starts at zero, ends at the number of input
+        fingerprints, and satisfies
+        ``cumulative_offsets[k + 1] - cumulative_offsets[k] == len(clusters[k])``.
+        The function returns ``(clusters, cumulative_offsets)`` by default. If
+        ``return_centroids=True``, it returns
+        ``(clusters, cumulative_offsets, centroids)``, where
+        ``centroids[k] == clusters[k][0]``.
     """
     _validate_output(output, return_centroids)
     if metric not in ("tanimoto", "cosine"):

--- a/nvmolkit/clustering.py
+++ b/nvmolkit/clustering.py
@@ -70,13 +70,6 @@ class ButinaDeviceResult:
     cluster_sizes: AsyncGpuResult
 
 
-def _wrap_result(result, return_centroids: bool):
-    if return_centroids:
-        cluster_ids, centroids = result
-        return AsyncGpuResult(cluster_ids), AsyncGpuResult(centroids)
-    return AsyncGpuResult(result)
-
-
 def _wrap_cluster_arrays(result) -> tuple[AsyncGpuResult, AsyncGpuResult]:
     cluster_ids_obj, centroids_obj = result
     return AsyncGpuResult(cluster_ids_obj), AsyncGpuResult(centroids_obj)
@@ -108,11 +101,9 @@ def _resolve_output(result, output: ButinaOutputMode) -> _RDKitClusters | Butina
     return _to_rdkit_clusters(*_wrap_cluster_arrays(result))
 
 
-def _validate_output(output: ButinaOutputMode | None, return_centroids: bool) -> None:
-    if output is not None and not isinstance(output, ButinaOutputMode):
-        raise TypeError(f"output must be a ButinaOutputMode or None, got {type(output).__name__}")
-    if output is not None and return_centroids:
-        raise ValueError("return_centroids cannot be used with output; explicit output modes have fixed return types")
+def _validate_output(output: ButinaOutputMode) -> None:
+    if not isinstance(output, ButinaOutputMode):
+        raise TypeError(f"output must be a ButinaOutputMode, got {type(output).__name__}")
 
 
 def _check_distance_matrix(name: str, x: torch.Tensor) -> torch.Tensor:
@@ -128,12 +119,11 @@ def butina(
     distance_matrix: ArrayInput,
     cutoff: float,
     neighborlist_max_size: int = 64,
-    return_centroids: bool = False,
     reordering: bool = True,
     stream: torch.cuda.Stream | None = None,
     *,
-    output: None = None,
-) -> AsyncGpuResult | tuple[AsyncGpuResult, AsyncGpuResult]: ...
+    output: Literal[ButinaOutputMode.DEVICE] = ButinaOutputMode.DEVICE,
+) -> ButinaDeviceResult: ...
 
 
 @overload
@@ -141,7 +131,6 @@ def butina(
     distance_matrix: ArrayInput,
     cutoff: float,
     neighborlist_max_size: int = 64,
-    return_centroids: Literal[False] = False,
     reordering: bool = True,
     stream: torch.cuda.Stream | None = None,
     *,
@@ -149,29 +138,15 @@ def butina(
 ) -> _RDKitClusters: ...
 
 
-@overload
 def butina(
     distance_matrix: ArrayInput,
     cutoff: float,
     neighborlist_max_size: int = 64,
-    return_centroids: Literal[False] = False,
     reordering: bool = True,
     stream: torch.cuda.Stream | None = None,
     *,
-    output: Literal[ButinaOutputMode.DEVICE],
-) -> ButinaDeviceResult: ...
-
-
-def butina(
-    distance_matrix: ArrayInput,
-    cutoff: float,
-    neighborlist_max_size: int = 64,
-    return_centroids: bool = False,
-    reordering: bool = True,
-    stream: torch.cuda.Stream | None = None,
-    *,
-    output: ButinaOutputMode | None = None,
-) -> AsyncGpuResult | tuple[AsyncGpuResult, AsyncGpuResult] | _RDKitClusters | ButinaDeviceResult:
+    output: ButinaOutputMode = ButinaOutputMode.DEVICE,
+) -> _RDKitClusters | ButinaDeviceResult:
     """Perform Butina clustering on a distance matrix.
 
     The Butina algorithm is a deterministic clustering method that groups items based
@@ -192,13 +167,11 @@ def butina(
                               optimization. Must be 8, 16, 24, 32, 64, or 128. Larger values
                               allow parallel processing of larger clusters but use more
                               shared memory. Ignored when reordering is False.
-        return_centroids: When ``output`` is None, return centroids alongside
-                          the cluster IDs. Cannot be combined with ``output``.
         reordering: Whether to update neighbor counts among unassigned items
                     after each cluster is formed. Defaults to True, while
                     RDKit's ``Butina.ClusterData`` defaults to False.
         stream: CUDA stream to use. If None, uses the current stream.
-        output: Output format. None selects the compatibility return described below.
+        output: Output representation. Defaults to ``ButinaOutputMode.DEVICE``.
 
     Returns:
         The representation selected by ``output``.
@@ -221,16 +194,10 @@ def butina(
         without a host copy, while ``.numpy()`` synchronizes and copies that
         field to the host.
 
-        When ``output`` is None, the function preserves its original return
-        type. It returns ``cluster_ids`` as an :class:`AsyncGpuResult` of shape
-        ``(N,)``. If ``return_centroids=True``, it instead returns
-        ``(cluster_ids, centroids)``, where ``centroids`` is an
-        :class:`AsyncGpuResult` of shape ``(num_clusters,)``.
-
     Note:
         The distance matrix should be symmetric and have zeros on the diagonal.
     """
-    _validate_output(output, return_centroids)
+    _validate_output(output)
     if neighborlist_max_size not in _VALID_NEIGHBORLIST_SIZES:
         raise ValueError(
             f"neighborlist_max_size must be one of {_VALID_NEIGHBORLIST_SIZES}, got {neighborlist_max_size}"
@@ -239,17 +206,14 @@ def butina(
     with torch.cuda.stream(active_stream):
         distance_matrix_tensor = _as_cuda_tensor("distance_matrix", distance_matrix, stream=active_stream)
         distance_matrix_tensor = _check_distance_matrix("distance_matrix", distance_matrix_tensor)
-        native_return_centroids = return_centroids or output is not None
         result = _clustering.butina(
             distance_matrix_tensor.__cuda_array_interface__,
             cutoff,
             neighborlist_max_size,
-            native_return_centroids,
+            True,
             reordering,
             active_stream.cuda_stream,
         )
-        if output is None:
-            return _wrap_result(result, return_centroids)
         return _resolve_output(result, output)
 
 
@@ -257,19 +221,17 @@ def butina(
 def fused_butina(
     x: ArrayInput,
     cutoff: float,
-    return_centroids: bool = False,
     metric: str = "tanimoto",
     stream: torch.cuda.Stream | None = None,
     *,
-    output: None = None,
-) -> tuple[list[tuple[int, ...]], list[int]] | tuple[list[tuple[int, ...]], list[int], list[int]]: ...
+    output: Literal[ButinaOutputMode.DEVICE] = ButinaOutputMode.DEVICE,
+) -> ButinaDeviceResult: ...
 
 
 @overload
 def fused_butina(
     x: ArrayInput,
     cutoff: float,
-    return_centroids: Literal[False] = False,
     metric: str = "tanimoto",
     stream: torch.cuda.Stream | None = None,
     *,
@@ -277,32 +239,14 @@ def fused_butina(
 ) -> _RDKitClusters: ...
 
 
-@overload
 def fused_butina(
     x: ArrayInput,
     cutoff: float,
-    return_centroids: Literal[False] = False,
     metric: str = "tanimoto",
     stream: torch.cuda.Stream | None = None,
     *,
-    output: Literal[ButinaOutputMode.DEVICE],
-) -> ButinaDeviceResult: ...
-
-
-def fused_butina(
-    x: ArrayInput,
-    cutoff: float,
-    return_centroids: bool = False,
-    metric: str = "tanimoto",
-    stream: torch.cuda.Stream | None = None,
-    *,
-    output: ButinaOutputMode | None = None,
-) -> (
-    tuple[list[tuple[int, ...]], list[int]]
-    | tuple[list[tuple[int, ...]], list[int], list[int]]
-    | _RDKitClusters
-    | ButinaDeviceResult
-):
+    output: ButinaOutputMode = ButinaOutputMode.DEVICE,
+) -> _RDKitClusters | ButinaDeviceResult:
     """Perform fused Butina clustering on a set of fingerprints.
 
     This function uses a fused implementation of Butina clustering that computes
@@ -315,12 +259,10 @@ def fused_butina(
            CPU tensors and NumPy arrays are copied to CUDA.
         cutoff: Distance threshold for clustering. Items are neighbors if their
                 distance is at most this cutoff (i.e. similarity >= 1 - cutoff).
-        return_centroids: When ``output`` is None, include centroids in the
-                          return tuple. Cannot be combined with ``output``.
         metric: Metric to use for similarity computation. Currently only "tanimoto"
                 and "cosine" are supported.
         stream: CUDA stream to use. If None, uses the current stream.
-        output: Output format. None selects the compatibility return described below.
+        output: Output representation. Defaults to ``ButinaOutputMode.DEVICE``.
 
     Returns:
         The representation selected by ``output``.
@@ -343,18 +285,8 @@ def fused_butina(
         without a host copy, while ``.numpy()`` synchronizes and copies that
         field to the host.
 
-        When ``output`` is None, the function preserves the nvMolKit 0.5
-        return type. ``clusters`` is a list of cluster tuples in the same form
-        described for RDKit output. ``cumulative_offsets`` has length
-        ``len(clusters) + 1``, starts at zero, ends at the number of input
-        fingerprints, and satisfies
-        ``cumulative_offsets[k + 1] - cumulative_offsets[k] == len(clusters[k])``.
-        The function returns ``(clusters, cumulative_offsets)`` by default. If
-        ``return_centroids=True``, it returns
-        ``(clusters, cumulative_offsets, centroids)``, where
-        ``centroids[k] == clusters[k][0]``.
     """
-    _validate_output(output, return_centroids)
+    _validate_output(output)
     if metric not in ("tanimoto", "cosine"):
         raise ValueError(f"metric must be one of ['tanimoto', 'cosine'], got {metric}")
 
@@ -364,14 +296,4 @@ def fused_butina(
     (x,), active_stream = _prepare_packed_fingerprints(("x", x), stream=stream)
     with torch.cuda.stream(active_stream):
         result = _clustering.fused_butina(x.__cuda_array_interface__, cutoff, True, metric, active_stream.cuda_stream)
-        if output is not None:
-            return _resolve_output(result, output)
-
-        clusters = list(_to_rdkit_clusters(*_wrap_cluster_arrays(result)))
-        cluster_offsets = [0]
-        for cluster in clusters:
-            cluster_offsets.append(cluster_offsets[-1] + len(cluster))
-        if return_centroids:
-            centroids = [cluster[0] for cluster in clusters]
-            return clusters, cluster_offsets, centroids
-        return clusters, cluster_offsets
+        return _resolve_output(result, output)

--- a/nvmolkit/clustering.py
+++ b/nvmolkit/clustering.py
@@ -77,20 +77,23 @@ def _wrap_cluster_arrays(result) -> tuple[AsyncGpuResult, AsyncGpuResult]:
 
 def _wrap_device_result(result) -> ButinaDeviceResult:
     cluster_ids, centroids = _wrap_cluster_arrays(result)
-    cluster_sizes = torch.bincount(
-        cluster_ids.torch().to(torch.int64),
-        minlength=centroids.torch().numel(),
-    )
+    cluster_ids_int64 = cluster_ids.torch().to(torch.int64)
+    cluster_sizes = torch.zeros_like(centroids.torch(), dtype=torch.int64)
+    cluster_sizes.index_add_(0, cluster_ids_int64, torch.ones_like(cluster_ids_int64))
     return ButinaDeviceResult(cluster_ids, centroids, AsyncGpuResult(cluster_sizes))
 
 
 def _to_rdkit_clusters(cluster_ids: AsyncGpuResult, centroids: AsyncGpuResult) -> _RDKitClusters:
     cluster_ids_array = cluster_ids.numpy()
     centroids_array = centroids.numpy()
+    member_order = np.argsort(cluster_ids_array, kind="stable")
+    sorted_cluster_ids = cluster_ids_array[member_order]
+    cluster_offsets = np.searchsorted(sorted_cluster_ids, np.arange(centroids_array.size + 1))
+
     clusters = []
     for cluster_id, centroid_value in enumerate(centroids_array):
         centroid = int(centroid_value)
-        members = np.flatnonzero(cluster_ids_array == cluster_id)
+        members = member_order[cluster_offsets[cluster_id] : cluster_offsets[cluster_id + 1]]
         clusters.append(tuple([centroid] + [int(member) for member in members if member != centroid]))
     return tuple(clusters)
 

--- a/nvmolkit/tests/test_clustering.py
+++ b/nvmolkit/tests/test_clustering.py
@@ -18,7 +18,7 @@ import pytest
 import torch
 from rdkit.ML.Cluster.Butina import ClusterData
 
-from nvmolkit.clustering import ButinaDeviceResult, ButinaOutput, butina, fused_butina
+from nvmolkit.clustering import ButinaDeviceResult, ButinaOutputMode, butina, fused_butina
 from nvmolkit.types import AsyncGpuResult
 
 
@@ -58,7 +58,7 @@ def _nvmolkit_butina_clusters(distance_matrix, cutoff, *, reordering):
         torch.tensor(distance_matrix, device="cuda"),
         cutoff,
         reordering=reordering,
-        output=ButinaOutput.DEVICE,
+        output=ButinaOutputMode.DEVICE,
     )
     labels = result.cluster_ids.torch().cpu().numpy()
     centroids = result.centroids.torch().cpu().numpy()
@@ -171,7 +171,7 @@ def test_butina_rdkit_output_matches_rdkit(reordering):
         distance_matrix,
         0.2,
         reordering=reordering,
-        output=ButinaOutput.RDKIT,
+        output=ButinaOutputMode.RDKIT,
     )
 
     assert got == _rdkit_butina_clusters(distance_matrix, 0.2, reordering=reordering)
@@ -189,7 +189,7 @@ def test_butina_device_output_has_fixed_result_type():
         device="cuda",
     )
 
-    result = butina(dists, 0.2, output=ButinaOutput.DEVICE)
+    result = butina(dists, 0.2, output=ButinaOutputMode.DEVICE)
 
     assert isinstance(result, ButinaDeviceResult)
     torch.testing.assert_close(result.cluster_sizes.torch(), torch.tensor([2, 2], device="cuda"))
@@ -257,12 +257,12 @@ def test_butina_invalid_neighborlist_max_size(invalid_size):
 def test_butina_rejects_return_centroids_with_explicit_output():
     dists = torch.zeros(2, 2, dtype=torch.float64)
     with pytest.raises(ValueError, match="return_centroids cannot be used with output"):
-        butina(dists, 0.1, return_centroids=True, output=ButinaOutput.DEVICE)
+        butina(dists, 0.1, return_centroids=True, output=ButinaOutputMode.DEVICE)
 
 
 def test_butina_rejects_invalid_output():
     dists = torch.zeros(2, 2, dtype=torch.float64)
-    with pytest.raises(TypeError, match="output must be a ButinaOutput or None"):
+    with pytest.raises(TypeError, match="output must be a ButinaOutputMode or None"):
         butina(dists, 0.1, output="device")
 
 
@@ -335,7 +335,7 @@ def fused_butina_clusters(x, cutoff, metric="tanimoto", stream=None):
         cutoff,
         metric=metric,
         stream=stream,
-        output=ButinaOutput.DEVICE,
+        output=ButinaOutputMode.DEVICE,
     )
     cluster_ids = result.cluster_ids.numpy()
     centroids = result.centroids.numpy()
@@ -416,7 +416,7 @@ def test_fused_butina_all_singletons(metric):
 def test_fused_butina_returns_centroids(n, metric):
     cutoff = 0.4
     x = generate_clustered_fingerprints(n, num_words=32, num_clusters=10)
-    result = fused_butina(x, cutoff=cutoff, metric=metric, output=ButinaOutput.DEVICE)
+    result = fused_butina(x, cutoff=cutoff, metric=metric, output=ButinaOutputMode.DEVICE)
     cluster_ids = result.cluster_ids.numpy()
     centroids = result.centroids.numpy()
 
@@ -436,7 +436,7 @@ def test_fused_butina_returns_centroids(n, metric):
 def test_fused_butina_accepts_array_input_types(input_kind):
     x = generate_clustered_fingerprints(50, num_words=32, num_clusters=10)
     cutoff = 0.4
-    expected_cluster_ids = fused_butina(x, cutoff=cutoff, output=ButinaOutput.DEVICE).cluster_ids.torch().cpu()
+    expected_cluster_ids = fused_butina(x, cutoff=cutoff, output=ButinaOutputMode.DEVICE).cluster_ids.torch().cpu()
 
     if input_kind == "async":
         inp = AsyncGpuResult(x)
@@ -445,7 +445,7 @@ def test_fused_butina_accepts_array_input_types(input_kind):
     else:
         inp = x.cpu().numpy()
 
-    cluster_ids = fused_butina(inp, cutoff=cutoff, output=ButinaOutput.DEVICE).cluster_ids.torch().cpu()
+    cluster_ids = fused_butina(inp, cutoff=cutoff, output=ButinaOutputMode.DEVICE).cluster_ids.torch().cpu()
     torch.testing.assert_close(cluster_ids, expected_cluster_ids)
 
 
@@ -453,18 +453,20 @@ def test_fused_butina_accepts_int32_and_uint32():
     fingerprints_int32 = generate_clustered_fingerprints(50, num_words=32, num_clusters=10)
     fingerprints_uint32 = fingerprints_int32.view(torch.uint32)
 
-    expected_cluster_ids = fused_butina(fingerprints_int32, cutoff=0.4, output=ButinaOutput.DEVICE).cluster_ids.torch()
-    cluster_ids = fused_butina(fingerprints_uint32, cutoff=0.4, output=ButinaOutput.DEVICE).cluster_ids.torch()
+    expected_cluster_ids = fused_butina(
+        fingerprints_int32, cutoff=0.4, output=ButinaOutputMode.DEVICE
+    ).cluster_ids.torch()
+    cluster_ids = fused_butina(fingerprints_uint32, cutoff=0.4, output=ButinaOutputMode.DEVICE).cluster_ids.torch()
 
     torch.testing.assert_close(cluster_ids, expected_cluster_ids)
 
 
 def test_fused_butina_on_explicit_stream():
     x = generate_clustered_fingerprints(100, num_words=32, num_clusters=10)
-    expected = fused_butina(x, cutoff=0.4, output=ButinaOutput.DEVICE).cluster_ids.torch()
+    expected = fused_butina(x, cutoff=0.4, output=ButinaOutputMode.DEVICE).cluster_ids.torch()
 
     s = torch.cuda.Stream()
-    actual = fused_butina(x, cutoff=0.4, stream=s, output=ButinaOutput.DEVICE).cluster_ids.torch()
+    actual = fused_butina(x, cutoff=0.4, stream=s, output=ButinaOutputMode.DEVICE).cluster_ids.torch()
     s.synchronize()
 
     torch.testing.assert_close(actual, expected)
@@ -514,8 +516,8 @@ def test_fused_butina_restores_v05_return_contract():
 def test_fused_butina_rdkit_and_device_outputs_agree():
     x = generate_clustered_fingerprints(50, num_words=32, num_clusters=10)
 
-    rdkit_result = fused_butina(x, cutoff=0.4, output=ButinaOutput.RDKIT)
-    device_result = fused_butina(x, cutoff=0.4, output=ButinaOutput.DEVICE)
+    rdkit_result = fused_butina(x, cutoff=0.4, output=ButinaOutputMode.RDKIT)
+    device_result = fused_butina(x, cutoff=0.4, output=ButinaOutputMode.DEVICE)
 
     assert isinstance(rdkit_result, tuple)
     assert isinstance(device_result, ButinaDeviceResult)

--- a/nvmolkit/tests/test_clustering.py
+++ b/nvmolkit/tests/test_clustering.py
@@ -18,7 +18,7 @@ import pytest
 import torch
 from rdkit.ML.Cluster.Butina import ClusterData
 
-from nvmolkit.clustering import butina, fused_butina
+from nvmolkit.clustering import ButinaDeviceResult, ButinaOutput, butina, fused_butina
 from nvmolkit.types import AsyncGpuResult
 
 
@@ -54,14 +54,14 @@ def check_butina_correctness(hit_mat, clusts):
 
 
 def _nvmolkit_butina_clusters(distance_matrix, cutoff, *, reordering):
-    labels, centroids = butina(
+    result = butina(
         torch.tensor(distance_matrix, device="cuda"),
         cutoff,
         reordering=reordering,
-        return_centroids=True,
+        output=ButinaOutput.DEVICE,
     )
-    labels = labels.torch().cpu().numpy()
-    centroids = centroids.torch().cpu().numpy()
+    labels = result.cluster_ids.torch().cpu().numpy()
+    centroids = result.centroids.torch().cpu().numpy()
 
     clusters = []
     for cluster_id, centroid in enumerate(centroids):
@@ -155,6 +155,48 @@ def test_butina_returns_centroids():
             assert adjacency[centroid, member].item()
 
 
+@pytest.mark.parametrize("reordering", [False, True])
+def test_butina_rdkit_output_matches_rdkit(reordering):
+    distance_matrix = np.array(
+        [
+            [0.0, 0.2, 1.0, 1.0],
+            [0.2, 0.0, 0.2, 1.0],
+            [1.0, 0.2, 0.0, 0.2],
+            [1.0, 1.0, 0.2, 0.0],
+        ],
+        dtype=np.float64,
+    )
+
+    got = butina(
+        distance_matrix,
+        0.2,
+        reordering=reordering,
+        output=ButinaOutput.RDKIT,
+    )
+
+    assert got == _rdkit_butina_clusters(distance_matrix, 0.2, reordering=reordering)
+
+
+def test_butina_device_output_has_fixed_result_type():
+    dists = torch.tensor(
+        [
+            [0.0, 0.1, 1.0, 1.0],
+            [0.1, 0.0, 1.0, 1.0],
+            [1.0, 1.0, 0.0, 0.1],
+            [1.0, 1.0, 0.1, 0.0],
+        ],
+        dtype=torch.float64,
+        device="cuda",
+    )
+
+    result = butina(dists, 0.2, output=ButinaOutput.DEVICE)
+
+    assert isinstance(result, ButinaDeviceResult)
+    torch.testing.assert_close(result.cluster_sizes.torch(), torch.tensor([2, 2], device="cuda"))
+    assert result.cluster_ids.torch().shape == (4,)
+    assert result.centroids.torch().shape == (2,)
+
+
 @pytest.mark.parametrize("input_kind", ["async", "cpu_tensor", "numpy"])
 def test_butina_accepts_array_input_types(input_kind):
     n = 20
@@ -210,6 +252,18 @@ def test_butina_invalid_neighborlist_max_size(invalid_size):
     dists = torch.zeros(n, n, dtype=torch.float64)
     with pytest.raises(ValueError, match="neighborlist_max_size must be one of"):
         butina(dists, 0.1, neighborlist_max_size=invalid_size)
+
+
+def test_butina_rejects_return_centroids_with_explicit_output():
+    dists = torch.zeros(2, 2, dtype=torch.float64)
+    with pytest.raises(ValueError, match="return_centroids cannot be used with output"):
+        butina(dists, 0.1, return_centroids=True, output=ButinaOutput.DEVICE)
+
+
+def test_butina_rejects_invalid_output():
+    dists = torch.zeros(2, 2, dtype=torch.float64)
+    with pytest.raises(TypeError, match="output must be a ButinaOutput or None"):
+        butina(dists, 0.1, output="device")
 
 
 # ---------------------------------------------------------------------------
@@ -276,15 +330,15 @@ def check_fused_butina_basic(clusters, n):
 
 
 def fused_butina_clusters(x, cutoff, metric="tanimoto", stream=None):
-    cluster_ids, centroids = fused_butina(
+    result = fused_butina(
         x,
         cutoff,
-        return_centroids=True,
         metric=metric,
         stream=stream,
+        output=ButinaOutput.DEVICE,
     )
-    cluster_ids = cluster_ids.numpy()
-    centroids = centroids.numpy()
+    cluster_ids = result.cluster_ids.numpy()
+    centroids = result.centroids.numpy()
 
     clusters = []
     for cluster_id, centroid in enumerate(centroids):
@@ -362,9 +416,9 @@ def test_fused_butina_all_singletons(metric):
 def test_fused_butina_returns_centroids(n, metric):
     cutoff = 0.4
     x = generate_clustered_fingerprints(n, num_words=32, num_clusters=10)
-    cluster_ids, centroids = fused_butina(x, cutoff=cutoff, return_centroids=True, metric=metric)
-    cluster_ids = cluster_ids.numpy()
-    centroids = centroids.numpy()
+    result = fused_butina(x, cutoff=cutoff, metric=metric, output=ButinaOutput.DEVICE)
+    cluster_ids = result.cluster_ids.numpy()
+    centroids = result.centroids.numpy()
 
     sim = compute_pairwise_similarity_cpu(x.cpu().numpy(), metric=metric)
     threshold = 1.0 - cutoff
@@ -382,7 +436,7 @@ def test_fused_butina_returns_centroids(n, metric):
 def test_fused_butina_accepts_array_input_types(input_kind):
     x = generate_clustered_fingerprints(50, num_words=32, num_clusters=10)
     cutoff = 0.4
-    expected_cluster_ids = fused_butina(x, cutoff=cutoff).torch().cpu()
+    expected_cluster_ids = fused_butina(x, cutoff=cutoff, output=ButinaOutput.DEVICE).cluster_ids.torch().cpu()
 
     if input_kind == "async":
         inp = AsyncGpuResult(x)
@@ -391,7 +445,7 @@ def test_fused_butina_accepts_array_input_types(input_kind):
     else:
         inp = x.cpu().numpy()
 
-    cluster_ids = fused_butina(inp, cutoff=cutoff).torch().cpu()
+    cluster_ids = fused_butina(inp, cutoff=cutoff, output=ButinaOutput.DEVICE).cluster_ids.torch().cpu()
     torch.testing.assert_close(cluster_ids, expected_cluster_ids)
 
 
@@ -399,18 +453,18 @@ def test_fused_butina_accepts_int32_and_uint32():
     fingerprints_int32 = generate_clustered_fingerprints(50, num_words=32, num_clusters=10)
     fingerprints_uint32 = fingerprints_int32.view(torch.uint32)
 
-    expected_cluster_ids = fused_butina(fingerprints_int32, cutoff=0.4).torch()
-    cluster_ids = fused_butina(fingerprints_uint32, cutoff=0.4).torch()
+    expected_cluster_ids = fused_butina(fingerprints_int32, cutoff=0.4, output=ButinaOutput.DEVICE).cluster_ids.torch()
+    cluster_ids = fused_butina(fingerprints_uint32, cutoff=0.4, output=ButinaOutput.DEVICE).cluster_ids.torch()
 
     torch.testing.assert_close(cluster_ids, expected_cluster_ids)
 
 
 def test_fused_butina_on_explicit_stream():
     x = generate_clustered_fingerprints(100, num_words=32, num_clusters=10)
-    expected = fused_butina(x, cutoff=0.4).torch()
+    expected = fused_butina(x, cutoff=0.4, output=ButinaOutput.DEVICE).cluster_ids.torch()
 
     s = torch.cuda.Stream()
-    actual = fused_butina(x, cutoff=0.4, stream=s).torch()
+    actual = fused_butina(x, cutoff=0.4, stream=s, output=ButinaOutput.DEVICE).cluster_ids.torch()
     s.synchronize()
 
     torch.testing.assert_close(actual, expected)
@@ -438,3 +492,32 @@ def test_fused_butina_invalid_stream_type():
     x = torch.randint(-(2**31 - 1), 2**31 - 1, (10, 32), dtype=torch.int32).cuda()
     with pytest.raises(TypeError):
         fused_butina(x, cutoff=0.5, stream=42)
+
+
+def test_fused_butina_restores_v05_return_contract():
+    x = generate_clustered_fingerprints(50, num_words=32, num_clusters=10)
+
+    clusters_without_centroids, offsets_without_centroids = fused_butina(x, cutoff=0.4)
+    clusters, offsets, centroids = fused_butina(x, cutoff=0.4, return_centroids=True)
+
+    assert clusters_without_centroids == clusters
+    assert offsets_without_centroids == offsets
+    assert isinstance(clusters, list)
+    assert isinstance(offsets, list)
+    assert isinstance(centroids, list)
+    assert offsets[0] == 0
+    assert offsets[-1] == x.shape[0]
+    assert [offsets[i + 1] - offsets[i] for i in range(len(clusters))] == [len(cluster) for cluster in clusters]
+    assert centroids == [cluster[0] for cluster in clusters]
+
+
+def test_fused_butina_rdkit_and_device_outputs_agree():
+    x = generate_clustered_fingerprints(50, num_words=32, num_clusters=10)
+
+    rdkit_result = fused_butina(x, cutoff=0.4, output=ButinaOutput.RDKIT)
+    device_result = fused_butina(x, cutoff=0.4, output=ButinaOutput.DEVICE)
+
+    assert isinstance(rdkit_result, tuple)
+    assert isinstance(device_result, ButinaDeviceResult)
+    assert rdkit_result == fused_butina_clusters(x, cutoff=0.4)
+    assert device_result.cluster_sizes.torch().tolist() == [len(cluster) for cluster in rdkit_result]

--- a/nvmolkit/tests/test_clustering.py
+++ b/nvmolkit/tests/test_clustering.py
@@ -108,7 +108,7 @@ def test_butina_clustering(size, neighborlist_max_size):
     dists = np.random.default_rng(42).random((n, n))
     dists = np.abs(dists - dists.T)
     torch_dists = torch.tensor(dists).to("cuda")
-    nvmol_res = butina(torch_dists, cutoff, neighborlist_max_size=neighborlist_max_size).torch()
+    nvmol_res = butina(torch_dists, cutoff, neighborlist_max_size=neighborlist_max_size).cluster_ids.torch()
     nvmol_clusts = [tuple(torch.argwhere(nvmol_res == i).flatten().tolist()) for i in range(nvmol_res.max() + 1)]
 
     check_butina_correctness(torch_dists <= cutoff, nvmol_clusts)
@@ -119,7 +119,7 @@ def test_butina_edge_one_cluster(neighborlist_max_size):
     n = 10
     cutoff = 100.0
     torch_dists = torch.zeros((n, n), dtype=torch.float64, device="cuda")
-    nvmol_res = butina(torch_dists, cutoff, neighborlist_max_size=neighborlist_max_size).torch()
+    nvmol_res = butina(torch_dists, cutoff, neighborlist_max_size=neighborlist_max_size).cluster_ids.torch()
     assert torch.all(nvmol_res == 0)
 
 
@@ -129,7 +129,7 @@ def test_butina_edge_n_clusters(neighborlist_max_size):
     cutoff = 1e-8
     torch_dists = torch.ones((n, n), dtype=torch.float64, device="cuda")
     torch_dists.fill_diagonal_(0)
-    nvmol_res = butina(torch_dists, cutoff, neighborlist_max_size=neighborlist_max_size).torch()
+    nvmol_res = butina(torch_dists, cutoff, neighborlist_max_size=neighborlist_max_size).cluster_ids.torch()
     assert torch.all(nvmol_res.sort()[0] == torch.arange(10).to("cuda"))
 
 
@@ -139,9 +139,9 @@ def test_butina_returns_centroids():
     dists = np.random.default_rng(123).random((n, n))
     dists = np.abs(dists - dists.T)
     torch_dists = torch.tensor(dists).to("cuda")
-    cluster_ids, centroids = butina(torch_dists, cutoff, return_centroids=True)
-    cluster_ids_tensor = cluster_ids.torch()
-    centroids_tensor = centroids.torch()
+    result = butina(torch_dists, cutoff)
+    cluster_ids_tensor = result.cluster_ids.torch()
+    centroids_tensor = result.centroids.torch()
 
     num_clusters = int(cluster_ids_tensor.max().item()) + 1
     assert centroids_tensor.numel() == num_clusters
@@ -173,11 +173,19 @@ def test_butina_rdkit_output_matches_rdkit(reordering):
         reordering=reordering,
         output=ButinaOutputMode.RDKIT,
     )
+    device_result = butina(
+        distance_matrix,
+        0.2,
+        reordering=reordering,
+        output=ButinaOutputMode.DEVICE,
+    )
 
     assert got == _rdkit_butina_clusters(distance_matrix, 0.2, reordering=reordering)
+    assert [cluster[0] for cluster in got] == device_result.centroids.numpy().tolist()
 
 
-def test_butina_device_output_has_fixed_result_type():
+@pytest.mark.parametrize("explicit_output", [False, True])
+def test_butina_device_output_has_fixed_result_type(explicit_output):
     dists = torch.tensor(
         [
             [0.0, 0.1, 1.0, 1.0],
@@ -189,7 +197,8 @@ def test_butina_device_output_has_fixed_result_type():
         device="cuda",
     )
 
-    result = butina(dists, 0.2, output=ButinaOutputMode.DEVICE)
+    output_args = {"output": ButinaOutputMode.DEVICE} if explicit_output else {}
+    result = butina(dists, 0.2, **output_args)
 
     assert isinstance(result, ButinaDeviceResult)
     torch.testing.assert_close(result.cluster_sizes.torch(), torch.tensor([2, 2], device="cuda"))
@@ -204,7 +213,7 @@ def test_butina_accepts_array_input_types(input_kind):
     dists = np.random.default_rng(456).random((n, n))
     dists = np.abs(dists - dists.T)
     torch_dists = torch.tensor(dists, device="cuda", dtype=torch.float64)
-    expected = butina(torch_dists, cutoff).torch().cpu()
+    expected = butina(torch_dists, cutoff).cluster_ids.torch().cpu()
 
     if input_kind == "async":
         inp = AsyncGpuResult(torch_dists)
@@ -213,7 +222,7 @@ def test_butina_accepts_array_input_types(input_kind):
     else:
         inp = dists
 
-    got = butina(inp, cutoff).torch().cpu()
+    got = butina(inp, cutoff).cluster_ids.torch().cpu()
     torch.testing.assert_close(got, expected)
 
 
@@ -225,7 +234,7 @@ def test_butina_on_explicit_stream():
     torch_dists = torch.tensor(dists).to("cuda")
 
     s = torch.cuda.Stream()
-    result = butina(torch_dists, cutoff, stream=s).torch()
+    result = butina(torch_dists, cutoff, stream=s).cluster_ids.torch()
     s.synchronize()
 
     nvmol_clusts = [tuple(torch.argwhere(result == i).flatten().tolist()) for i in range(result.max() + 1)]
@@ -254,15 +263,9 @@ def test_butina_invalid_neighborlist_max_size(invalid_size):
         butina(dists, 0.1, neighborlist_max_size=invalid_size)
 
 
-def test_butina_rejects_return_centroids_with_explicit_output():
-    dists = torch.zeros(2, 2, dtype=torch.float64)
-    with pytest.raises(ValueError, match="return_centroids cannot be used with output"):
-        butina(dists, 0.1, return_centroids=True, output=ButinaOutputMode.DEVICE)
-
-
 def test_butina_rejects_invalid_output():
     dists = torch.zeros(2, 2, dtype=torch.float64)
-    with pytest.raises(TypeError, match="output must be a ButinaOutputMode or None"):
+    with pytest.raises(TypeError, match="output must be a ButinaOutputMode"):
         butina(dists, 0.1, output="device")
 
 
@@ -496,21 +499,16 @@ def test_fused_butina_invalid_stream_type():
         fused_butina(x, cutoff=0.5, stream=42)
 
 
-def test_fused_butina_restores_v05_return_contract():
+def test_fused_butina_defaults_to_device_output():
     x = generate_clustered_fingerprints(50, num_words=32, num_clusters=10)
 
-    clusters_without_centroids, offsets_without_centroids = fused_butina(x, cutoff=0.4)
-    clusters, offsets, centroids = fused_butina(x, cutoff=0.4, return_centroids=True)
+    default_result = fused_butina(x, cutoff=0.4)
+    explicit_result = fused_butina(x, cutoff=0.4, output=ButinaOutputMode.DEVICE)
 
-    assert clusters_without_centroids == clusters
-    assert offsets_without_centroids == offsets
-    assert isinstance(clusters, list)
-    assert isinstance(offsets, list)
-    assert isinstance(centroids, list)
-    assert offsets[0] == 0
-    assert offsets[-1] == x.shape[0]
-    assert [offsets[i + 1] - offsets[i] for i in range(len(clusters))] == [len(cluster) for cluster in clusters]
-    assert centroids == [cluster[0] for cluster in clusters]
+    assert isinstance(default_result, ButinaDeviceResult)
+    torch.testing.assert_close(default_result.cluster_ids.torch(), explicit_result.cluster_ids.torch())
+    torch.testing.assert_close(default_result.centroids.torch(), explicit_result.centroids.torch())
+    torch.testing.assert_close(default_result.cluster_sizes.torch(), explicit_result.cluster_sizes.torch())
 
 
 def test_fused_butina_rdkit_and_device_outputs_agree():
@@ -522,4 +520,5 @@ def test_fused_butina_rdkit_and_device_outputs_agree():
     assert isinstance(rdkit_result, tuple)
     assert isinstance(device_result, ButinaDeviceResult)
     assert rdkit_result == fused_butina_clusters(x, cutoff=0.4)
+    assert [cluster[0] for cluster in rdkit_result] == device_result.centroids.numpy().tolist()
     assert device_result.cluster_sizes.torch().tolist() == [len(cluster) for cluster in rdkit_result]

--- a/nvmolkit/tests/test_clustering.py
+++ b/nvmolkit/tests/test_clustering.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 from rdkit.ML.Cluster.Butina import ClusterData
 
+import nvmolkit.clustering as clustering
 from nvmolkit.clustering import ButinaDeviceResult, ButinaOutputMode, butina, fused_butina
 from nvmolkit.types import AsyncGpuResult
 
@@ -204,6 +205,13 @@ def test_butina_device_output_has_fixed_result_type(explicit_output):
     torch.testing.assert_close(result.cluster_sizes.torch(), torch.tensor([2, 2], device="cuda"))
     assert result.cluster_ids.torch().shape == (4,)
     assert result.centroids.torch().shape == (2,)
+
+
+def test_to_rdkit_clusters_preserves_cluster_and_member_order():
+    cluster_ids = AsyncGpuResult(torch.tensor([1, 0, 1, 2, 0, 2], dtype=torch.int32, device="cuda"))
+    centroids = AsyncGpuResult(torch.tensor([4, 2, 5], dtype=torch.int32, device="cuda"))
+
+    assert clustering._to_rdkit_clusters(cluster_ids, centroids) == ((4, 1), (2, 0), (5, 3))
 
 
 @pytest.mark.parametrize("input_kind", ["async", "cpu_tensor", "numpy"])

--- a/skills/nvmolkit-usage/SKILL.md
+++ b/skills/nvmolkit-usage/SKILL.md
@@ -301,8 +301,8 @@ for mol_clusters in clusters:
 
 For new code, select an output mode explicitly:
 
-- `output=ButinaOutput.RDKIT` returns RDKit clusters on the host.
-- `output=ButinaOutput.DEVICE` returns GPU-resident cluster IDs, centroids, and sizes.
+- `output=ButinaOutputMode.RDKIT` returns RDKit clusters on the host.
+- `output=ButinaOutputMode.DEVICE` returns GPU-resident cluster IDs, centroids, and sizes.
 
 Calls without `output` retain the older, function-specific return types.
 

--- a/skills/nvmolkit-usage/SKILL.md
+++ b/skills/nvmolkit-usage/SKILL.md
@@ -292,19 +292,21 @@ condensed = GetConformerRMSMatrixBatch(heavy_mols)
 
 # Butina expects a square distance matrix, so request square GPU tensors.
 square = GetConformerRMSMatrixBatch(heavy_mols, output_format="square")
-clusters = [butina(distance_matrix, cutoff=0.5).torch() for distance_matrix in square]
+results = [butina(distance_matrix, cutoff=0.5) for distance_matrix in square]
 
 torch.cuda.synchronize()
-for mol_clusters in clusters:
-    print(mol_clusters.cpu().tolist())
+for result in results:
+    print(result.cluster_ids.torch().cpu().tolist())
 ```
 
-For new code, select an output mode explicitly:
+Both Butina functions return GPU-resident results by default:
 
-- `output=ButinaOutputMode.RDKIT` returns RDKit clusters on the host.
-- `output=ButinaOutputMode.DEVICE` returns GPU-resident cluster IDs, centroids, and sizes.
+- The default, `output=ButinaOutputMode.DEVICE`, returns cluster IDs, centroids, and sizes.
+- `output=ButinaOutputMode.RDKIT` returns RDKit cluster tuples on the host. The first element of each cluster is its centroid.
 
-Calls without `output` retain the older, function-specific return types.
+The device output fields are `AsyncGpuResult` objects. Use `.torch()` to access
+their CUDA tensors without a host copy or `.numpy()` to synchronize and copy a
+field to the host.
 
 `GetConformerRMSMatrix(mol)` and `GetConformerRMSMatrixBatch(mols)` default to `output_format="condensed"`, returning `AsyncGpuResult` objects that wrap RDKit-style flat vectors of length `N * (N - 1) // 2`. Use `output_format="square"` when chaining into `butina()` or any other API that expects an `N x N` distance matrix. Both forms live on the GPU; call `.numpy()` on condensed results or synchronize before moving square tensors to the CPU.
 

--- a/skills/nvmolkit-usage/SKILL.md
+++ b/skills/nvmolkit-usage/SKILL.md
@@ -299,12 +299,12 @@ for mol_clusters in clusters:
     print(mol_clusters.cpu().tolist())
 ```
 
-Both clustering functions accept the same explicit output modes. Use
-`output=ButinaOutput.RDKIT` for RDKit's tuple-of-tuples cluster representation,
-or `output=ButinaOutput.DEVICE` for a `ButinaDeviceResult` containing GPU-resident
-`cluster_ids`, `centroids`, and per-cluster `cluster_sizes`. The omitted-output
-behavior is retained for compatibility and differs between the historical
-non-fused and fused APIs, so new code should select a mode explicitly.
+For new code, select an output mode explicitly:
+
+- `output=ButinaOutput.RDKIT` returns RDKit clusters on the host.
+- `output=ButinaOutput.DEVICE` returns GPU-resident cluster IDs, centroids, and sizes.
+
+Calls without `output` retain the older, function-specific return types.
 
 `GetConformerRMSMatrix(mol)` and `GetConformerRMSMatrixBatch(mols)` default to `output_format="condensed"`, returning `AsyncGpuResult` objects that wrap RDKit-style flat vectors of length `N * (N - 1) // 2`. Use `output_format="square"` when chaining into `butina()` or any other API that expects an `N x N` distance matrix. Both forms live on the GPU; call `.numpy()` on condensed results or synchronize before moving square tensors to the CPU.
 

--- a/skills/nvmolkit-usage/SKILL.md
+++ b/skills/nvmolkit-usage/SKILL.md
@@ -83,7 +83,7 @@ If this fails, point the user at the install guide on the docs site rather than 
 | Forcefield with custom options + constraints | `nvmolkit.batchedForcefield` | `MMFFBatchedForcefield(mols, properties=..., nonBondedThreshold=..., ignoreInterfragInteractions=..., hardwareOptions=...)`, `UFFBatchedForcefield(mols, vdwThreshold=..., ...)`. Per-molecule view `ff[i]` exposes `add_distance_constraint`, `add_position_constraint`, `add_angle_constraint`, `add_torsion_constraint`. Methods: `.compute_energy()`, `.compute_gradients()`, `.minimize(maxIters, forceTol, minimizerKind=..., fireOptions=...)` |
 | Pairwise conformer RMSD | `nvmolkit.conformerRmsd` | `GetConformerRMSMatrix(mol)`, `GetConformerRMSMatrixBatch(mols)` |
 | Torsion Fingerprint Deviation (TFD) | `nvmolkit.tfd` | `GetTFDMatrix(mol)`, `GetTFDMatrices(mols)` |
-| Butina clustering | `nvmolkit.clustering` | `butina(distance_matrix, cutoff)` (precomputed matrix), `fused_butina(fingerprints, cutoff)` (memory-efficient, on-the-fly) |
+| Butina clustering | `nvmolkit.clustering` | `butina(distance_matrix, cutoff)` (precomputed matrix), `fused_butina(fingerprints, cutoff)` (memory-efficient, on-the-fly); both support explicit RDKit and device output modes |
 | Substructure search | `nvmolkit.substructure` | `hasSubstructMatch`, `countSubstructMatches`, `getSubstructMatches` |
 | Maximum common substructure | `nvmolkit.mcs` | `findMCS(mols, ...)` for all pairs, explicit pairs, or two paired molecule lists |
 | Hardware tuning (batch size, GPU IDs) | `nvmolkit.types` | `HardwareOptions(...)` passed to ETKDG / MMFF / UFF |
@@ -298,6 +298,13 @@ torch.cuda.synchronize()
 for mol_clusters in clusters:
     print(mol_clusters.cpu().tolist())
 ```
+
+Both clustering functions accept the same explicit output modes. Use
+`output=ButinaOutput.RDKIT` for RDKit's tuple-of-tuples cluster representation,
+or `output=ButinaOutput.DEVICE` for a `ButinaDeviceResult` containing GPU-resident
+`cluster_ids`, `centroids`, and per-cluster `cluster_sizes`. The omitted-output
+behavior is retained for compatibility and differs between the historical
+non-fused and fused APIs, so new code should select a mode explicitly.
 
 `GetConformerRMSMatrix(mol)` and `GetConformerRMSMatrixBatch(mols)` default to `output_format="condensed"`, returning `AsyncGpuResult` objects that wrap RDKit-style flat vectors of length `N * (N - 1) // 2`. Use `output_format="square"` when chaining into `butina()` or any other API that expects an `N x N` distance matrix. Both forms live on the GPU; call `.numpy()` on condensed results or synchronize before moving square tensors to the CPU.
 

--- a/skills/nvmolkit-usage/SKILL.md
+++ b/skills/nvmolkit-usage/SKILL.md
@@ -277,7 +277,7 @@ If any input molecule is `None` or lacks MMFF/UFF atom types, the call raises `V
 import torch
 from rdkit import Chem
 from rdkit.Chem.rdDistGeom import EmbedMultipleConfs
-from nvmolkit.clustering import butina
+from nvmolkit.clustering import ButinaOutputMode, butina
 from nvmolkit.conformerRmsd import GetConformerRMSMatrixBatch
 
 mols = [Chem.AddHs(Chem.MolFromSmiles(smi)) for smi in ["CCCCCC", "c1ccccc1"]]
@@ -292,7 +292,10 @@ condensed = GetConformerRMSMatrixBatch(heavy_mols)
 
 # Butina expects a square distance matrix, so request square GPU tensors.
 square = GetConformerRMSMatrixBatch(heavy_mols, output_format="square")
-results = [butina(distance_matrix, cutoff=0.5) for distance_matrix in square]
+results = [
+    butina(distance_matrix, cutoff=0.5, output=ButinaOutputMode.DEVICE)
+    for distance_matrix in square
+]
 
 torch.cuda.synchronize()
 for result in results:


### PR DESCRIPTION
Addresses #269 , though with another API modification. There's no good way to unify fused/nonfused Butina + our previous history of return types without a clean approach. 