### PR TITLE
Use mamba for Python CI dependencies

### DIFF
--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -86,7 +86,10 @@ jobs:
           set -xeuo pipefail
           . /usr/local/anaconda/etc/profile.d/conda.sh
           conda activate base
-          conda install -q -y \
+          # Installing the native build dependencies into base can replace
+          # conda-libmamba-solver. Use the standalone solver retained by the
+          # setup step so this transaction cannot fall back to classic conda.
+          mamba install -q -y \
             "cuda-version=${{ matrix.cuda }}" \
             pytorch-gpu \
             "scikit-build>=0.18" \

--- a/admin/ci/setup_dependencies.sh
+++ b/admin/ci/setup_dependencies.sh
@@ -44,6 +44,7 @@ conda activate base
 
 conda config --add channels conda-forge --add channels nvidia
 conda install -q -y \
+    mamba \
     "python=${PYTHON_VERSION}" \
     "rdkit=${RDKIT_VERSION}" \
     "gcc=13.*" \


### PR DESCRIPTION
This should help the 10 minute python test setup time