### PR TITLE
Fix concurrent ETKDG retry dispatch

### DIFF
--- a/src/etkdg.cpp
+++ b/src/etkdg.cpp
@@ -455,8 +455,11 @@ std::optional<DeviceCoordResult> embedMolecules(const std::vector<RDKit::ROMol*>
       }
     } catch (...) {
       dispatchExceptionRegistry.store(std::current_exception());
+      Scheduler.cancel();
+      workComplete.store(true);
     }
   }
+  dispatchExceptionRegistry.rethrow();
 
   if (deviceOutput) {
     // Gather the results on one GPU before pruning.

--- a/src/etkdg_impl.cpp
+++ b/src/etkdg_impl.cpp
@@ -281,33 +281,65 @@ Scheduler::Scheduler(const int numUniqueMols, const int numConfsPerMol, const in
   maxTriesPerMolecule_ = maxIterations_ * numConfsPerMol_;
   completedConformers_.resize(numUniqueMols, 0);
   totalAttempts_.resize(numUniqueMols, 0);
+  attemptsInFlightByMolecule_.resize(numUniqueMols, 0);
 }
 
-std::vector<int> Scheduler::dispatch(const int batchSize) {
-  std::vector<int> molIds;
-  molIds.reserve(batchSize);
-  const std::lock_guard lock(mutex_);
-  size_t                prevSize = 1;  // Just don't set to 0 to avoid loop iter 0 exit.
-  while (molIds.size() < batchSize && prevSize != molIds.size()) {
-    prevSize          = molIds.size();
-    // Try again with next round. Note that we're still checking the maxTriesPerMolecule_ condition. If this fails,
-    // it means we're at the end of our loops, and the exit criteria will be satisfied in the caller when molIds is
-    // empty.
-    const int maxIter = std::min(maxTriesPerMolecule_, numConfsPerMol_ * roundRobinIter_);
-    for (size_t i = 0; i < numUniqueMolecules_; i++) {
-      while (completedConformers_[i] < numConfsPerMol_ && totalAttempts_[i] < maxIter) {
-        if (static_cast<int>(molIds.size()) >= batchSize) {
-          break;
-        }
-        molIds.push_back(static_cast<int>(i));
-        totalAttempts_[i]++;
-      }
+std::vector<int> Scheduler::dispatch(const int batchSize, std::vector<int>* attemptIds) {
+  std::unique_lock lock(mutex_);
+  if (attemptIds != nullptr) {
+    attemptIds->clear();
+  }
+  if (batchSize <= 0) {
+    return {};
+  }
+  while (true) {
+    if (canceled_) {
+      return {};
     }
-    if (totalAttempts_.back() == maxIter) {
-      roundRobinIter_++;
+    auto molIds = dispatchAvailableLocked(batchSize, attemptIds);
+    if (!molIds.empty()) {
+      return molIds;
+    }
+    if (attemptsInFlight_ > 0) {
+      progressCondition_.wait(lock);
+    } else {
+      return {};
     }
   }
+}
 
+void Scheduler::cancel() {
+  {
+    const std::lock_guard lock(mutex_);
+    canceled_ = true;
+  }
+  progressCondition_.notify_all();
+}
+
+std::vector<int> Scheduler::dispatchAvailableLocked(const int batchSize, std::vector<int>* attemptIds) {
+  std::vector<int> molIds;
+  molIds.reserve(batchSize);
+  if (attemptIds != nullptr) {
+    attemptIds->clear();
+    attemptIds->reserve(batchSize);
+  }
+  for (size_t i = 0; i < numUniqueMolecules_; i++) {
+    // Keep one attempt in flight for each conformer still needed. Recording a
+    // failure immediately reopens its slot without waiting on other molecules.
+    while (completedConformers_[i] + attemptsInFlightByMolecule_[i] < numConfsPerMol_ &&
+           totalAttempts_[i] < maxTriesPerMolecule_) {
+      if (static_cast<int>(molIds.size()) >= batchSize) {
+        break;
+      }
+      molIds.push_back(static_cast<int>(i));
+      if (attemptIds != nullptr) {
+        attemptIds->push_back(totalAttempts_[i]);
+      }
+      totalAttempts_[i]++;
+      attemptsInFlightByMolecule_[i]++;
+      attemptsInFlight_++;
+    }
+  }
   return molIds;
 }
 
@@ -315,14 +347,21 @@ void Scheduler::record(const std::vector<int>& molIds, const std::vector<int16_t
   if (molIds.size() != finishedOnIteration.size()) {
     throw std::invalid_argument("molIds and finishedOnIteration must have the same size.");
   }
-  const std::lock_guard lock(mutex_);
-  for (size_t i = 0; i < molIds.size(); i++) {
-    const int molId = molIds[i];
-    if (molId < 0 || molId >= numUniqueMolecules_) {
-      throw std::out_of_range("molId is out of range: " + std::to_string(molId));
+  {
+    const std::lock_guard lock(mutex_);
+    for (const int molId : molIds) {
+      if (molId < 0 || static_cast<size_t>(molId) >= numUniqueMolecules_) {
+        throw std::out_of_range("molId is out of range: " + std::to_string(molId));
+      }
     }
-    completedConformers_[molId] += finishedOnIteration[i] == -1 ? 0 : 1;
+    for (size_t i = 0; i < molIds.size(); i++) {
+      const int molId = molIds[i];
+      completedConformers_[molId] += finishedOnIteration[i] == -1 ? 0 : 1;
+      attemptsInFlightByMolecule_[molId]--;
+    }
+    attemptsInFlight_ -= static_cast<int>(molIds.size());
   }
+  progressCondition_.notify_all();
 }
 
 }  // namespace detail

--- a/src/etkdg_impl.cpp
+++ b/src/etkdg_impl.cpp
@@ -329,7 +329,7 @@ std::vector<int> Scheduler::dispatchAvailableLocked(const int batchSize, std::ve
     while (completedConformers_[i] + attemptsInFlightByMolecule_[i] < numConfsPerMol_ &&
            totalAttempts_[i] < maxTriesPerMolecule_) {
       if (static_cast<int>(molIds.size()) >= batchSize) {
-        break;
+        return molIds;
       }
       molIds.push_back(static_cast<int>(i));
       if (attemptIds != nullptr) {

--- a/src/etkdg_impl.h
+++ b/src/etkdg_impl.h
@@ -23,6 +23,7 @@
 #include <GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.h>
 
 #include <chrono>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -236,13 +237,18 @@ class Scheduler {
    *
    * Returns a vector of molecule IDs that need conformer generation attempts.
    * Prioritizes molecules that haven't reached their target conformer count
-   * and haven't exceeded the maximum attempt limit. Will return duplicates if not enough
-   * unique molecules are available to fill the batch size.
+   * and haven't exceeded the maximum attempt limit. Will return duplicates when a
+   * molecule needs multiple conformers. If all safe work is currently in flight,
+   * waits until recording a result makes more work available or completes the search.
    *
    * @param batchSize Maximum number of molecule IDs to return
+   * @param attemptIds Optional output populated with each molecule's zero-based attempt number
    * @return Vector of molecule IDs to process (may be smaller than batchSize if insufficient work remains)
    */
-  std::vector<int> dispatch(int batchSize);
+  std::vector<int> dispatch(int batchSize, std::vector<int>* attemptIds = nullptr);
+
+  //! Wake blocked dispatchers and prevent additional work after an external failure.
+  void cancel();
 
   /**
    * @brief Record the results of conformer generation attempts
@@ -267,16 +273,21 @@ class Scheduler {
 
  private:
   //!
-  mutable std::mutex mutex_;
+  mutable std::mutex      mutex_;
+  std::condition_variable progressCondition_;
 
   int    numConfsPerMol_;
   int    maxIterations_;
   size_t numUniqueMolecules_;
   int    maxTriesPerMolecule_;
-  int    roundRobinIter_ = 1;
 
   std::vector<int> completedConformers_;
   std::vector<int> totalAttempts_;
+  std::vector<int> attemptsInFlightByMolecule_;
+  int              attemptsInFlight_ = 0;
+  bool             canceled_         = false;
+
+  std::vector<int> dispatchAvailableLocked(int batchSize, std::vector<int>* attemptIds);
 };
 
 }  // namespace detail

--- a/tests/test_etkdg_result_tracker.cpp
+++ b/tests/test_etkdg_result_tracker.cpp
@@ -17,6 +17,8 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
+#include <future>
 #include <thread>
 #include <unordered_set>
 #include <vector>
@@ -50,13 +52,21 @@ TEST_F(SchedulerTest, BasicDispatchOversubscribe) {
   ASSERT_THAT(molIds2, ::testing::ElementsAreArray({1, 2, 2, 2, 3}));
   auto molIds3 = tracker.dispatch(numMols);
   ASSERT_THAT(molIds3, ::testing::ElementsAreArray({3, 3, 4, 4, 4}));
-  // oversubscribe in the same round robin format.
+  const std::vector<int16_t> failedResults(numMols, -1);
+  tracker.record(molIds, failedResults);
+  tracker.record(molIds2, failedResults);
+  tracker.record(molIds3, failedResults);
+
+  // Failed attempts open replacement slots without exceeding the per-molecule limit.
   molIds = tracker.dispatch(numMols);
   ASSERT_THAT(molIds, ::testing::ElementsAreArray({0, 0, 0, 1, 1}));
   molIds2 = tracker.dispatch(numMols);
   ASSERT_THAT(molIds2, ::testing::ElementsAreArray({1, 2, 2, 2, 3}));
   molIds3 = tracker.dispatch(numMols);
   ASSERT_THAT(molIds3, ::testing::ElementsAreArray({3, 3, 4, 4, 4}));
+  tracker.record(molIds, failedResults);
+  tracker.record(molIds2, failedResults);
+  tracker.record(molIds3, failedResults);
 
   // We've dispatched max attempts.
   auto molIds4 = tracker.dispatch(numMols);
@@ -98,16 +108,12 @@ TEST_F(SchedulerTest, BasicDispatchPartialCompleteNoErrors) {
   auto molIds3 = tracker.dispatch(numMols);
   ASSERT_THAT(molIds3, ::testing::ElementsAreArray({3, 3, 4, 4, 4}));
 
-  // Second round, we skip 0 since it's finished already.
-  auto molIds4 = tracker.dispatch(numMols);
-  ASSERT_THAT(molIds4, ::testing::ElementsAreArray({1, 1, 1, 2, 2}));
-
   tracker.record(molIds2, goodResults);
   tracker.record(molIds3, goodResults);
 
   // We've recorded passes on everything
-  auto molIds5 = tracker.dispatch(numMols);
-  EXPECT_THAT(molIds5, testing::IsEmpty());
+  auto molIds4 = tracker.dispatch(numMols);
+  EXPECT_THAT(molIds4, testing::IsEmpty());
 }
 
 // Test basic dispatch functionality
@@ -127,13 +133,19 @@ TEST_F(SchedulerTest, BasicDispatchFullWithSomeFails) {
   tracker.record(molIds2, mixedResults);
   tracker.record(molIds3, goodResults);
 
-  // Systems 0, 3 and 4 are done.
+  // Systems 0, 3 and 4 are done. Molecules 1 and 2 each need one replacement.
   auto molIds4 = tracker.dispatch(numMols);
-  EXPECT_THAT(molIds4, ::testing::ElementsAreArray({1, 1, 1, 2, 2}));
+  EXPECT_THAT(molIds4, ::testing::ElementsAreArray({1, 2}));
+  tracker.record(molIds4, {0, -1});
+
   auto molIds5 = tracker.dispatch(numMols);
   EXPECT_THAT(molIds5, ::testing::ElementsAreArray({2}));
+  tracker.record(molIds5, {-1});
+
   auto molIds6 = tracker.dispatch(numMols);
-  EXPECT_THAT(molIds6, ::testing::IsEmpty());
+  EXPECT_THAT(molIds6, ::testing::ElementsAreArray({2}));
+  tracker.record(molIds6, {0});
+  EXPECT_THAT(tracker.dispatch(numMols), ::testing::IsEmpty());
 }
 
 // Test dispatch with batch size larger than number of molecules
@@ -142,7 +154,7 @@ TEST_F(SchedulerTest, DispatchLargeBatchSize) {
 
   constexpr int largeBatchSize = 100;
   auto          molIds         = tracker.dispatch(largeBatchSize);
-  EXPECT_THAT(molIds, ::testing::ElementsAreArray({0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1}));
+  EXPECT_THAT(molIds, ::testing::ElementsAreArray({0, 0, 1, 1}));
 }
 
 // Test record validation - mismatched vector sizes
@@ -180,6 +192,81 @@ TEST_F(SchedulerTest, BatchSizeEdgeCases) {
   // Batch size of 1
   auto singleBatch = tracker.dispatch(1);
   EXPECT_EQ(singleBatch.size(), 1);
+}
+
+TEST_F(SchedulerTest, ReportsStablePerMoleculeAttemptIds) {
+  Scheduler        tracker(2, 3, 2);
+  std::vector<int> attemptIds;
+
+  EXPECT_THAT(tracker.dispatch(4, &attemptIds), testing::ElementsAre(0, 0, 0, 1));
+  EXPECT_THAT(attemptIds, testing::ElementsAre(0, 1, 2, 0));
+
+  auto remainingInitialAttempts = tracker.dispatch(4, &attemptIds);
+  EXPECT_THAT(remainingInitialAttempts, testing::ElementsAre(1, 1));
+  EXPECT_THAT(attemptIds, testing::ElementsAre(1, 2));
+
+  tracker.record({0, 0, 0}, {-1, -1, -1});
+  auto moleculeZeroRetries = tracker.dispatch(4, &attemptIds);
+  EXPECT_THAT(moleculeZeroRetries, testing::ElementsAre(0, 0, 0));
+  EXPECT_THAT(attemptIds, testing::ElementsAre(3, 4, 5));
+  tracker.record(moleculeZeroRetries, {-1, -1, -1});
+  tracker.record({1}, {-1});
+  tracker.record(remainingInitialAttempts, {-1, -1});
+
+  auto moleculeOneRetries = tracker.dispatch(4, &attemptIds);
+  EXPECT_THAT(moleculeOneRetries, testing::ElementsAre(1, 1, 1));
+  EXPECT_THAT(attemptIds, testing::ElementsAre(3, 4, 5));
+  tracker.record(moleculeOneRetries, {-1, -1, -1});
+  EXPECT_TRUE(tracker.dispatch(1).empty());
+}
+
+TEST_F(SchedulerTest, DispatchWaitsForInFlightRetryResults) {
+  Scheduler scheduler(1, 1, 2);
+
+  auto firstAttempt = scheduler.dispatch(1);
+  ASSERT_THAT(firstAttempt, testing::ElementsAre(0));
+
+  auto nextDispatch = std::async(std::launch::async, [&scheduler]() { return scheduler.dispatch(1); });
+  EXPECT_EQ(nextDispatch.wait_for(std::chrono::milliseconds(20)), std::future_status::timeout);
+
+  scheduler.record(firstAttempt, {-1});
+  ASSERT_EQ(nextDispatch.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+  auto secondAttempt = nextDispatch.get();
+  EXPECT_THAT(secondAttempt, testing::ElementsAre(0));
+  scheduler.record(secondAttempt, {0});
+
+  EXPECT_TRUE(scheduler.dispatch(1).empty());
+  EXPECT_TRUE(scheduler.allFinished());
+}
+
+TEST_F(SchedulerTest, ResolvedFailureRetriesWhileUnrelatedAttemptIsInFlight) {
+  Scheduler scheduler(2, 1, 2);
+
+  auto initialAttempts = scheduler.dispatch(2);
+  ASSERT_THAT(initialAttempts, testing::ElementsAre(0, 1));
+  scheduler.record({0}, {-1});
+
+  auto retry = std::async(std::launch::async, [&scheduler]() { return scheduler.dispatch(1); });
+  if (retry.wait_for(std::chrono::seconds(1)) != std::future_status::ready) {
+    scheduler.cancel();
+  }
+  ASSERT_EQ(retry.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+  EXPECT_THAT(retry.get(), testing::ElementsAre(0));
+
+  scheduler.record({0, 1}, {0, 0});
+  EXPECT_TRUE(scheduler.dispatch(1).empty());
+}
+
+TEST_F(SchedulerTest, CancelWakesBlockingDispatch) {
+  Scheduler scheduler(1, 1, 2);
+  ASSERT_THAT(scheduler.dispatch(1), testing::ElementsAre(0));
+
+  auto blockedDispatch = std::async(std::launch::async, [&scheduler]() { return scheduler.dispatch(1); });
+  EXPECT_EQ(blockedDispatch.wait_for(std::chrono::milliseconds(20)), std::future_status::timeout);
+
+  scheduler.cancel();
+  ASSERT_EQ(blockedDispatch.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+  EXPECT_TRUE(blockedDispatch.get().empty());
 }
 
 // Test thread safety (basic concurrent access)


### PR DESCRIPTION
  An ETKDG worker can temporarily run out of dispatchable work while another
  worker still has attempts in flight. The first worker currently treats that
  empty dispatch as global completion. If any in-flight attempts subsequently
  fail, their retries are never scheduled.

  Track in-flight attempts in the scheduler and make production dispatch wait
  until those attempts are recorded. Retry rounds now advance only after the
  current round has completed. Cancellation wakes waiting workers, and exceptions
  from dispatch threads are rethrown by `embedMolecules()` instead of being
  silently discarded.

  The scheduler also returns stable, per-molecule attempt IDs. This lets callers
  vary retry initialization independently of thread scheduling and batch order.
  
  Fixes #300 
